### PR TITLE
Update Admin Section types and add Number and EmptyState types

### DIFF
--- a/.changeset/admin-component-type-drift.md
+++ b/.changeset/admin-component-type-drift.md
@@ -1,0 +1,7 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Regenerate the Admin per-component types so they match the components as shipped. Around 35 components gain properties that existed in the implementation but were missing from the types, including the whole of `DatePicker` (`allow`, `allowDays`, `defaultValue`, `defaultView`, `disallow`, `disallowDays`, `value`, `view`, `visibleMonths`), typography properties on `Text`, `Paragraph`, and `Heading` (`fontSize`, `fontWeight`, `fontVariantNumeric`), `Banner`'s `heading` and `dismissible`, `Button`'s `variant` and `accessibilityLabel`, and `ColorPicker`'s `alpha`, `value`, and `defaultValue`.
+
+The regeneration also drops the `@private` `click({sourceEvent})` overload and its `ClickOptions` and `ActivationEventEsque` types from the component element classes. The standard DOM `element.click()` is unaffected.

--- a/.changeset/admin-component-type-drift.md
+++ b/.changeset/admin-component-type-drift.md
@@ -3,4 +3,3 @@
 ---
 
 Regenerate the Admin per-component types so they match the components as shipped. Around 35 components gain properties that existed in the implementation but were missing from the types, including the whole of `DatePicker` (`allow`, `allowDays`, `defaultValue`, `defaultView`, `disallow`, `disallowDays`, `value`, `view`, `visibleMonths`), typography properties on `Text`, `Paragraph`, and `Heading` (`fontSize`, `fontWeight`, `fontVariantNumeric`), `Banner`'s `heading` and `dismissible`, `Button`'s `variant` and `accessibilityLabel`, and `ColorPicker`'s `alpha`, `value`, and `defaultValue`.
-

--- a/.changeset/admin-component-type-drift.md
+++ b/.changeset/admin-component-type-drift.md
@@ -4,4 +4,3 @@
 
 Regenerate the Admin per-component types so they match the components as shipped. Around 35 components gain properties that existed in the implementation but were missing from the types, including the whole of `DatePicker` (`allow`, `allowDays`, `defaultValue`, `defaultView`, `disallow`, `disallowDays`, `value`, `view`, `visibleMonths`), typography properties on `Text`, `Paragraph`, and `Heading` (`fontSize`, `fontWeight`, `fontVariantNumeric`), `Banner`'s `heading` and `dismissible`, `Button`'s `variant` and `accessibilityLabel`, and `ColorPicker`'s `alpha`, `value`, and `defaultValue`.
 
-The regeneration also drops the `@private` `click({sourceEvent})` overload and its `ClickOptions` and `ActivationEventEsque` types from the component element classes. The standard DOM `element.click()` is unaffected.

--- a/.changeset/admin-number-empty-state-types.md
+++ b/.changeset/admin-number-empty-state-types.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add Admin `Number` and `EmptyState` types. `Number` exposes the `tone`, `color`, `fontSize`, and `fontWeight` properties; `EmptyState` exposes the `heading` property and the `graphic`, `subheading`, `primaryAction`, and `secondaryActions` slots.

--- a/.changeset/admin-section-header-slots.md
+++ b/.changeset/admin-section-header-slots.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Update the Admin `Section` types with the `subheading` property and the `primaryAction`, `secondaryActions`, `graphic`, `accessory`, and `supplemental` slots.

--- a/.changeset/admin-section-header-slots.md
+++ b/.changeset/admin-section-header-slots.md
@@ -2,4 +2,4 @@
 '@shopify/ui-extensions': minor
 ---
 
-Update the Admin `Section` types with the `subheading` property and the `primaryAction`, `secondaryActions`, `graphic`, `accessory`, and `supplemental` slots.
+Added `subheading` property and the `primaryAction`, `secondaryActions`, `graphic`, `accessory`, and `supplemental` slots to Admin `Section`.

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
@@ -1,151 +1,111 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, AdminActionProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  AdminActionProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * The properties for the admin action component. These properties configure the heading and loading state of the admin action extension interface.
+ * Configure the following properties on the admin action component.
  * @publicDocs
  */
 export interface AdminActionProps
-  extends Pick<AdminActionProps$1, 'heading' | 'loading'> {}
+  extends Pick<AdminActionProps$1, 'heading' | 'loading'> {
+  /**
+   * Whether the action is in a loading state, such as during initial page load or when the action is being opened.
+   * When `true`, the action is in an inert state that prevents user interaction.
+   *
+   * @default false
+   */
+  loading: AdminActionProps$1['loading'];
+}
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 declare const tagName = 's-admin-action';
-
-/**
- * The JSX props for the admin action component. These properties extend `AdminActionProps` with slots for primary and secondary action buttons that merchants can interact with.
- * @publicDocs
- */
 export interface AdminActionJSXProps
   extends Partial<AdminActionProps>,
     Pick<AdminActionProps$1, 'id'> {
   /**
-   * The primary action button or link to display in the admin action area. This is the main call-to-action that appears prominently in the interface. Typically uses a button component with `variant="primary"` to complete or advance the workflow.
+   * The main action button or link displayed in the admin action modal.
+   * This represents the primary or most important action that users can take in this modal context, typically displayed with high visual prominence.
    */
   primaryAction: ComponentChildren;
   /**
-   * The secondary action buttons or links to display in the admin action area. These are supporting actions like cancel, back, or alternative operations. Typically uses button components with `variant="secondary"` or `variant="tertiary"`.
+   * Additional action buttons or links displayed in the admin action modal.
+   * These provide alternative or supporting actions, visually de-emphasized compared to the primary action to establish clear hierarchy.
    */
   secondaryActions: ComponentChildren;
 }
 
-/**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
-}
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The admin action custom element class that renders action controls in the Shopify admin interface. This component creates a standardized action area with a heading and slots for primary and secondary action buttons, used exclusively in admin action extensions.
+ * Configure the following properties on the admin action component.
+ * @publicDocs
  */
 declare class AdminAction
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements AdminActionProps
 {
   /**
-   * The heading text to display at the top of the action area. This title describes the action or task the merchant is performing. If not provided, the extension name is used as the heading.
+   * The text to use as the Action modal's title. If not provided, the name of the extension will be used.
    */
   heading: string;
-
   /**
-   * Whether the action extension is currently in a loading state, such as during initial data fetching or when opening the action. When `true`, the action area might display loading indicators and prevent user interaction until loading completes.
-   *
-   * @default false
+   * Whether the action is in a loading state, such as during initial page load or when the action is being opened. When `true`, the action might be in an inert state that prevents user interaction.
    */
   loading: boolean;
-
   constructor();
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock.d.ts
@@ -1,140 +1,61 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {AdminBlockProps$1, ComponentChildren} from './shared.d.ts';
+import type {
+  AdminBlockProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
 
 /**
- * The properties for the admin block component. These properties configure the heading and collapsed summary of collapsible content blocks in the admin interface.
+ * Configure the following properties on the admin block component.
  * @publicDocs
  */
 export interface AdminBlockProps
-  extends Pick<AdminBlockProps$1, 'heading' | 'collapsedSummary'> {}
+  extends Pick<AdminBlockProps$1, 'heading' | 'collapsedSummary'> {
+  /**
+   * The text displayed as the block's title in the header. If not provided, the extension name will be used.
+   */
+  heading: AdminBlockProps$1['heading'];
+  /**
+   * The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated.
+   */
+  collapsedSummary: AdminBlockProps$1['collapsedSummary'];
+}
 
 declare const tagName = 's-admin-block';
-
-/**
- * The JSX props for the admin block component. These properties extend `AdminBlockProps` with an optional `id` for element identification in JSX rendering.
- * @publicDocs
- */
 export interface AdminBlockJSXProps
   extends Partial<AdminBlockProps>,
     Pick<AdminBlockProps$1, 'id'> {}
 
-/**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
-}
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The admin block custom element class that renders a collapsible content block in the Shopify admin interface. This component organizes content into expandable sections with headings and provides a summary when collapsed.
+ * Configure the following properties on the admin block component.
+ * @publicDocs
  */
 declare class AdminBlock
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements AdminBlockProps
 {
-  /**
-   * The heading text to display at the top of the block. This title describes the content section the merchant is viewing. If not provided, no heading is displayed.
-   */
   heading: string;
-
-  /**
-   * The summary text to display when the block is collapsed. This provides merchants with a preview of the block's contents without expanding it. If not provided, no summary is displayed.
-   */
   collapsedSummary: string;
-
   constructor();
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
@@ -1,135 +1,60 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {AdminPrintActionProps$1, ComponentChildren} from './shared.d.ts';
+import type {
+  AdminPrintActionProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
 
 /**
- * The properties for the admin print action component. These properties configure the source URL for printing content within admin extensions.
+ * Configure the following properties on the admin print action component.
  * @publicDocs
  */
 export interface AdminPrintActionProps
-  extends Pick<AdminPrintActionProps$1, 'src'> {}
+  extends Pick<AdminPrintActionProps$1, 'src'> {
+  /**
+   * The URL of the document to preview and print. Supports HTML, PDF, and image formats.
+   * If not provided, the preview will show an empty state and the print button will be disabled.
+   */
+  src: AdminPrintActionProps$1['src'];
+}
 
 declare const tagName = 's-admin-print-action';
-
-/**
- * The JSX props for the admin print action component. These properties extend `AdminPrintActionProps` with an optional `id` for element identification in JSX rendering.
- * @publicDocs
- */
 export interface AdminPrintActionJSXProps
   extends Partial<AdminPrintActionProps>,
     Pick<AdminPrintActionProps$1, 'id'> {}
 
-/**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
-}
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The admin print action custom element class that renders a print interface in the Shopify admin. This component enables merchants to print content from a specified source URL using the browser's print functionality.
+ * Configure the following properties on the admin print action component.
+ * @publicDocs
  */
 declare class AdminPrintAction
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements AdminPrintActionProps
 {
   /**
-   * The source URL of the content to print. This should point to the document or page that'll be sent to the printer when the merchant initiates the print action.
+   * The `src` URL of the preview and the document to print. If not provided, the preview will show an empty state and the print button will be disabled. HTML, PDFs, and images are supported.
    */
   src: string;
-
   constructor();
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav.d.ts
@@ -1,8 +1,14 @@
-/** VERSION: 1.67.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -10,8 +16,41 @@ import type {
   PreactCustomElement,
   RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 export interface AppNavProps {}
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 declare const tagName = 's-app-nav';
 export interface AppNavJSXProps
@@ -20,6 +59,10 @@ export interface AppNavJSXProps
 
 declare class PolarisCustomElement extends PreactCustomElement {
   constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
 }
 
 declare class AppNav extends PolarisCustomElement implements AppNavProps {

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
@@ -1,151 +1,134 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {AvatarProps$1, ComponentChildren} from './shared.d.ts';
+import type {
+  AvatarProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The properties for the avatar component. An avatar displays a user or entity image with fallback initials when the image isn't available. Properties include `src` for the image URL, `initials` for the fallback text, `alt` for accessibility text, and `size` for controlling the avatar dimensions.
- * @publicDocs
+ * Configure the following properties on the avatar component.
  */
 export interface AvatarProps
   extends Required<Pick<AvatarProps$1, 'initials' | 'src' | 'alt' | 'size'>> {
   /**
-   * The initials to display when no image is provided or if the image fails to load. This typically includes the first letter of a user's first and last name (for example, `'JD'` for John Doe).
-   */
-  initials: AvatarProps$1['initials'];
-  /**
-   * The URL of the avatar image to display. You can provide an absolute or relative URL pointing to the image file.
-   */
-  src: AvatarProps$1['src'];
-  /**
-   * Alternative text that describes the avatar for screen readers. This text should identify who or what the avatar represents.
-   */
-  alt: AvatarProps$1['alt'];
-  /**
-   * The size of the avatar. Choose from `'small-200'`, `'small'`, `'base'`, `'large'`, or `'large-200'` to control the avatar dimensions.
+   * The size of the avatar image.
    *
-   * @default 'base'
+   * - `small-200`: Extra small avatar, suitable for compact displays or lists with many items.
+   * - `small-100`: Alias of `small`.
+   * - `small`: Small avatar, good for secondary contexts or tight layouts.
+   * - `base`: Default size that works well in most contexts.
+   * - `large`: Large avatar for emphasis or when the avatar is a focal point.
+   * - `large-100`: Alias of `large`.
+   * - `large-200`: Extra large avatar for prominent display.
    */
   size: Extract<
     AvatarProps$1['size'],
-    'small-200' | 'small' | 'base' | 'large' | 'large-200'
+    | 'small-200'
+    | 'small-100'
+    | 'small'
+    | 'base'
+    | 'large'
+    | 'large-100'
+    | 'large-200'
   >;
+  /**
+   * Alternative text that describes the avatar for accessibility.
+   *
+   * Provides a text description of the avatar for users with assistive technology
+   * and serves as a fallback when the avatar fails to load. A well-written description
+   * enables people with visual impairments to understand non-text content.
+   *
+   * When a screen reader encounters an avatar, it reads this description aloud.
+   * When an avatar fails to load, this text displays on screen, helping all users
+   * understand what content was intended.
+   *
+   * Learn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4)
+   * and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).
+   */
+  alt: Required<AvatarProps$1>['alt'];
+  /**
+   * The URL or path to the avatar image. When provided, the image takes priority over `initials`.
+   * If the image fails to load or loads slowly, `initials` will be rendered as a fallback.
+   */
+  src: Required<AvatarProps$1>['src'];
+  /**
+   * The initials to display in the avatar when no image is provided or fails to load.
+   * Typically one or two characters representing a person's first and last name initials, such as "JD" for John Doe.
+   */
+  initials: Required<AvatarProps$1>['initials'];
 }
 
-/**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event, such as a click or keypress. These properties capture which modifier keys were pressed and which mouse button was used during the event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of `HTMLElement` to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queues a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to `@property` values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in a background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * A callback event that's typed to a specific HTML element.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that currently has the event listener attached.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener for callback events, typed to a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -154,51 +137,38 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
 /**
- * An avatar displays a user or entity image with fallback initials when the image isn't available.
+ * Configure the following properties on the avatar component.
+ * @publicDocs
  */
-declare class Avatar extends PreactCustomElement implements AvatarProps {
-  /**
-   * The initials to display when no image is provided or if the image fails to load.
-   */
+declare class Avatar extends PolarisCustomElement implements AvatarProps {
   accessor initials: AvatarProps['initials'];
-  /**
-   * The URL of the avatar image to display.
-   */
   accessor src: AvatarProps['src'];
-  /**
-   * The size of the avatar.
-   */
   accessor size: AvatarProps['size'];
-  /**
-   * Alternative text that describes the avatar for screen readers.
-   */
   accessor alt: AvatarProps['alt'];
-  /**
-   * A callback that's fired when the avatar image has loaded successfully.
-   */
   accessor onload: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's fired when the avatar image fails to load.
-   */
   accessor onerror: OnErrorEventHandler;
   constructor();
 }
@@ -216,19 +186,15 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-avatar';
-/**
- * The properties for the avatar component when it's used in JSX.
- * @publicDocs
- */
 export interface AvatarJSXProps
   extends Partial<AvatarProps>,
     Pick<AvatarProps$1, 'id'> {
   /**
-   * A callback that's fired when the avatar image has loaded successfully.
+   * A callback fired when the avatar image loads successfully.
    */
   onLoad?: () => void;
   /**
-   * A callback that's fired when the avatar image fails to load.
+   * A callback fired when the avatar image fails to load.
    */
   onError?: () => void;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -11,30 +16,68 @@ import type {
   IconProps$1,
   BadgeProps$1,
   IconType,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The configuration for icons used within Badge components. Defines the visual appearance, size, and semantic meaning of icons displayed in badges.
- * @publicDocs
+ * Configure the following properties on the icon component.
  */
 export interface IconProps
-  extends Pick<
-    IconProps$1,
-    'type' | 'tone' | 'color' | 'size' | 'interestFor'
+  extends Required<
+    Pick<IconProps$1, 'type' | 'tone' | 'color' | 'size' | 'interestFor'>
   > {
   /**
-   * The type of icon to display inside the badge. Use any valid icon name from the admin icon set, an empty string for no icon, or `'empty'` to reserve space for an icon without displaying one.
+   * The icon to display from the icon library.
+   *
+   * Set to a valid icon name to display that icon. To hide the icon completely,
+   * use an empty string `''`. To reserve the icon's space without displaying an icon,
+   * use `'empty'`.
    */
   type: '' | IconType | 'empty';
   /**
-   * Determines the color used for the icon based on semantic meaning. Available options:
-   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
-   * - `'neutral'` - Gray styling for general information.
-   * - `'info'` - Blue styling for informational content.
-   * - `'success'` - Green styling for positive states.
-   * - `'caution'` - Yellow styling for situations that need attention.
-   * - `'warning'` - Orange styling for important notices.
-   * - `'critical'` - Red styling for errors and urgent issues.
+   * The semantic meaning and color treatment of the component.
+   *
+   * - `info`: Informational content or helpful tips.
+   * - `success`: Positive outcomes or successful states.
+   * - `warning`: Important warnings about potential issues.
+   * - `critical`: Urgent problems or destructive actions.
+   * - `auto`: Automatically determined based on context.
+   * - `neutral`: General information without specific intent.
+   * - `caution`: Advisory notices that need attention.
    *
    * @default 'auto'
    */
@@ -43,61 +86,62 @@ export interface IconProps
     'auto' | 'neutral' | 'info' | 'success' | 'caution' | 'warning' | 'critical'
   >;
   /**
-   * Controls the visual prominence of the icon. Available options:
-   * - `'base'` - Standard color intensity for normal emphasis.
-   * - `'subdued'` - Reduced color intensity for less emphasis.
+   * The color emphasis level that controls visual intensity.
+   *
+   * - `base`: Primary color for body text, standard UI elements, and general content with good readability.
+   * - `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.
    *
    * @default 'base'
    */
   color: Extract<IconProps$1['color'], 'base' | 'subdued'>;
   /**
-   * Determines the size of the icon. Available options:
-   * - `'small'` - Smaller icon size for compact layouts.
-   * - `'base'` - Standard icon size for most use cases.
+   * The size of the icon.
    *
-   * @default 'base'
+   * - `small`: Smaller icon suitable for inline use within text or compact UI elements.
+   * - `base`: Default size that works well for standalone icons and standard use cases.
    */
   size: Extract<IconProps$1['size'], 'small' | 'base'>;
 }
 
 /**
- * The properties for the badge component. Badges display status information through compact visual indicators with customizable tones, sizes, and optional icons.
- * @publicDocs
+ * Configure the following properties on the badge component.
  */
 export interface BadgeProps
   extends Pick<BadgeProps$1, 'color' | 'icon' | 'size' | 'tone'> {
   /**
-   * Controls the visual weight and emphasis of the badge. Available options:
-   * - `'base'` - Standard weight with moderate emphasis, suitable for most use cases.
-   * - `'strong'` - Increased visual weight for higher emphasis and prominence.
+   * Controls the visual weight and emphasis of the badge.
+   *
+   * - `base`: Standard weight with moderate emphasis, suitable for most use cases.
+   * - `strong`: Increased visual weight for higher emphasis and prominence.
    *
    * @default 'base'
    */
   color: Extract<BadgeProps$1['color'], 'base' | 'strong'>;
   /**
-   * The icon to display inside the badge. Accepts any valid icon type or an empty string to display no icon.
+   * An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning.
+   * Accepts any icon name from the icon library or a custom string identifier.
    *
    * @default ''
    */
   icon: IconProps['type'] | '';
   /**
-   * Determines the size of the badge. Available options:
-   * - `'base'` - Standard size for most use cases.
-   * - `'large'` - Larger size for increased visibility and prominence.
-   * - `'large-100'` - Extra large size for maximum visibility in specific contexts.
+   * The size of the badge.
    *
-   * @default 'base'
+   * - `base`: Default size suitable for most badge use cases.
+   * - `large`: Larger badge for increased visibility and prominence.
+   * - `large-100`: Extra large badge for maximum visibility in emphasized contexts.
    */
   size: Extract<BadgeProps$1['size'], 'base' | 'large' | 'large-100'>;
   /**
-   * Determines the visual appearance and semantic meaning of the badge. Badges rely on the tone system for semantic meaning, so using custom styling might not clearly convey meaning to merchants. Available options:
-   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
-   * - `'neutral'` - Gray styling for general status information that doesn't require emphasis.
-   * - `'info'` - Blue styling for informational content and neutral updates.
-   * - `'success'` - Green styling for positive states, completed actions, and successful operations.
-   * - `'caution'` - Yellow styling for situations that need attention but aren't urgent.
-   * - `'warning'` - Orange styling for important notices that require merchant awareness.
-   * - `'critical'` - Red styling for errors, failures, and urgent issues requiring immediate action.
+   * The semantic meaning and color treatment of the component.
+   *
+   * - `info`: Informational content or helpful tips.
+   * - `success`: Positive outcomes or successful states.
+   * - `warning`: Important warnings about potential issues.
+   * - `critical`: Urgent problems or destructive actions.
+   * - `auto`: Automatically determined based on context.
+   * - `neutral`: General information without specific intent.
+   * - `caution`: Advisory notices that need attention.
    *
    * @default 'auto'
    */
@@ -107,149 +151,65 @@ export interface BadgeProps
   >;
 }
 
-/**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
-}
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
+}
+
+declare abstract class BadgeBase
+  extends PolarisCustomElement
+  implements Pick<BadgeProps, 'color' | 'size'>
+{
+  accessor color: BadgeProps['color'];
+  accessor size: BadgeProps['size'];
+  abstract tone: string;
+  abstract icon: string;
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
 }
 
 /**
- * The base properties for Preact elements without children. Provides key, ref, and slot properties for element identification, DOM access, and slot-based positioning.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for the element when used in lists. Preact uses keys for efficient rendering and reconciliation when lists change.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element. Typically created with `useRef()` to access the element directly for imperative operations like focusing or measuring.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements with children. Extends `PreactBaseElementProps` with the ability to render child elements.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
   /**
-   * The child elements to render within this component.
+   * The child elements to be rendered within this component.
    */
   children?: preact.ComponentChildren;
 }
 
 /**
- * The badge custom element class that renders status indicators in the Shopify admin interface. This component displays compact visual indicators with customizable tones, sizes, and optional icons to communicate status information to merchants.
+ * Configure the following properties on the badge component.
+ * @publicDocs
  */
-declare class Badge extends PreactCustomElement implements BadgeProps {
-  /**
-   * The visual weight of the badge. Available options: `'base'` for standard weight or `'strong'` for increased emphasis.
-   */
-  accessor color: BadgeProps['color'];
-  /**
-   * The icon to display inside the badge. Accepts any valid icon type from the admin icon set, or an empty string to display no icon.
-   */
+declare class Badge extends BadgeBase implements BadgeProps {
   accessor icon: BadgeProps['icon'];
-  /**
-   * The size of the badge. Available options: `'base'` for standard size, `'large'` for larger size, or `'large-100'` for extra large size.
-   */
-  accessor size: BadgeProps['size'];
-  /**
-   * The tone that determines the badge's visual appearance and semantic meaning. Available options: `'auto'`, `'neutral'`, `'info'`, `'success'`, `'caution'`, `'warning'`, or `'critical'`.
-   */
   accessor tone: BadgeProps['tone'];
   constructor();
 }
@@ -267,15 +227,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-badge';
-/**
- * The JSX props for the badge component. These properties extend `BadgeProps` with an optional `id` and `children` for rendering badge content in JSX.
- * @publicDocs
- */
 export interface BadgeJSXProps
   extends Partial<BadgeProps>,
     Pick<BadgeProps$1, 'id' | 'children'> {
   /**
-   * The text content to display inside the badge. Typically a short status label like "Fulfilled", "Draft", or "Active".
+   * The text label displayed within the badge component, typically a short status indicator or category label.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
@@ -1,25 +1,43 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, BannerProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  BannerProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * A callback event that's typed to a specific HTML element.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that currently has the event listener attached.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener for callback events, typed to a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -28,43 +46,77 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
   /**
-   * The child elements to render inside this element.
+   * The child elements to be rendered within this component.
    */
   children?: preact.ComponentChildren;
 }
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
 /**
- * All properties for the banner component marked as required.
+ * Represents the banner component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredBannerProps = Required<BannerProps$1>;
 /**
- * The properties for the banner component. These properties define an important message or notification with visual styling that conveys its semantic meaning.
- * @publicDocs
+ * Configure the following properties on the banner component.
  */
 export interface BannerProps
   extends Pick<
@@ -72,7 +124,13 @@ export interface BannerProps
     'heading' | 'dismissible' | 'hidden' | 'tone'
   > {
   /**
-   * The color tone of the banner based on its semantic meaning.
+   * The semantic meaning and color treatment of the component.
+   *
+   * - `info`: Informational content or helpful tips.
+   * - `success`: Positive outcomes or successful states.
+   * - `warning`: Important warnings about potential issues.
+   * - `critical`: Urgent problems or destructive actions.
+   * - `auto`: Automatically determined based on context.
    *
    * @default 'auto'
    */
@@ -80,129 +138,52 @@ export interface BannerProps
     RequiredBannerProps['tone'],
     'auto' | 'critical' | 'warning' | 'success' | 'info'
   >;
+  /**
+   * The heading text displayed at the top of the banner.
+   *
+   * @default ''
+   */
+  heading: RequiredBannerProps['heading'];
+  /**
+   * Whether the banner displays a close button that allows users to dismiss it.
+   *
+   * When the close button is pressed, the `dismiss` event fires, then `hidden` is set to `true`,
+   * any animation completes, and the `afterhide` event fires.
+   *
+   * @default false
+   */
+  dismissible: RequiredBannerProps['dismissible'];
+  /**
+   * Controls whether the banner is visible or hidden.
+   *
+   * When using a controlled component pattern and the banner is `dismissible`,
+   * update this property to `true` when the `dismiss` event fires.
+   *
+   * You can hide the banner programmatically by setting this to `true` even if it's not `dismissible`.
+   *
+   * @default false
+   */
+  hidden: RequiredBannerProps['hidden'];
 }
 
-/**
- * A string containing CSS styles for the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * Optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * An event-like object that contains activation information for synthetic clicks.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during activation.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on Windows) was pressed during activation.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during activation.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during activation.
-   */
-  button: number;
-}
-/**
- * Options for customizing synthetic click behavior.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * A custom element for displaying important messages and notifications.
+ * Configure the following properties on the banner component.
+ * @publicDocs
  */
-declare class Banner extends PreactCustomElement implements BannerProps {
-  /**
-   * The heading text displayed at the top of the banner.
-   */
+declare class Banner extends PolarisCustomElement implements BannerProps {
   accessor heading: BannerProps['heading'];
-  /**
-   * The color tone of the banner based on its semantic meaning.
-   */
   accessor tone: BannerProps['tone'];
-  /**
-   * Whether the banner is hidden from view.
-   */
   accessor hidden: BannerProps['hidden'];
-  /**
-   * Whether the banner can be dismissed by the user.
-   */
   accessor dismissible: BannerProps['dismissible'];
-  /**
-   * A callback that's fired when the banner is dismissed.
-   */
   accessor ondismiss: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's fired after the banner finishes hiding.
-   */
   accessor onafterhide: CallbackEventListener<typeof tagName> | null;
   constructor();
 }
@@ -221,27 +202,26 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-banner';
-/**
- * The JSX properties for the banner component. These properties define how a banner is rendered in Preact or JSX.
- * @publicDocs
- */
 export interface BannerJSXProps
   extends Partial<BannerProps>,
     Pick<BannerProps$1, 'id' | 'children'> {
   /**
-   * The content of the banner.
+   * The main message content displayed within the banner component, providing important information or guidance to users.
    */
   children?: ComponentChildren;
   /**
-   * The secondary actions to display at the bottom of the banner. Only buttons with the `variant` of `'secondary'` or `'auto'` are allowed. A maximum of two `s-button` components can be provided.
+   * Action buttons displayed at the bottom of the banner that let users respond to the message.
+   * Accepts up to two button components with `variant="secondary"` or `variant="auto"`.
    */
   secondaryActions?: ComponentChildren;
   /**
-   * A callback that's fired when the banner is dismissed.
+   * A callback fired when the user dismisses the banner by clicking the close button.
+   * Use this to update your app state and control the banner's visibility.
    */
   onDismiss?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's fired after the banner finishes hiding.
+   * A callback fired when the banner is completely hidden, after any hide animations have completed.
+   * Use this to perform cleanup or trigger subsequent actions after the banner is no longer visible.
    */
   onAfterHide?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box.d.ts
@@ -1,8 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -12,10 +18,45 @@ import type {
   SizeUnitsOrAuto,
   SizeUnits,
   SizeUnitsOrNone,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * A type that allows a value to be responsive using container query syntax.
+ * Makes a type responsive by allowing it to be either the base value or a container query string. This enables conditional styling based on container dimensions.
  * @publicDocs
  */
 export type MakeResponsive<T> = T | `@container${string}`;
@@ -41,12 +82,21 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * A version of the box properties with all fields required.
+ * Represents the box component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The allowed border radius values for a box component.
+ * Represents the subset of border radius values supported by the component.
+ *
+ * - `small-200`: Extra small radius for subtle rounding.
+ * - `small-100`: Small radius for minimal corner rounding.
+ * - `small`: Standard small radius.
+ * - `base`: Medium radius for moderate corner rounding.
+ * - `large`: Standard large radius for pronounced rounding.
+ * - `large-100`: Large radius for more prominent corner rounding.
+ * - `large-200`: Extra large radius for maximum rounding.
+ * - `none`: No border radius (sharp corners).
  * @publicDocs
  */
 export type BoxBorderRadii = Extract<
@@ -61,7 +111,12 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The allowed border style values for a box component.
+ * Represents the subset of border style values supported by the box component.
+ *
+ * - `auto`: Default border style determined by the system.
+ * - `none`: No border style (removes the border).
+ * - `solid`: Continuous line border.
+ * - `dashed`: Border made up of dashes.
  * @publicDocs
  */
 export type BoxBorderStyles = Extract<
@@ -69,7 +124,9 @@ export type BoxBorderStyles = Extract<
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The box properties that support responsive values through container queries.
+ * Represents box props with responsive capabilities for layout properties.
+ *
+ * This enables conditional styling based on container queries.
  * @publicDocs
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
@@ -83,10 +140,6 @@ export type ResponsiveBoxProps = MakeResponsivePick<
   | 'paddingInlineEnd'
   | 'display'
 >;
-/**
- * The properties for the box component. A box provides control over layout, spacing, sizing, borders, and background styling for its content.
- * @publicDocs
- */
 export interface BoxProps
   extends Pick<
     RequiredBoxProps,
@@ -108,7 +161,7 @@ export interface BoxProps
     | 'overflow'
   > {
   /**
-   * The background color of the box. You can choose from `'transparent'`, `'base'`, `'subdued'`, or `'strong'` to control the visual emphasis of the background.
+   * The background color of the component.
    *
    * @default 'transparent'
    */
@@ -117,16 +170,13 @@ export interface BoxProps
     'transparent' | 'base' | 'subdued' | 'strong'
   >;
   /**
-   * Controls the thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
+   * A border applied using shorthand syntax to specify width, color, and style in a single property.
    *
-   * - `small`: Thin border for subtle definition.
-   * - `small-100`: Extra thin border for minimal emphasis.
-   * - `base`: Standard border width.
-   * - `large`: Thick border for strong emphasis.
-   * - `large-100`: Extra thick border for maximum prominence.
-   * - `none`: No border.
-   *
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.
+   * @default 'none'
+   */
+  border: RequiredBoxProps['border'];
+  /**
+   * The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -139,11 +189,7 @@ export interface BoxProps
       >
     | Extract<RequiredBoxProps['borderWidth'], ''>;
   /**
-   * Controls the visual style of the border on all sides (solid, dashed, auto, or none).
-   *
-   * When set, this overrides the style value specified in the `border` property.
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box)for specifying different styles per side: one value applies to all sides,
-   * two values apply to block and inline sides, and so on.
+   * The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -151,10 +197,7 @@ export interface BoxProps
     | MaybeAllValuesShorthandProperty<BoxBorderStyles>
     | Extract<RequiredBoxProps['borderStyle'], ''>;
   /**
-   * Controls the color of the border using the design system's color scale.
-   *
-   * When set, this overrides the color value specified in the `border` property.
-   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.
+   * The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -163,64 +206,94 @@ export interface BoxProps
     'subdued' | 'base' | 'strong' | ''
   >;
   /**
-   * Controls the roundedness of the element's corners using the design system's radius scale.
-   *
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.
-   * One value applies to all corners, two values apply to opposite corners, and so on.
+   * The roundedness of the element's corners using the design system's radius scale.
    *
    * @default 'none'
    */
   borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;
   /**
-   * The padding on all sides of the box. The [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is supported, using flow-relative values in the order `block-start inline-end block-end inline-start`. For example, `'large'` applies large padding to all sides, while `'large none'` applies large padding to the block axis and no padding to the inline axis. A value of `'auto'` will use the default padding from the closest container that has had its padding removed. This property also accepts responsive values using container query syntax.
+   * The padding applied to all edges of the component.
+   *
+   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:
+   * - 1 value applies to all sides
+   * - 2 values apply to block (top/bottom) and inline (left/right)
+   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)
+   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)
+   *
+   * **Examples:** `base`, `large none`, `base large-100 base small`
+   *
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
   padding: ResponsiveBoxProps['padding'];
   /**
-   * The padding on the block axis (top and bottom in horizontal writing modes). This property overrides the block-axis value set by the `padding` property. For example, `'large none'` applies large padding to the block-start and no padding to the block-end. This property also accepts responsive values using container query syntax.
+   * The block-direction padding (top and bottom in horizontal writing modes).
+   *
+   * Accepts a single value for both sides or two space-separated values for block-start and block-end.
+   *
+   * **Example:** `large none` applies `large` to the top and `none` to the bottom.
+   *
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlock: ResponsiveBoxProps['paddingBlock'];
   /**
-   * The padding at the start of the block axis (top in horizontal writing modes). This property overrides the block-start value set by the `paddingBlock` property. It also accepts responsive values using container query syntax.
+   * The block-start padding (top in horizontal writing modes).
+   *
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];
   /**
-   * The padding at the end of the block axis (bottom in horizontal writing modes). This property overrides the block-end value set by the `paddingBlock` property. It also accepts responsive values using container query syntax.
+   * The block-end padding (bottom in horizontal writing modes).
+   *
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];
   /**
-   * The padding on the inline axis (left and right in horizontal writing modes). This property overrides the inline-axis value set by the `padding` property. For example, `'large none'` applies large padding to the inline-start and no padding to the inline-end. This property also accepts responsive values using container query syntax.
+   * The inline-direction padding (left and right in horizontal writing modes).
+   *
+   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.
+   *
+   * **Example:** `large none` applies `large` to the left and `none` to the right.
+   *
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInline: ResponsiveBoxProps['paddingInline'];
   /**
-   * The padding at the start of the inline axis (left in left-to-right writing modes). This property overrides the inline-start value set by the `paddingInline` property. It also accepts responsive values using container query syntax.
+   * The inline-start padding (left in LTR writing modes, right in RTL).
+   *
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];
   /**
-   * The padding at the end of the inline axis (right in left-to-right writing modes). This property overrides the inline-end value set by the `paddingInline` property. It also accepts responsive values using container query syntax.
+   * The inline-end padding (right in LTR writing modes, left in RTL).
+   *
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];
   /**
-   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component, which controls how it participates in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout). Use `'auto'` for the component's default behavior, or `'none'` to hide the component completely and remove it from the accessibility tree.
+   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   *
+   * - `auto` the component's initial value. The actual value depends on the component and context.
+   * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
    *
    * @default 'auto'
    */
   display: ResponsiveBoxProps['display'];
   /**
-   * The vertical size of the box in standard layouts (height in left-to-right or right-to-left writing modes).
+   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).
    *
    * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;
    * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.
@@ -231,275 +304,123 @@ export interface BoxProps
    */
   blockSize: SizeUnitsOrAuto;
   /**
-   * The [minimum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) of the box (minimum height in horizontal writing modes).
+   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize: SizeUnits;
   /**
-   * The [maximum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) of the box (maximum height in horizontal writing modes).
+   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize: SizeUnitsOrNone;
   /**
-   * The [inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size) of the box (width in horizontal writing modes).
+   * The width in horizontal writing modes, or height in vertical writing modes.
+   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize: SizeUnitsOrAuto;
   /**
-   * The [minimum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) of the box (minimum width in horizontal writing modes).
+   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize: SizeUnits;
   /**
-   * The [maximum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) of the box (maximum width in horizontal writing modes).
+   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
   maxInlineSize: SizeUnitsOrNone;
 }
 
-/**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event, such as a click or keypress. These properties capture which modifier keys were pressed and which mouse button was used during the event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of `HTMLElement` to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/**
- * The base element class for Box components with all Box properties as accessors.
- */
-declare class BoxElement extends PreactCustomElement implements BoxProps {
+declare class BoxElement extends PolarisCustomElement implements BoxProps {
   constructor(renderImpl: RenderImpl);
-  /**
-   * The ARIA role that defines the semantic meaning of the box for assistive technologies.
-   */
   accessor accessibilityRole: BoxProps['accessibilityRole'];
-  /**
-   * The background color of the box using the design system's color scale. Choose from `transparent`, `subdued`, `base`, or `strong`.
-   */
   accessor background: BoxProps['background'];
-  /**
-   * The height of the box in horizontal writing modes, or width in vertical writing modes.
-   * Use this for flow-relative sizing that adapts to text direction.
-   */
   accessor blockSize: BoxProps['blockSize'];
-  /**
-   * The minimum height of the box in horizontal writing modes, or minimum width in vertical writing modes.
-   * Prevents the box from shrinking below this size.
-   */
   accessor minBlockSize: BoxProps['minBlockSize'];
-  /**
-   * The maximum height of the box in horizontal writing modes, or maximum width in vertical writing modes.
-   * Prevents the box from growing beyond this size.
-   */
   accessor maxBlockSize: BoxProps['maxBlockSize'];
-  /**
-   * The width of the box in horizontal writing modes, or height in vertical writing modes.
-   * Use this for flow-relative sizing that adapts to text direction.
-   */
   accessor inlineSize: BoxProps['inlineSize'];
-  /**
-   * The minimum width of the box in horizontal writing modes, or minimum height in vertical writing modes.
-   * Prevents the box from shrinking below this size.
-   */
   accessor minInlineSize: BoxProps['minInlineSize'];
-  /**
-   * The maximum width of the box in horizontal writing modes, or maximum height in vertical writing modes.
-   * Prevents the box from growing beyond this size.
-   */
   accessor maxInlineSize: BoxProps['maxInlineSize'];
-  /**
-   * Controls how content that exceeds the box's boundaries is displayed. Use `hidden` to clip overflow or `visible` to allow content to extend beyond boundaries.
-   */
   accessor overflow: BoxProps['overflow'];
-  /**
-   * The padding on all sides of the box.
-   */
   accessor padding: BoxProps['padding'];
-  /**
-   * The vertical padding (top and bottom) in horizontal writing modes.
-   * Use this for flow-relative padding that adapts to text direction.
-   */
   accessor paddingBlock: BoxProps['paddingBlock'];
-  /**
-   * The padding at the top in horizontal writing modes, or at the start edge in vertical writing modes.
-   */
   accessor paddingBlockStart: BoxProps['paddingBlockStart'];
-  /**
-   * The padding at the bottom in horizontal writing modes, or at the end edge in vertical writing modes.
-   */
   accessor paddingBlockEnd: BoxProps['paddingBlockEnd'];
-  /**
-   * The horizontal padding (left and right) in horizontal writing modes.
-   * Use this for flow-relative padding that adapts to text direction.
-   */
   accessor paddingInline: BoxProps['paddingInline'];
-  /**
-   * The padding at the left in left-to-right languages, or at the right in right-to-left languages.
-   */
   accessor paddingInlineStart: BoxProps['paddingInlineStart'];
-  /**
-   * The padding at the right in left-to-right languages, or at the left in right-to-left languages.
-   */
   accessor paddingInlineEnd: BoxProps['paddingInlineEnd'];
-  /**
-   * Applies a border using shorthand syntax to specify width, color, and style in a single property.
-   */
   accessor border: BoxProps['border'];
-  /**
-   * Controls the thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
-   */
   accessor borderWidth: BoxProps['borderWidth'];
-  /**
-   * Controls the visual style of the border on all sides (solid, dashed, auto, or none). When set, this overrides the style value specified in the `border` property.
-   */
   accessor borderStyle: BoxProps['borderStyle'];
-  /**
-   * Controls the color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
-   */
   accessor borderColor: BoxProps['borderColor'];
-  /**
-   * Controls the roundedness of the element's corners using the design system's radius scale.
-   */
   accessor borderRadius: BoxProps['borderRadius'];
-  /**
-   * The accessibility label for screen readers.
-   */
   accessor accessibilityLabel: BoxProps['accessibilityLabel'];
-  /**
-   * Controls the visibility of the box for both visual and assistive technology users. Use `hidden` to hide from screen readers or `exclusive` to hide visually but announce to screen readers.
-   */
   accessor accessibilityVisibility: BoxProps['accessibilityVisibility'];
-  /**
-   * Controls how the box is displayed in the layout, such as block, inline, or none.
-   */
   accessor display: BoxProps['display'];
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
-  /** The child elements to render inside this element. */
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A box is a container component that provides control over layout, spacing, and styling.
+ * Configure the following properties on the box component.
+ * @publicDocs
  */
 declare class Box extends BoxElement implements BoxProps {
   constructor();
@@ -518,15 +439,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-box';
-/**
- * The properties for the box component when it's used in JSX.
- * @publicDocs
- */
 export interface BoxJSXProps
   extends Partial<BoxProps>,
     Pick<BoxProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the box.
+   * The content displayed within the box component, which serves as a flexible container for organizing and styling other components.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -12,20 +17,30 @@ import type {
   ButtonProps$1,
   IconType,
   InteractionProps,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * A callback event with a strongly-typed `currentTarget` property that corresponds to a specific HTML element. This provides better type safety when handling events from custom elements.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to, strongly typed based on the element's tag name.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function type for callback events with a strongly-typed `currentTarget`. This ensures the event handler receives the correct element type.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -34,57 +49,95 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
     })
   | null;
 /**
- * The base properties for Preact elements without children. Provides `key`, `ref`, and `slot` properties for element identification, DOM access, and slot-based positioning.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for the element when used in lists. Preact uses keys for efficient rendering and reconciliation when lists change.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element. Typically created with `useRef()` to access the element directly for imperative operations like focusing or measuring.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements with children. Extends `PreactBaseElementProps` with the ability to render child elements.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
   /**
-   * The child elements to render within this component.
+   * The child elements to be rendered within this component.
    */
   children?: preact.ComponentChildren;
 }
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
 /**
- * The configuration for icons used within Button components. Defines the visual appearance, size, and semantic meaning of icons displayed in buttons.
- * @publicDocs
+ * Configure the following properties on the icon component.
  */
 export interface IconProps
-  extends Pick<
-    IconProps$1,
-    'type' | 'tone' | 'color' | 'size' | 'interestFor'
+  extends Required<
+    Pick<IconProps$1, 'type' | 'tone' | 'color' | 'size' | 'interestFor'>
   > {
   /**
-   * Specifies the type of icon that will be displayed.
+   * The icon to display from the icon library.
+   *
+   * Set to a valid icon name to display that icon. To hide the icon completely,
+   * use an empty string `''`. To reserve the icon's space without displaying an icon,
+   * use `'empty'`.
    */
   type: '' | IconType | 'empty';
   /**
-   * Determines the color used for the icon based on semantic meaning. Available options:
-   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
-   * - `'neutral'` - Gray styling for general information.
-   * - `'info'` - Blue styling for informational content.
-   * - `'success'` - Green styling for positive states.
-   * - `'caution'` - Yellow styling for situations that need attention.
-   * - `'warning'` - Orange styling for important notices.
-   * - `'critical'` - Red styling for errors and urgent issues.
+   * The semantic meaning and color treatment of the component.
+   *
+   * - `info`: Informational content or helpful tips.
+   * - `success`: Positive outcomes or successful states.
+   * - `warning`: Important warnings about potential issues.
+   * - `critical`: Urgent problems or destructive actions.
+   * - `auto`: Automatically determined based on context.
+   * - `neutral`: General information without specific intent.
+   * - `caution`: Advisory notices that need attention.
    *
    * @default 'auto'
    */
@@ -93,25 +146,25 @@ export interface IconProps
     'auto' | 'neutral' | 'info' | 'success' | 'caution' | 'warning' | 'critical'
   >;
   /**
-   * Controls the visual prominence of the icon. Available options:
-   * - `'base'` - Standard color intensity for normal emphasis.
-   * - `'subdued'` - Reduced color intensity for less emphasis.
+   * The color emphasis level that controls visual intensity.
+   *
+   * - `base`: Primary color for body text, standard UI elements, and general content with good readability.
+   * - `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.
    *
    * @default 'base'
    */
   color: Extract<IconProps$1['color'], 'base' | 'subdued'>;
   /**
-   * Determines the size of the icon. Available options:
-   * - `'small'` - Smaller icon size for compact layouts.
-   * - `'base'` - Standard icon size for most use cases.
+   * The size of the icon.
    *
-   * @default 'base'
+   * - `small`: Smaller icon suitable for inline use within text or compact UI elements.
+   * - `base`: Default size that works well for standalone icons and standard use cases.
    */
   size: Extract<IconProps$1['size'], 'small' | 'base'>;
 }
 
 /**
- * The button-specific properties extracted from the base button props type, used internally for type safety.
+ * Represents button props that are specific to button-type elements only. Extracts the subset of `ButtonProps` that includes the `type` property.
  * @publicDocs
  */
 export type ButtonOnlyProps = Extract<
@@ -121,7 +174,7 @@ export type ButtonOnlyProps = Extract<
   }
 >;
 /**
- * The base required properties for the button component, including all essential button configuration options. This type ensures all button properties have default values.
+ * Represents the base button props with all properties marked as required.
  * @publicDocs
  */
 export type ButtonBaseProps = Required<
@@ -141,138 +194,69 @@ export type ButtonBaseProps = Required<
     | 'target'
     | 'href'
     | 'download'
+    | 'inlineSize'
   >
 >;
 /**
- * The properties for the button component. Buttons trigger actions or navigation when clicked, with customizable visual styles, states, and optional icons.
- * @publicDocs
+ * Configure the following properties on the button component.
  */
 export interface ButtonProps extends ButtonBaseProps {
   /**
-   * Determines the visual appearance and semantic meaning of the button. Buttons rely on the tone system for semantic meaning, so using custom styling might not clearly convey intent to merchants. Available options:
-   * - `'auto'` - Lets the system automatically choose the appropriate tone based on context.
-   * - `'neutral'` - Standard styling for general actions without specific semantic meaning.
-   * - `'critical'` - Red styling for destructive actions that can't be undone, such as deleting data.
+   * The semantic meaning and color treatment of the component.
+   *
+   * - `critical`: Urgent problems or destructive actions.
+   * - `auto`: Automatically determined based on context.
+   * - `neutral`: General information without specific intent.
    *
    * @default 'auto'
    */
   tone: Extract<ButtonProps$1['tone'], 'neutral' | 'critical' | 'auto'>;
   /**
-   * The icon to display inside the button. Accepts any valid icon type or an empty string to display no icon.
+   * An icon displayed inside the button, typically positioned before the button text.
+   * Use icons to help users quickly identify the button's action or to improve scannability.
+   * Accepts any icon name from the icon library or a custom string identifier.
    *
    * @default ''
    */
   icon: IconProps['type'];
+  /**
+   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   */
+  accessibilityLabel: Required<ButtonOnlyProps>['accessibilityLabel'];
+  /**
+   * The visual appearance of the button component.
+   *
+   * - `auto`: The variant is automatically determined by the button component's context.
+   * - `primary`: High emphasis button for the primary action on the page. Should be used sparingly.
+   * - `secondary`: Medium emphasis button for secondary actions.
+   * - `tertiary`: Low emphasis button for less important actions.
+   *
+   * @default 'auto'
+   */
+  variant: Required<ButtonOnlyProps>['variant'];
+  /**
+   * The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
+   */
+  lang: Required<ButtonOnlyProps>['lang'];
 }
 
-/**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
-}
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/**
- * The properties for controlling overlay interactions via commands. These properties enable buttons to control other components like modals, popovers, and dialogs using declarative commands.
- * @publicDocs
- */
 export interface PreactOverlayControlProps
   extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
   /**
-   * Sets the action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this button is activated. Available options:
-   * - `'--auto'`: Performs the default action appropriate for the target component.
-   * - `'--show'`: Displays the target component if it's currently hidden.
-   * - `'--hide'`: Conceals the target component from view.
-   * - `'--toggle'`: Alternates the target component between visible and hidden states.
+   * The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
    *
-   * The supported actions vary by target component type.
+   * - `--auto`: A default action for the target component.
+   * - `--show`: Shows the target component.
+   * - `--hide`: Hides the target component.
+   * - `--toggle`: Toggles the visibility of the target component.
    *
    * @default '--auto'
    */
@@ -281,78 +265,59 @@ export interface PreactOverlayControlProps
     '--show' | '--hide' | '--toggle' | '--auto'
   >;
   /**
-   * Sets the element ID that the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this button is activated. References another component by its `id` attribute.
+   * The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
    */
   commandFor: Extract<InteractionProps['commandFor'], string>;
   /**
-   * Sets the element ID that the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this button is activated. Used for interest-based interactions with other components.
+   * The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.
    */
   interestFor: Extract<InteractionProps['interestFor'], string>;
 }
 
-/**
- * The base class for the button component, combining Preact custom element functionality with overlay control capabilities.
- */
-declare const Button_base: (abstract new (
-  args_0: RenderImpl,
-) => PreactCustomElement & PreactOverlayControlProps) &
-  Pick<typeof PreactCustomElement, 'prototype' | 'observedAttributes'>;
-/**
- * The button custom element class that renders interactive buttons in the Shopify admin interface. This component triggers actions or navigation when clicked, with customizable visual styles, states, and optional icons.
- */
-declare class Button extends Button_base implements ButtonProps {
-  /**
-   * Whether the button is disabled, preventing any interaction. When `true`, the button appears visually disabled and doesn't respond to user clicks.
-   */
+declare const ButtonBase_base: (abstract new (
+  renderImpl: Omit<RenderImpl, 'globalShadowCSS'>,
+) => PolarisCustomElement & PreactOverlayControlProps) &
+  Pick<typeof PolarisCustomElement, 'prototype' | 'observedAttributes'>;
+declare abstract class ButtonBase<TTagName extends keyof HTMLElementTagNameMap>
+  extends ButtonBase_base
+  implements
+    Pick<
+      ButtonProps,
+      | 'disabled'
+      | 'loading'
+      | 'target'
+      | 'href'
+      | 'download'
+      | 'type'
+      | 'accessibilityLabel'
+      | 'inlineSize'
+    >
+{
   accessor disabled: ButtonProps['disabled'];
-  /**
-   * The icon to display inside the button. Accepts any valid icon type from the admin icon set, or an empty string to display no icon.
-   */
-  accessor icon: ButtonProps['icon'];
-  /**
-   * Whether the button is in a loading state. When `true`, displays a loading indicator and prevents interaction to show that an action is in progress.
-   */
   accessor loading: ButtonProps['loading'];
-  /**
-   * The visual style variant of the button that determines its emphasis. Available options: `'primary'`, `'secondary'`, `'tertiary'`, or `'plain'`.
-   */
-  accessor variant: ButtonProps['variant'];
-  /**
-   * The tone that determines the button's visual appearance and semantic meaning. Available options: `'auto'`, `'neutral'`, or `'critical'`.
-   */
-  accessor tone: ButtonProps['tone'];
-  /**
-   * Specifies where to open the linked document when the button acts as a link. Available options: `''`, `'_blank'`, `'_self'`, `'_parent'`, or `'_top'`.
-   */
   accessor target: ButtonProps['target'];
-  /**
-   * A URL that the button should navigate to when clicked. When provided, the button behaves as a link.
-   */
   accessor href: ButtonProps['href'];
-  /**
-   * Prompts the user to save the linked URL as a file with the specified filename. Only works when `href` is provided.
-   */
   accessor download: ButtonProps['download'];
-  /**
-   * A callback that's invoked when the button is clicked. Receives the click event as an argument.
-   */
-  accessor onclick: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's invoked when the button loses focus. Receives the blur event as an argument.
-   */
-  accessor onblur: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's invoked when the button receives focus. Receives the focus event as an argument.
-   */
-  accessor onfocus: CallbackEventListener<typeof tagName> | null;
-  /**
-   * The button's behavior in forms. Available options: `'button'`, `'submit'`, or `'reset'`.
-   */
   accessor type: ButtonProps['type'];
-  /**
-   * A text description of the button's purpose for screen readers. This is essential for accessibility when the button doesn't have visible text.
-   */
   accessor accessibilityLabel: ButtonProps['accessibilityLabel'];
+  accessor inlineSize: ButtonProps['inlineSize'];
+  accessor onclick: CallbackEventListener<TTagName> | null;
+  accessor onblur: CallbackEventListener<TTagName> | null;
+  accessor onfocus: CallbackEventListener<TTagName> | null;
+  abstract icon: string;
+  abstract variant: string;
+  abstract tone: string;
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the button component.
+ * @publicDocs
+ */
+declare class Button extends ButtonBase<typeof tagName> implements ButtonProps {
+  accessor icon: ButtonProps['icon'];
+  accessor variant: ButtonProps['variant'];
+  accessor tone: ButtonProps['tone'];
   constructor();
 }
 declare global {
@@ -369,95 +334,25 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-button';
-/**
- * The JSX props for the button component. These properties extend `ButtonProps` with event callbacks and additional options for rendering buttons in JSX.
- * @publicDocs
- */
 export interface ButtonJSXProps
   extends Partial<ButtonProps>,
     Pick<ButtonProps$1, 'id' | 'children'> {
   /**
-   * The text label or content to display inside the button. Can be plain text or other components.
+   * The label text or elements displayed inside the button component, describing the action that will be performed when clicked.
    */
   children?: ComponentChildren;
   /**
-   * Callback function that's invoked when the button is clicked. Receives the click event as an argument.
+   * A callback fired when the button is clicked.
    */
   onClick?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback function that's invoked when the button receives focus. Receives the focus event as an argument.
+   * A callback fired when the button receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * Callback function that's invoked when the button loses focus. Receives the blur event as an argument.
+   * A callback fired when the button loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
-  /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
-   *
-   * @default ''
-   */
-  accessibilityLabel?: string;
-  /**
-   * Prevents the button from being clicked when set to `true`. The button appears visually disabled and doesn't respond to user interaction.
-   *
-   * @default false
-   */
-  disabled?: boolean;
-  /**
-   * Displays a loading indicator and prevents interaction when set to `true`. Use this to show that an action triggered by the button is in progress.
-   *
-   * @default false
-   */
-  loading?: boolean;
-  /**
-   * Determines the visual style and emphasis of the button. Available options:
-   * - `'primary'` - Highest emphasis for the main action on a screen.
-   * - `'secondary'` - Medium emphasis for secondary actions.
-   * - `'tertiary'` - Lowest emphasis for less important actions.
-   * - `'plain'` - Text-only appearance for subtle actions that don't need visual weight.
-   *
-   * @default 'secondary'
-   */
-  variant?: ButtonProps['variant'];
-  /**
-   * Specifies where to open the linked document when the button acts as a link (when `href` is provided). Available options:
-   * - `''` - Opens in the same frame (default behavior).
-   * - `'_blank'` - Opens in a new window or tab.
-   * - `'_self'` - Opens in the same frame (explicit version of default).
-   * - `'_parent'` - Opens in the parent frame.
-   * - `'_top'` - Opens in the full body of the window.
-   *
-   * @default ''
-   */
-  target?: ButtonProps['target'];
-  /**
-   * A URL that the button should navigate to when clicked. When provided, the button behaves as a link.
-   *
-   * @default ''
-   */
-  href?: ButtonProps['href'];
-  /**
-   * Prompts the user to save the linked URL as a file with the specified filename. Only works when `href` is provided.
-   *
-   * @default ''
-   */
-  download?: ButtonProps['download'];
-  /**
-   * Specifies the button's behavior in forms. Available options:
-   * - `'button'` - A standard button with no default behavior.
-   * - `'submit'` - Submits the form data to the server.
-   * - `'reset'` - Resets all form controls to their initial values.
-   *
-   * @default 'button'
-   */
-  type?: ButtonProps['type'];
-  /**
-   * The language of the button's content, specified as a BCP 47 language tag (such as `'en'` or `'fr'`). This helps assistive technologies pronounce content correctly.
-   *
-   * @default ''
-   */
-  lang?: ButtonProps['lang'];
 }
 
 export {Button};

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
@@ -1,162 +1,142 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, ButtonGroupProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  ButtonGroupProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * Properties for rendering a button group that arranges multiple buttons together with consistent spacing and semantic grouping.
- * @publicDocs
+ * Configure the following properties on the button group component.
  */
 export interface ButtonGroupProps
-  extends Required<Pick<ButtonGroupProps$1, 'gap' | 'accessibilityLabel'>> {}
-
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  extends Required<Pick<ButtonGroupProps$1, 'gap' | 'accessibilityLabel'>> {
   /**
-   * A function that renders the component's content inside the shadow root.
+   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   *
+   * @implementation Used as a hidden heading or an aria-label on the wrapping element.
    */
-  ShadowRoot: (element: any) => ComponentChildren;
+  accessibilityLabel: Required<ButtonGroupProps$1>['accessibilityLabel'];
   /**
-   * CSS styles that will be applied to the shadow DOM.
+   * The spacing between buttons in the group.
+   *
+   * - `base`: Standard spacing that provides clear visual separation between buttons.
+   * - `none`: No spacing, creating a connected button group.
+   *
+   * @default 'base'
    */
-  styles?: Styles;
-};
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
+  gap: Required<ButtonGroupProps$1>['gap'];
 }
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
+}
+
+declare abstract class ButtonGroupBase
+  extends PolarisCustomElement
+  implements Pick<ButtonGroupProps, 'gap' | 'accessibilityLabel'>
+{
+  accessor gap: ButtonGroupProps['gap'];
+  accessor accessibilityLabel: ButtonGroupProps['accessibilityLabel'];
+  constructor(renderImpl: RenderImpl);
   /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
+   * Actions whose translucent fill can't paint over a seam, so the neighbour
+   * has to be told not to draw it. The foundation resolves the list.
    * @private
    */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
+  setInertActions(actions: readonly Element[]): void;
+  /** @private */
+  disconnectedCallback(): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
-
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
   /**
-   * The child elements or content that will be rendered inside this element.
+   * The child elements to be rendered within this component.
    */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A button group that arranges multiple buttons together with consistent spacing and semantic grouping for related actions.
+ * Configure the following properties on the button group component.
+ * @publicDocs
  */
-declare class ButtonGroup
-  extends PreactCustomElement
-  implements ButtonGroupProps
-{
-  /**
-   * The amount of spacing between buttons in the group, affecting the visual separation of actions.
-   */
-  accessor gap: ButtonGroupProps['gap'];
-
-  /**
-   * A label that's only visible to screen readers, describing the purpose of this group of buttons.
-   */
-  accessor accessibilityLabel: ButtonGroupProps['accessibilityLabel'];
-
+declare class ButtonGroup extends ButtonGroupBase implements ButtonGroupProps {
   constructor();
 }
 declare global {
@@ -177,28 +157,25 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-button-group';
-
-/**
- * Properties for using the button group component in JSX with React-style props.
- * @publicDocs
- */
 export interface ButtonGroupJSXProps
   extends Partial<ButtonGroupProps>,
     Pick<ButtonGroupProps$1, 'id' | 'children'> {
   /**
-   * The buttons that should be grouped together, provided as Button components.
+   * The buttons displayed within the button group component, which are arranged together as a cohesive set of related actions.
    */
   children?: ComponentChildren;
   /**
-   * A single primary action button that's visually emphasized as the most important action in the group.
+   * The main action for this group, displayed with high visual emphasis.
+   * Accepts a single button with `variant="primary"`.
    *
-   * Accepts a single Button element with a `variant` of `primary`. Can't be used when `gap` is set to `none`.
+   * Use this for the primary action you want users to take. This can't be used when `gap="none"`.
    */
   primaryAction?: ComponentChildren;
   /**
-   * One or more secondary action buttons that provide alternative or less prominent actions.
+   * Supporting actions displayed with less emphasis than the primary action.
+   * Accepts one or more button components with `variant="secondary"` or `variant="auto"`.
    *
-   * Accepts Button elements with a `variant` of `secondary` or `auto`.
+   * Use these for alternative or less critical actions.
    */
   secondaryActions?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -93,7 +88,7 @@ declare abstract class ButtonGroupBase
    * has to be told not to draw it. The foundation resolves the list.
    * @private
    */
-  setInertActions(actions: readonly Element[]): void;
+  setInertActions(actions: ReadonlyArray<Element>): void;
   /** @private */
   disconnectedCallback(): void;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
@@ -1,29 +1,43 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   CheckboxProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event that includes a strongly-typed reference to the element that triggered it.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event handler was attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A function that handles events for a specific element type, or null if no handler is set.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -31,170 +45,113 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's content inside the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * CSS styles that will be applied to the shadow DOM.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The core properties that all input elements need to function within forms.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/**
- * Base class for input elements that participate in form submission.
- */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
-  /**
-   * Indicates that this element can participate in form submission.
-   */
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's triggered when the input's value changes and the field loses focus.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's triggered when the input's value changes as the user types.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the input is disabled and can't be interacted with.
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * A unique identifier for the input element.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * The name that identifies this input when the form is submitted.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value of the input.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
-/**
- * Properties that are common to checkbox-style components.
- * @publicDocs
- */
 export interface PreactCheckboxProps
   extends Required<
     Pick<
@@ -211,20 +168,15 @@ export interface PreactCheckboxProps
     >
   > {
   /**
-   * The value that's submitted with the form when the checkbox is checked.
+   * The value used in form data when the checkbox is checked.
    */
   value: Required<CheckboxProps$1>['value'];
 }
-/**
- * Base class for checkbox-style elements that can be toggled on and off.
- */
 declare class PreactCheckboxElement
   extends PreactInputElement
   implements PreactCheckboxProps
 {
-  /**
-   * Whether the checkbox is currently checked.
-   */
+  accessor onblur: CallbackEventListener<'input'>;
   get checked(): boolean;
   set checked(checked: PreactCheckboxProps['checked']);
   /**
@@ -232,29 +184,11 @@ declare class PreactCheckboxElement
    */
   get value(): string;
   set value(value: string);
-  /**
-   * Whether the checkbox should be checked when it's first rendered.
-   */
   accessor defaultChecked: PreactCheckboxProps['defaultChecked'];
-  /**
-   * A label that's only visible to screen readers, used when the visual label isn't descriptive enough.
-   */
   accessor accessibilityLabel: PreactCheckboxProps['accessibilityLabel'];
-  /**
-   * Additional text to provide context or guidance for the checkbox.
-   */
   accessor details: PreactCheckboxProps['details'];
-  /**
-   * An error message that's displayed below the checkbox when validation fails.
-   */
   accessor error: PreactCheckboxProps['error'];
-  /**
-   * The text that describes what the checkbox is for.
-   */
   accessor label: PreactCheckboxProps['label'];
-  /**
-   * Whether the checkbox must be checked before the form can be submitted.
-   */
   accessor required: PreactCheckboxProps['required'];
   /** @private */
   formResetCallback(): void;
@@ -263,33 +197,69 @@ declare class PreactCheckboxElement
 }
 
 /**
- * Properties for rendering a checkbox that supports checked, unchecked, and indeterminate states for complex selection scenarios.
- * @publicDocs
+ * Configure the following properties on the checkbox component.
  */
 export interface CheckboxProps extends PreactCheckboxProps {
   /**
-   * Whether the checkbox is in an indeterminate state, showing a dash instead of a checkmark to represent a partial selection.
+   * Whether the checkbox displays in an indeterminate state (neither checked nor unchecked),
+   * typically used to indicate partial selection in hierarchical lists.
+   *
+   * This visual state takes priority over the `checked` prop in appearance only.
+   * The form submission value is still determined by the `checked` prop.
+   *
+   * If `indeterminate` has not been explicitly set and hasn't been modified by user interaction,
+   * it returns the value of `defaultIndeterminate`.
    */
   indeterminate: Required<CheckboxProps$1>['indeterminate'];
   /**
-   * Whether the checkbox should be in an indeterminate state when it's first rendered, useful for partial selection scenarios.
+   * The initial indeterminate state for uncontrolled components. Use this when you want the checkbox to start
+   * in an indeterminate state but don't need to control it afterward.
+   *
+   * This value applies until `indeterminate` is explicitly set or the user changes the checkbox state by clicking.
+   *
+   * @default false
    */
   defaultIndeterminate: Required<CheckboxProps$1>['defaultIndeterminate'];
+  /**
+   * Whether the field needs a value. This requirement adds semantic value
+   * to the field, but it will not cause an error to appear automatically.
+   * If you want to present an error when this field is empty, you can do
+   * so with the `error` property.
+   *
+   * @default false
+   */
+  required: Required<CheckboxProps$1>['required'];
+  /**
+   * Changes the visibility of the component's label.
+   *
+   * - `visible`: the label is visible to all users.
+   * - `exclusive`: the label is visually hidden but remains in the accessibility tree.
+   *
+   * @default 'visible'
+   */
+  labelAccessibilityVisibility: Required<CheckboxProps$1>['labelAccessibilityVisibility'];
+}
+
+declare abstract class CheckboxBase
+  extends PreactCheckboxElement
+  implements
+    Pick<
+      CheckboxProps,
+      'defaultIndeterminate' | 'indeterminate' | 'labelAccessibilityVisibility'
+    >
+{
+  get indeterminate(): CheckboxProps['indeterminate'];
+  set indeterminate(indeterminate: CheckboxProps['indeterminate']);
+  accessor defaultIndeterminate: CheckboxProps['defaultIndeterminate'];
+  accessor labelAccessibilityVisibility: CheckboxProps['labelAccessibilityVisibility'];
+  constructor(renderImpl: RenderImpl);
 }
 
 /**
- * A checkbox that lets users select or deselect an option, with support for an indeterminate state.
+ * Configure the following properties on the checkbox component.
+ * @publicDocs
  */
-declare class Checkbox extends PreactCheckboxElement implements CheckboxProps {
-  /**
-   * Whether the checkbox is in an indeterminate state, showing a dash instead of a checkmark.
-   */
-  get indeterminate(): CheckboxProps['indeterminate'];
-  set indeterminate(indeterminate: CheckboxProps['indeterminate']);
-  /**
-   * Whether the checkbox should be in an indeterminate state when it's first rendered.
-   */
-  accessor defaultIndeterminate: CheckboxProps['defaultIndeterminate'];
+declare class Checkbox extends CheckboxBase implements CheckboxProps {
   constructor();
 }
 declare global {
@@ -300,27 +270,27 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: CheckboxJSXProps & PreactBaseElementProps<Checkbox>;
+      [tagName]: Omit<CheckboxJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<Checkbox>;
     }
   }
 }
 
 declare const tagName = 's-checkbox';
-/**
- * Props for using the checkbox component in JSX with React-style event handlers.
- * @publicDocs
- */
 export interface CheckboxJSXProps
-  extends Partial<CheckboxProps>,
-    Pick<CheckboxProps$1, 'id'> {
+  extends Partial<Omit<CheckboxProps, 'error' | 'details'>>,
+    Pick<CheckboxProps$1, 'id'>,
+    FieldSlotInternalReactProps {
   /**
-   * A callback that's triggered when the checkbox's checked state changes and it loses focus.
+   * A callback fired when the checkbox state changes and the user has finished interacting with it.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the checkbox's checked state changes.
+   * A callback fired when the checkbox state changes, including intermediate states during user interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
+  onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
 
 export {Checkbox};

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -52,19 +47,19 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.38.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -12,34 +17,135 @@ import type {
   PreactCustomElement,
   RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
-export interface ChipProps
-  extends Required<Pick<ChipProps$1, 'color' | 'accessibilityLabel'>> {}
-
-declare class PolarisCustomElement extends PreactCustomElement {
-  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
-}
-
-/** Used when an element does not have children. * @publicDocs
+/**
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
+ * @publicDocs
+ */
+export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
+  currentTarget: HTMLElementTagNameMap[T];
+};
+/**
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
+ * @publicDocs
+ */
+export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
+  | (EventListener & {
+      (event: CallbackEvent<T>): void;
+    })
+  | null;
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
-  /** Assigns a unique key to this element. */
+  /**
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
+   */
   key?: preact.Key;
-  /** Assigns a ref (generally from `useRef()`) to this element. */
+  /**
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
+   */
   ref?: preact.Ref<TClass>;
-  /** Assigns this element to a parent's slot. */
+  /**
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
+   */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+/**
+ * Configure the following properties on the chip component.
+ */
+export interface ChipProps
+  extends Required<
+    Pick<ChipProps$1, 'color' | 'accessibilityLabel' | 'removable'>
+  > {
+  /**
+   * The color emphasis level that controls visual intensity.
+   *
+   * @default 'base'
+   */
+  color: Required<ChipProps$1>['color'];
+  /**
+   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   */
+  accessibilityLabel: Required<ChipProps$1>['accessibilityLabel'];
+}
+
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+}
+
+/**
+ * Configure the following properties on the chip component.
+ * @publicDocs
+ */
 declare class Chip extends PolarisCustomElement implements ChipProps {
   accessor color: ChipProps['color'];
   accessor accessibilityLabel: ChipProps['accessibilityLabel'];
+  accessor removable: ChipProps['removable'];
+  accessor onremove: CallbackEventListener<typeof tagName> | null;
   constructor();
 }
 declare global {
@@ -61,13 +167,14 @@ export interface ChipJSXProps
   extends Partial<ChipProps>,
     Pick<ChipProps$1, 'id' | 'children'> {
   /**
-   * The content of the chip.
+   * The text label displayed within the chip component, typically representing a selected filter, tag, or removable item.
    */
   children?: ComponentChildren;
   /**
-   * An optional icon to display at the start of the chip. Accepts only Icon components.
+   * An optional icon to display at the start of the chip. Accepts only icon components.
    */
   graphic?: ComponentChildren;
+  onRemove?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
 
 export {Chip};

--- a/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Chip.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
@@ -1,16 +1,60 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, ChoiceProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  ChoiceProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * Properties for rendering a single choice within a choice list that can be selected using a radio button or checkbox.
- * @publicDocs
+ * The choice component creates individual selectable options within a choice list. Use choice to define each option that merchants can select, supporting both single selection (radio buttons) and multiple selection (checkboxes) modes.
+ *
+ * Choice components support labels, help text, and custom content through slots, providing flexible option presentation within choice lists.
  */
 export interface ChoiceProps
   extends Required<
@@ -24,146 +68,77 @@ export interface ChoiceProps
     >
   > {}
 
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's content inside the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * CSS styles that will be applied to the shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
-}
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A single choice within a choice list that can be selected with a radio button or checkbox.
+ * The choice component creates individual selectable options within a choice list. Use choice to define each option that merchants can select, supporting both single selection (radio buttons) and multiple selection (checkboxes) modes.
+ *
+ * Choice components support labels, help text, and custom content through slots, providing flexible option presentation within choice lists.
+ * @publicDocs
  */
-declare class Choice extends PreactCustomElement implements ChoiceProps {
+declare class Choice extends PolarisCustomElement implements ChoiceProps {
   /**
-   * Whether the choice is disabled and can't be selected.
+   * Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.
    */
   accessor disabled: ChoiceProps['disabled'];
   /**
-   * Whether the choice is currently selected.
+   * Whether the option is currently selected. Use this for controlled components where you manage the selection state.
    */
   get selected(): boolean;
+  /**
+   * Whether the option is currently selected. Use this for controlled components where you manage the selection state.
+   */
   set selected(selected: ChoiceProps['selected']);
   /**
-   * The value that's submitted with the form when this choice is selected.
+   * The value submitted with the form when this checkbox is checked. If not specified, the default value is "on".
    */
   accessor value: ChoiceProps['value'];
   /**
-   * A label that's only visible to screen readers, used when the visual label isn't descriptive enough.
+   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
    */
   accessor accessibilityLabel: ChoiceProps['accessibilityLabel'];
   /**
-   * Whether the choice should be selected when it's first rendered.
+   * The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.
    */
   accessor defaultSelected: ChoiceProps['defaultSelected'];
   constructor();
@@ -180,34 +155,39 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: Omit<ChoiceJSXProps, 'details'> &
+      [tagName]: Omit<ChoiceJSXProps, 'details' | 'secondaryContent'> &
         PreactBaseElementPropsWithChildren<Choice>;
     }
   }
 }
 
 declare const tagName = 's-choice';
-/**
- * Properties for using the choice component in JSX with React-style props.
- * @publicDocs
- */
 export interface ChoiceJSXProps
   extends Partial<ChoiceProps>,
     Pick<ChoiceProps$1, 'id' | 'children' | 'details'> {
   /**
-   * The content that's used as the choice label, extracted as plain text from any provided markup.
+   * The label that identifies this selectable choice option to users.
    *
-   * The label is produced by extracting and concatenating the text nodes from the provided content; any markup or element structure is ignored.
+   * The label is produced by extracting and
+   * concatenating the text nodes from the provided content;
+   * any markup or element structure is ignored.
    */
   children?: ComponentChildren;
   /**
-   * Additional text that provides context or guidance for the input, displayed alongside the choice label.
+   * Additional text to provide context or guidance for the input.
    *
-   * This text is displayed along with the input and its label to offer more information or instructions to the user.
+   * This text is displayed along with the input and its label
+   * to offer more information or instructions to the user.
    *
    * @implementation this content should be linked to the input with an `aria-describedby` attribute.
    */
   details?: ComponentChildren;
+  /**
+   * Additional content to display below the choice label.
+   * Can include rich content like TextFields, Buttons, or other interactive components.
+   * Event handlers on React components are preserved.
+   */
+  secondaryContent?: ComponentChildren;
 }
 
 export {Choice};

--- a/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Choice.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -176,12 +171,14 @@ declare class ChoiceList extends BaseClass implements ChoiceListProps {
     callback: EventListenerOrEventListenerObject | null,
     options?: AddEventListenerOptions | boolean,
   ): void;
+
   /** @private */
   removeEventListener(
     type: string,
     callback: EventListenerOrEventListenerObject | null,
     options?: EventListenerOptions | boolean,
   ): void;
+
   accessor disabled: ChoiceListProps['disabled'];
   /**
    * The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList.d.ts
@@ -1,25 +1,43 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, ChoiceListProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  ChoiceListProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event that includes a strongly-typed reference to the element that triggered it.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event handler was attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A function that handles events for a specific element type, or null if no handler is set.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -27,32 +45,73 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
 /**
- * Properties for rendering a list of choices that lets users select one or more options using radio buttons or checkboxes.
- * @publicDocs
+ * Configure the following properties on the choice list component.
  */
 export interface ChoiceListProps
   extends Required<
@@ -67,159 +126,98 @@ export interface ChoiceListProps
       | 'name'
       | 'values'
     >
-  > {}
-
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  > {
   /**
-   * A function that renders the component's content inside the shadow root.
+   * Whether the field is disabled, preventing any user interaction. When `true`, the `disabled` property on any child choices is ignored.
+   *
+   * @default false
    */
-  ShadowRoot: (element: any) => ComponentChildren;
+  disabled: Required<ChoiceListProps$1>['disabled'];
   /**
-   * CSS styles that will be applied to the shadow DOM.
+   * Whether multiple choices can be selected.
+   *
+   * @default false
    */
-  styles?: Styles;
-};
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
+  multiple: Required<ChoiceListProps$1>['multiple'];
 }
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass$1: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass$1 {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
-/**
- * Base class for form-associated custom elements.
- */
-declare class BaseClass extends PreactCustomElement {
-  /**
-   * Indicates that this element can participate in form submission.
-   */
+declare class BaseClass extends PolarisCustomElement {
   static formAssociated: boolean;
   constructor(renderImpl: RenderImpl);
   /** @private */
   [internals]: ElementInternals;
 }
 /**
- * A list of choices that lets users select one or more options using radio buttons or checkboxes.
+ * Configure the following properties on the choice list component.
+ * @publicDocs
  */
 declare class ChoiceList extends BaseClass implements ChoiceListProps {
   /**
-   * Whether all choices in the list are disabled and can't be selected.
+   * Wraps change and input event listeners so they only fire when the event
+   * was dispatched directly on this ChoiceList (event.eventPhase === Event.AT_TARGET).
+   *
+   * This prevents form events from elements inside secondary content (e.g.
+   * TextField, native <input>) from being mistakenly treated as ChoiceList
+   * value-change events, while still allowing those events to bubble normally
+   * through the DOM (preserving React's event delegation).
+   * @private
    */
+  addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+  /** @private */
+  removeEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: EventListenerOptions | boolean,
+  ): void;
   accessor disabled: ChoiceListProps['disabled'];
   /**
-   * The name that identifies this choice list when the form is submitted.
+   * The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.
    */
   accessor name: ChoiceListProps['name'];
   /**
-   * An error message that's displayed below the choice list when validation fails.
+   * An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.
    */
   accessor error: ChoiceListProps['error'];
   /**
-   * Additional text to provide context or guidance for the choice list.
+   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.
    */
   accessor details: ChoiceListProps['details'];
-  /**
-   * Whether users can select more than one choice at a time.
-   */
   accessor multiple: ChoiceListProps['multiple'];
   /**
-   * The text that describes what the choice list is for.
+   * The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.
    */
   accessor label: ChoiceListProps['label'];
-  /**
-   * A callback that's triggered when the selected choices change and the choice list loses focus.
-   */
   accessor onchange: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's triggered when the selected choices change.
-   */
   accessor oninput: CallbackEventListener<typeof tagName> | null;
   /**
    * Controls whether the label is visible to all users or only to screen readers.
+   *
+   * - `visible`: The label is shown to everyone (default).
+   * - `exclusive`: The label is visually hidden but still announced by screen readers.
+   *
+   * Use `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.
    */
   accessor labelAccessibilityVisibility: ChoiceListProps['labelAccessibilityVisibility'];
   /**
-   * The values of the currently selected choices.
+   * An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.
    */
   get values(): ChoiceListProps['values'];
+  /**
+   * An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.
+   */
   set values(values: ChoiceListProps['values']);
   /** @private */
   formResetCallback(): void;
@@ -244,25 +242,21 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-choice-list';
-/**
- * Properties for using the choice list component in JSX with React-style event handlers.
- * @publicDocs
- */
 export interface ChoiceListJSXProps
   extends Partial<ChoiceListProps>,
     Pick<ChoiceListProps$1, 'id' | 'children'> {
   /**
-   * The choices that a user can select from, provided as Choice components.
+   * The choices a user can select from.
    *
-   * Accepts Choice components.
+   * Accepts choice components.
    */
   children?: ComponentChildren;
   /**
-   * A callback that's triggered when the selected choices change and the choice list loses focus.
+   * A callback fired when the user has finished changing the value.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the selected choices change as the user interacts with them.
+   * A callback fired when the user makes any changes to the value.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -15,43 +20,106 @@ import type {
   SizeUnits,
   SizeUnitsOrNone,
   InteractionProps,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+import * as _shopify_admin_web_component_foundations from '@shopify/admin-web-component-foundations';
 
+/**
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
+ * @publicDocs
+ */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
   currentTarget: HTMLElementTagNameMap[T];
 };
+/**
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
+ * @publicDocs
+ */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
       (event: CallbackEvent<T>): void;
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
-/**  * @publicDocs
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+/**
+ * Makes a type responsive by allowing it to be either the base value or a container query string. This enables conditional styling based on container dimensions.
+ * @publicDocs
  */
 export type MakeResponsive<T> = T | `@container${string}`;
 /**
@@ -75,7 +143,24 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
   [P in TProperty]: MakeResponsive<TType[P]>;
 };
 
+/**
+ * Represents the box component props with all properties marked as required.
+ * @publicDocs
+ */
 export type RequiredBoxProps = Required<BoxProps$1>;
+/**
+ * Represents the subset of border radius values supported by the component.
+ *
+ * - `small-200`: Extra small radius for subtle rounding.
+ * - `small-100`: Small radius for minimal corner rounding.
+ * - `small`: Standard small radius.
+ * - `base`: Medium radius for moderate corner rounding.
+ * - `large`: Standard large radius for pronounced rounding.
+ * - `large-100`: Large radius for more prominent corner rounding.
+ * - `large-200`: Extra large radius for maximum rounding.
+ * - `none`: No border radius (sharp corners).
+ * @publicDocs
+ */
 export type BoxBorderRadii = Extract<
   RequiredBoxProps['borderRadius'],
   | 'none'
@@ -87,10 +172,25 @@ export type BoxBorderRadii = Extract<
   | 'large-100'
   | 'large-200'
 >;
+/**
+ * Represents the subset of border style values supported by the box component.
+ *
+ * - `auto`: Default border style determined by the system.
+ * - `none`: No border style (removes the border).
+ * - `solid`: Continuous line border.
+ * - `dashed`: Border made up of dashes.
+ * @publicDocs
+ */
 export type BoxBorderStyles = Extract<
   RequiredBoxProps['borderStyle'],
   'none' | 'solid' | 'dashed' | 'auto'
 >;
+/**
+ * Represents box props with responsive capabilities for layout properties.
+ *
+ * This enables conditional styling based on container queries.
+ * @publicDocs
+ */
 export type ResponsiveBoxProps = MakeResponsivePick<
   RequiredBoxProps,
   | 'padding'
@@ -123,7 +223,7 @@ export interface BoxProps
     | 'overflow'
   > {
   /**
-   * The background color of the clickable element.
+   * The background color of the component.
    *
    * @default 'transparent'
    */
@@ -132,16 +232,13 @@ export interface BoxProps
     'transparent' | 'base' | 'subdued' | 'strong'
   >;
   /**
-   * Controls the thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
+   * A border applied using shorthand syntax to specify width, color, and style in a single property.
    *
-   * - `small`: Thin border for subtle definition.
-   * - `small-100`: Extra thin border for minimal emphasis.
-   * - `base`: Standard border width.
-   * - `large`: Thick border for strong emphasis.
-   * - `large-100`: Extra thick border for maximum prominence.
-   * - `none`: No border.
-   *
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.
+   * @default 'none'
+   */
+  border: RequiredBoxProps['border'];
+  /**
+   * The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -154,10 +251,7 @@ export interface BoxProps
       >
     | Extract<RequiredBoxProps['borderWidth'], ''>;
   /**
-   * Controls the visual style of the border on all sides (solid, dashed, auto, or none).
-   *
-   * When set, this overrides the style value specified in the `border` property.
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.
+   * The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -165,10 +259,7 @@ export interface BoxProps
     | MaybeAllValuesShorthandProperty<BoxBorderStyles>
     | Extract<RequiredBoxProps['borderStyle'], ''>;
   /**
-   * Controls the color of the border using the design system's color scale.
-   *
-   * When set, this overrides the color value specified in the `border` property.
-   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.
+   * The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -177,101 +268,85 @@ export interface BoxProps
     'subdued' | 'base' | 'strong' | ''
   >;
   /**
-   * Controls the roundedness of the element's corners using the design system's radius scale.
-   *
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded or pill-shaped clickable elements.
+   * The roundedness of the element's corners using the design system's radius scale.
    *
    * @default 'none'
    */
   borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;
   /**
-   * The padding applied to all edges of the clickable element.
+   * The padding applied to all edges of the component.
    *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
+   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:
+   * - 1 value applies to all sides
+   * - 2 values apply to block (top/bottom) and inline (left/right)
+   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)
+   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)
    *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
+   * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
-   *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
   padding: ResponsiveBoxProps['padding'];
   /**
-   * The padding applied to the block axis (top and bottom in horizontal writing modes).
+   * The block-direction padding (top and bottom in horizontal writing modes).
    *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for block-start and block-end.
    *
-   * This overrides the block value of `padding`.
+   * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlock: ResponsiveBoxProps['paddingBlock'];
   /**
-   * The padding applied to the block-start edge (top in horizontal writing modes).
+   * The block-start padding (top in horizontal writing modes).
    *
-   * This overrides the block-start value of `paddingBlock`.
-   *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];
   /**
-   * The padding applied to the block-end edge (bottom in horizontal writing modes).
+   * The block-end padding (bottom in horizontal writing modes).
    *
-   * This overrides the block-end value of `paddingBlock`.
-   *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];
   /**
-   * The padding applied to the inline axis (left and right in horizontal writing modes).
+   * The inline-direction padding (left and right in horizontal writing modes).
    *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.
    *
-   * This overrides the inline value of `padding`.
+   * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInline: ResponsiveBoxProps['paddingInline'];
   /**
-   * The padding applied to the inline-start edge (left in left-to-right languages).
+   * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * This overrides the inline-start value of `paddingInline`.
-   *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];
   /**
-   * The padding applied to the inline-end edge (right in left-to-right languages).
+   * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * This overrides the inline-end value of `paddingInline`.
-   *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];
   /**
-   * Sets the outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
    *
    * - `auto` the component's initial value. The actual value depends on the component and context.
    * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
@@ -280,7 +355,7 @@ export interface BoxProps
    */
   display: ResponsiveBoxProps['display'];
   /**
-   * The vertical size of the component in standard layouts (height in left-to-right or right-to-left writing modes).
+   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).
    *
    * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;
    * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.
@@ -291,37 +366,53 @@ export interface BoxProps
    */
   blockSize: SizeUnitsOrAuto;
   /**
-   * The [minimum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) (minimum height in horizontal writing modes) of the clickable element.
+   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize: SizeUnits;
   /**
-   * The [maximum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) (maximum height in horizontal writing modes) of the clickable element.
+   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize: SizeUnitsOrNone;
   /**
-   * The [inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size) (width in horizontal writing modes) of the clickable element.
+   * The width in horizontal writing modes, or height in vertical writing modes.
+   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize: SizeUnitsOrAuto;
   /**
-   * The [minimum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) (minimum width in horizontal writing modes) of the clickable element.
+   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize: SizeUnits;
   /**
-   * The [maximum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) (maximum width in horizontal writing modes) of the clickable element.
+   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
   maxInlineSize: SizeUnitsOrNone;
 }
-/**  * @publicDocs
+
+/**
+ * Represents the base clickable props with all properties marked as required.
+ * @publicDocs
  */
 export type ClickableBaseProps = Required<
   Pick<
@@ -340,87 +431,47 @@ export type ClickableBaseProps = Required<
   >
 >;
 /**
- * The properties for the clickable component. These properties define a low-level interactive container element that responds to user clicks while inheriting all box styling capabilities. The component serves as a foundation for building custom interactive components.
- * @publicDocs
+ * Configure the following properties on the clickable component.
  */
-export interface ClickableProps
-  extends Required<BoxProps>,
-    ClickableBaseProps {}
-/**  * @publicDocs
- */
-export type Styles = string;
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  ShadowRoot: (element: any) => ComponentChildren;
-  styles?: Styles;
-};
-export interface ActivationEventEsque {
-  shiftKey: boolean;
-  metaKey: boolean;
-  ctrlKey: boolean;
-  button: number;
-}
-/**  *
- * @publicDocs
- */
-export interface ClickOptions {
+export interface ClickableProps extends Required<BoxProps>, ClickableBaseProps {
   /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
+   * Whether the component is in a loading state, which indicates to assistive technology that an action is in progress and prevents interaction.
    */
-  sourceEvent?: ActivationEventEsque;
+  loading: Required<ClickableProps$1>['loading'];
+  /**
+   * The language of the text content.
+   *
+   * Use this when the text is in a different language than the rest of the page, allowing assistive technologies
+   * such as screen readers to invoke the correct pronunciation.
+   *
+   * The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
+   *
+   * @default ''
+   */
+  lang: Required<ClickableProps$1>['lang'];
+  /**
+   * Whether the component is disabled, preventing clicks and focus. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You should apply disabled styling as needed.
+   */
+  disabled: Required<ClickableProps$1>['disabled'];
 }
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
-/**  * @publicDocs
- */
+
 export interface PreactOverlayControlProps
   extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
   /**
-   * The action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated. The supported actions vary by target component type.
+   * The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
    *
-   * - `--auto`: Performs the default action appropriate for the target component.
-   * - `--show`: Displays the target component if it's currently hidden.
-   * - `--hide`: Conceals the target component from view.
-   * - `--toggle`: Alternates the target component between visible and hidden states.
+   * - `--auto`: A default action for the target component.
+   * - `--show`: Shows the target component.
+   * - `--hide`: Hides the target component.
+   * - `--toggle`: Toggles the visibility of the target component.
    *
    * @default '--auto'
    */
@@ -429,16 +480,16 @@ export interface PreactOverlayControlProps
     '--show' | '--hide' | '--toggle' | '--auto'
   >;
   /**
-   * Sets the component the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
+   * The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
    */
   commandFor: Extract<InteractionProps['commandFor'], string>;
   /**
-   * Sets the component the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this component is activated.
+   * The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.
    */
   interestFor: Extract<InteractionProps['interestFor'], string>;
 }
 
-declare class BoxElement extends PreactCustomElement implements BoxProps {
+declare class BoxElement extends PolarisCustomElement implements BoxProps {
   constructor(renderImpl: RenderImpl);
   accessor accessibilityRole: BoxProps['accessibilityRole'];
   accessor background: BoxProps['background'];
@@ -467,18 +518,50 @@ declare class BoxElement extends PreactCustomElement implements BoxProps {
 }
 
 declare const Clickable_base: (abstract new (
-  renderImpl: RenderImpl,
+  renderImpl: _shopify_admin_web_component_foundations.RenderImpl,
 ) => BoxElement & PreactOverlayControlProps) &
   Pick<typeof BoxElement, 'prototype' | 'observedAttributes'>;
+/**
+ * Configure the following properties on the clickable component.
+ * @publicDocs
+ */
 declare class Clickable extends Clickable_base implements ClickableProps {
   accessor disabled: ClickableProps['disabled'];
   accessor loading: ClickableProps['loading'];
+  /**
+   * The browsing context where the linked URL should be displayed.
+   *
+   * - `auto`: The target is automatically determined based on the origin of the URL.
+   * - `_blank`: Opens the URL in a new window or tab.
+   * - `_self`: Opens the URL in the same browsing context as the current one.
+   * - `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.
+   * - `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.
+   */
   accessor target: ClickableProps['target'];
+  /**
+   * The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.
+   */
   accessor href: ClickableProps['href'];
+  /**
+   * Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.
+   *
+   * The filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.
+   *
+   * Learn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).
+   */
   accessor download: ClickableProps['download'];
   accessor onclick: CallbackEventListener<typeof tagName> | null;
   accessor onblur: CallbackEventListener<typeof tagName> | null;
   accessor onfocus: CallbackEventListener<typeof tagName> | null;
+  /**
+   * The behavior of the button component.
+   *
+   * - `button`: Used to indicate the component acts as a button, meaning it has no default action.
+   * - `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).
+   * - `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.
+   *
+   * This property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.
+   */
   accessor type: ClickableProps['type'];
   constructor();
 }
@@ -497,85 +580,25 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-clickable';
-/**
- * The JSX properties for the clickable component. These properties define how a clickable container is rendered in Preact or JSX.
- * @publicDocs
- */
 export interface ClickableJSXProps
   extends Partial<ClickableProps>,
     Pick<ClickableProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the component. This can include text, components, or any other UI elements.
+   * The content displayed within the clickable component, which makes any content interactive and clickable without the semantic meaning of a button or link.
    */
   children?: ComponentChildren;
   /**
-   * A callback function that's invoked when the component is clicked. It receives the click event as an argument.
+   * A callback fired when the chip is clicked.
    */
   onClick?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function that's invoked when the component receives focus. It receives the focus event as an argument.
+   * A callback fired when the chip receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback function that's invoked when the component loses focus. It receives the blur event as an argument.
+   * A callback fired when the chip loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
-  /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
-   *
-   * @default ''
-   */
-  accessibilityLabel?: string;
-  /**
-   * Whether the component is disabled, preventing interaction. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You should apply disabled styling as needed.
-   *
-   * @default false
-   */
-  disabled?: boolean;
-  /**
-   * Whether a loading indicator is displayed and interaction is prevented. Set this to `true` to show that an action triggered by the click is in progress.
-   *
-   * @default false
-   */
-  loading?: boolean;
-  /**
-   * The URL that the component navigates to when clicked. When provided, the component behaves as a link.
-   *
-   * @default ''
-   */
-  href?: string;
-  /**
-   * Where to open the linked document when the component acts as a link (when `href` is provided). Available options:
-   * - `''` - Opens in the same frame (default behavior).
-   * - `'_blank'` - Opens in a new window or tab.
-   * - `'_self'` - Opens in the same frame (explicit version of default).
-   * - `'_parent'` - Opens in the parent frame.
-   * - `'_top'` - Opens in the full body of the window.
-   *
-   * @default ''
-   */
-  target?: string;
-  /**
-   * The filename to save the linked URL as when downloaded. This only works when `href` is provided.
-   *
-   * @default ''
-   */
-  download?: string;
-  /**
-   * The language of the component's content, specified as a BCP 47 language tag (such as `en` or `fr`). This helps assistive technologies pronounce content correctly.
-   *
-   * @default ''
-   */
-  lang?: string;
-  /**
-   * The component's behavior in forms when it's used as a form control. Available options:
-   * - `'button'` - A standard clickable with no default behavior.
-   * - `'submit'` - Submits the form data to the server.
-   * - `'reset'` - Resets all form controls to their initial values.
-   *
-   * @default 'button'
-   */
-  type?: string;
 }
 
 export {Clickable};

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
@@ -1,29 +1,44 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   ComponentChildren,
   ClickableChipProps$1,
   InteractionProps,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * A callback event that's typed to a specific HTML element.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that currently has the event listener attached.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener for callback events, typed to a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -32,38 +47,72 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
   /**
-   * The child elements to render inside this element.
+   * The child elements to be rendered within this component.
    */
   children?: preact.ComponentChildren;
 }
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
 /**
- * The properties for the clickable chip component. These properties define an interactive chip that can be clicked or removed.
- * @publicDocs
+ * Configure the following properties on the clickable chip component.
  */
 export interface ClickableChipProps
   extends Required<
@@ -79,115 +128,48 @@ export interface ClickableChipProps
       | 'commandFor'
       | 'interestFor'
     >
-  > {}
-
-/**
- * A string containing CSS styles for the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  > {
   /**
-   * The function that renders the component's shadow root content.
+   * Whether the chip is hidden from view. When using controlled component pattern with `removable` chips, update this property when the `remove` event fires. For non-removable chips, manually toggle this property to show or hide the chip.
+   *
+   * @default false
    */
-  ShadowRoot: (element: any) => ComponentChildren;
+  hidden: Required<ClickableChipProps$1>['hidden'];
   /**
-   * Optional CSS styles to apply to the shadow root.
+   * Whether the chip is disabled, preventing any user interaction.
+   *
+   * @default false
    */
-  styles?: Styles;
-};
-/**
- * An event-like object that contains activation information for synthetic clicks.
- * @publicDocs
- */
-export interface ActivationEventEsque {
+  disabled: Required<ClickableChipProps$1>['disabled'];
   /**
-   * Whether the shift key was pressed during activation.
+   * The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.
    */
-  shiftKey: boolean;
+  href: Required<ClickableChipProps$1>['href'];
   /**
-   * Whether the meta key (Command on Mac, Windows key on Windows) was pressed during activation.
+   * Whether the chip displays a remove button for dismissal. When clicked, the `remove` callback fires.
+   *
+   * @default false
    */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during activation.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during activation.
-   */
-  button: number;
+  removable: Required<ClickableChipProps$1>['removable'];
 }
-/**
- * Options for customizing synthetic click behavior.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/**
- * Props for controlling overlay components like popovers and dialogs.
- * @publicDocs
- */
 export interface PreactOverlayControlProps
   extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
   /**
-   * The action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated. The supported actions vary by target component type.
+   * The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
    *
-   * - `--auto`: Performs the default action appropriate for the target component.
-   * - `--show`: Displays the target component if it's currently hidden.
-   * - `--hide`: Conceals the target component from view.
-   * - `--toggle`: Alternates the target component between visible and hidden states.
+   * - `--auto`: A default action for the target component.
+   * - `--show`: Shows the target component.
+   * - `--hide`: Hides the target component.
+   * - `--toggle`: Toggles the visibility of the target component.
    *
    * @default '--auto'
    */
@@ -196,62 +178,53 @@ export interface PreactOverlayControlProps
     '--show' | '--hide' | '--toggle' | '--auto'
   >;
   /**
-   * Sets the element the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
+   * The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
    */
   commandFor: Extract<InteractionProps['commandFor'], string>;
   /**
-   * Sets the element the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this component is activated.
+   * The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.
    */
   interestFor: Extract<InteractionProps['interestFor'], string>;
 }
 
-declare const ClickableChip_base: (abstract new (
-  args_0: RenderImpl,
-) => PreactCustomElement & PreactOverlayControlProps) &
-  Pick<typeof PreactCustomElement, 'prototype' | 'observedAttributes'>;
+declare const ClickableChipBase_base: (abstract new (
+  renderImpl: Omit<RenderImpl, 'globalShadowCSS'>,
+) => PolarisCustomElement & PreactOverlayControlProps) &
+  Pick<typeof PolarisCustomElement, 'prototype' | 'observedAttributes'>;
+declare abstract class ClickableChipBase<
+    TTagName extends keyof HTMLElementTagNameMap,
+  >
+  extends ClickableChipBase_base
+  implements
+    Pick<
+      ClickableChipProps,
+      'accessibilityLabel' | 'removable' | 'hidden' | 'disabled' | 'href'
+    >
+{
+  accessor accessibilityLabel: ClickableChipProps['accessibilityLabel'];
+  accessor removable: ClickableChipProps['removable'];
+  accessor hidden: ClickableChipProps['hidden'];
+  accessor disabled: ClickableChipProps['disabled'];
+  accessor href: ClickableChipProps['href'];
+  accessor onclick: CallbackEventListener<TTagName> | null;
+  accessor onremove: CallbackEventListener<TTagName> | null;
+  accessor onafterhide: CallbackEventListener<TTagName> | null;
+  abstract accessor color: string;
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+}
+
 /**
- * A custom element for displaying interactive chips that can be clicked or removed.
+ * Configure the following properties on the clickable chip component.
+ * @publicDocs
  */
 declare class ClickableChip
-  extends ClickableChip_base
+  extends ClickableChipBase<typeof tagName>
   implements ClickableChipProps
 {
   /**
-   * The color of the chip.
+   * The color emphasis level that controls visual intensity.
    */
   accessor color: ClickableChipProps['color'];
-  /**
-   * A text description of the chip for screen readers.
-   */
-  accessor accessibilityLabel: ClickableChipProps['accessibilityLabel'];
-  /**
-   * Whether the chip can be removed by the user.
-   */
-  accessor removable: ClickableChipProps['removable'];
-  /**
-   * Whether the chip is hidden from view.
-   */
-  accessor hidden: ClickableChipProps['hidden'];
-  /**
-   * Whether the chip is disabled and can't be clicked.
-   */
-  accessor disabled: ClickableChipProps['disabled'];
-  /**
-   * The URL to navigate to when the chip is clicked.
-   */
-  accessor href: ClickableChipProps['href'];
-  /**
-   * A callback that's fired when the chip is clicked.
-   */
-  accessor onclick: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's fired when the chip is removed.
-   */
-  accessor onremove: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's fired after the chip finishes hiding.
-   */
-  accessor onafterhide: CallbackEventListener<typeof tagName> | null;
   constructor();
 }
 declare global {
@@ -269,31 +242,27 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-clickable-chip';
-/**
- * The JSX properties for the clickable chip component. These properties define how a clickable chip is rendered in Preact or JSX.
- * @publicDocs
- */
 export interface ClickableChipJSXProps
   extends Partial<ClickableChipProps>,
     Pick<ClickableChipProps$1, 'id' | 'children'> {
   /**
-   * The content of the chip.
+   * The text label displayed within the chip, which represents an interactive filter, tag, or selectable item.
    */
   children?: ComponentChildren;
   /**
-   * An optional icon to display at the start of the chip. Accepts only Icon components.
+   * An optional icon to display at the start of the chip. Accepts only icon components.
    */
   graphic?: ComponentChildren;
   /**
-   * A callback that's fired when the chip is clicked.
+   * A callback fired when the chip is clicked.
    */
   onClick?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's fired when the chip is removed.
+   * A callback fired when the user clicks the remove button on the chip.
    */
   onRemove?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's fired after the chip finishes hiding.
+   * A callback fired when the chip is completely hidden, after any hide animations have completed.
    */
   onAfterHide?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ClickableChip.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
@@ -1,226 +1,177 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   ColorFieldProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event object with a strongly-typed currentTarget property that references the specific HTML element type.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The DOM element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function or null that receives a typed callback event.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
-      /**
-       * The callback function that's invoked when the event fires.
-       */
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * The React-style event handler props for form field components.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's triggered when the field's value changes as the user types.
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field's value changes and the field loses focus.
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field receives focus.
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field loses focus.
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
+};
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles to be applied to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object containing information about keyboard and mouse button states during an activation event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta (Command on Mac, Windows key on PC) key was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the event.
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for programmatically triggering a click event on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The required props for input elements that all form controls must implement.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/**
- * The base class for form input elements that participate in form submission.
- */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
-  /** @private */
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * The callback that's triggered when the input value changes and the field loses focus.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * The callback that's triggered when the input value changes as the user types.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the input is disabled and can't be interacted with.
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * The unique identifier for the input element.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * The name of the input, used when submitting form data.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value of the input.
-   */
   get value(): PreactInputProps['value'];
-  /**
-   * The current value of the input.
-   */
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The common props shared by all form field components in the admin UI.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -239,17 +190,17 @@ export type PreactFieldProps<Autocomplete extends string = string> =
       >
     > & {
       /**
-       * A hint about the intended content of the field for browser autofill.
+       * A hint as to the intended content of the field.
        *
        * When set to `on` (the default), this property indicates that the field should support
-       * autofill, but you don't have any more semantic information on the intended
+       * autofill, but you do not have any more semantic information on the intended
        * contents.
        *
-       * When set to `off`, you're indicating that this field contains sensitive
+       * When set to `off`, you are indicating that this field contains sensitive
        * information, or contents that are never saved, like one-time codes.
        *
-       * Alternatively, you can provide a value which describes the
-       * specific data you'd like to be entered into this field during autofill.
+       * Alternatively, you can provide value which describes the
+       * specific data you would like to be entered into this field during autofill.
        *
        * @see Learn more about the set of {@link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens|autocomplete values} supported in browsers.
        *
@@ -260,63 +211,27 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/**
- * The base class for form field elements that includes label, error, and validation support.
- */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * The callback that's triggered when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * The callback that's triggered when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint about the intended content of the field for browser autofill.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value of the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * The additional text displayed below the field to provide helpful context.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * The error message displayed when the field validation fails.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label displayed above the field.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * The visibility of the label for accessibility purposes. Available values: `hidden`, `visible`.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The hint text displayed inside the field when it's empty.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only and can't be edited by the user.
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before the form can be submitted.
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
    * ignore keystrokes originating from within input elements. Unfortunately,
-   * these never account for a custom element being the input element.
+   * these never account for a Custom Element being the input element.
    *
-   * To fix this, we spoof getAttribute and hasAttribute to make a PreactFieldElement
+   * To fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement
    * appear as a contentEditable "input" when it contains a focused input element.
    * @private technically not private, but we don't want to expose this as public API
    */
@@ -326,8 +241,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
    */
   hasAttribute(qualifiedName: string): boolean;
   /**
-   * Checks if the shadow tree contains a focused input (input, textarea, select, contentEditable element).
-   * Note: this doesn't return true for focused non-field form elements like buttons.
+   * Checks if the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).
+   * Note: this does _not_ return true for focussed non-field form elements like buttons.
    * @private
    */
   get isContentEditable(): boolean;
@@ -339,38 +254,34 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the color field component. These properties configure an input field that allows merchants to select colors using an integrated visual color picker with text input, hex color format, and optional alpha (transparency) channel support.
+ * Represents the props for color input field components. Extends `PreactFieldProps` with autocomplete support for color-related fields.
  * @publicDocs
  */
-export type ColorFieldProps = Omit<
-  PreactFieldProps<Required<ColorFieldProps$1>['autocomplete']>,
-  'value' | 'defaultValue'
+export type ColorFieldProps = PreactFieldProps<
+  Required<ColorFieldProps$1>['autocomplete']
 > &
   Required<Pick<ColorFieldProps$1, 'alpha' | 'value' | 'defaultValue'>>;
 
-/**
- * The color field custom element class that renders a color input field with integrated visual picker in the Shopify admin interface. This component allows merchants to select colors by typing hex values or using an interactive color picker, with optional support for transparency (alpha channel).
- */
-declare class ColorField
+declare abstract class ColorFieldBase
   extends PreactFieldElement<ColorFieldProps['autocomplete']>
-  implements ColorFieldProps
+  implements Pick<ColorFieldProps, 'alpha' | 'value'>
 {
-  /**
-   * Whether the color picker includes an alpha (transparency) channel for selecting semi-transparent colors.
-   *
-   * @default false
-   */
   accessor alpha: ColorFieldProps['alpha'];
-  /**
-   * The current color value, formatted as a hex color string (e.g., `#FF0000` or `#FF0000FF` with alpha).
-   */
   get value(): string;
   set value(value: string);
   /** @private */
   formResetCallback(): void;
-  constructor();
+  constructor(renderImpl: RenderImpl);
   /** @private */
   setInternalValue(value: string, normalize: boolean): void;
+}
+
+/**
+ * Configure the following properties on the color field component.
+ * @publicDocs
+ */
+declare class ColorField extends ColorFieldBase implements ColorFieldProps {
+  constructor();
 }
 declare global {
   interface HTMLElementTagNameMap {
@@ -380,30 +291,20 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: ColorFieldJSXProps & PreactBaseElementProps<ColorField>;
+      [tagName]: Omit<ColorFieldJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<ColorField>;
     }
   }
 }
 
 declare const tagName = 's-color-field';
-/**
- * The JSX props for the color field component. These properties extend `ColorFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including callbacks for color changes as the merchant interacts with the picker.
- * @publicDocs
- */
 export interface ColorFieldJSXProps
-  extends Partial<
-      Omit<ColorFieldProps, 'accessory' | 'value' | 'defaultValue'>
-    >,
-    Pick<ColorFieldProps$1, 'id'>,
-    Required<Pick<ColorFieldProps$1, 'alpha' | 'value' | 'defaultValue'>>,
-    FieldReactProps<typeof tagName> {
-  /**
-   * A callback that's triggered when the color value changes as the user interacts with the picker.
-   */
+  extends Partial<Omit<ColorFieldProps, 'accessory' | 'error' | 'details'>>,
+    Pick<ColorFieldProps$1, 'id' | 'alpha' | 'value' | 'defaultValue'>,
+    FieldReactProps<typeof tagName>,
+    FieldSlotInternalReactProps {
   onInput?: (event: CallbackEvent<typeof tagName>) => void;
-  /**
-   * A callback that's triggered when the color value changes and the field loses focus.
-   */
   onChange?: (event: CallbackEvent<typeof tagName>) => void;
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -45,7 +40,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -62,7 +57,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -70,19 +65,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
@@ -1,205 +1,165 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ColorPickerProps$1, ComponentChildren} from './shared.d.ts';
+import type {
+  ColorPickerProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event object with a strongly-typed `currentTarget` property that references the specific HTML element type.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The DOM element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function or null that receives a typed callback event.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
-      /**
-       * The callback function that's invoked when the event fires.
-       */
       (event: CallbackEvent<T>): void;
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
 /**
- * Properties for rendering a color picker that provides a visual interface for selecting colors with optional transparency control.
- * @publicDocs
+ * Configure the following properties on the color picker component.
  */
 export interface ColorPickerProps
   extends Required<
     Pick<ColorPickerProps$1, 'id' | 'alpha' | 'value' | 'defaultValue' | 'name'>
-  > {}
-
-/**
- * A string containing CSS styles to be applied to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  > {
   /**
-   * A function that renders the component's shadow DOM content.
+   * The currently selected color value. Accepts multiple input formats:
+   *
+   * - Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)
+   * - RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)
+   * - HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`
+   *
+   * Returns an empty string if the value is invalid. The `change` event always emits values in hex format.
    */
-  ShadowRoot: (element: any) => ComponentChildren;
+  value: Required<ColorPickerProps$1>['value'];
   /**
-   * The CSS styles to apply to the component.
+   * The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.
    */
-  styles?: Styles;
-};
-/**
- * An object containing information about keyboard and mouse button states during an activation event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
+  defaultValue: Required<ColorPickerProps$1>['defaultValue'];
   /**
-   * Whether the Shift key was pressed during the event.
+   * Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.
+   *
+   * @default false
    */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta (Command on Mac, Windows key on PC) key was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the event.
-   */
-  button: number;
+  alpha: Required<ColorPickerProps$1>['alpha'];
 }
-/**
- * The options for programmatically triggering a click event on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass$1: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass$1 {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
-/**
- * The base class for form-associated components that can participate in form submission.
- */
-declare class BaseClass extends PreactCustomElement {
-  /**
-   * Whether this element can participate in form submission.
-   */
+declare class BaseClass extends PolarisCustomElement {
   static formAssociated: boolean;
   constructor(renderImpl: RenderImpl);
   /** @private */
   [internals]: ElementInternals;
 }
 /**
- * A visual color picker component that allows users to select colors from a color spectrum interface.
+ * Configure the following properties on the color picker component.
+ * @publicDocs
  */
 declare class ColorPicker extends BaseClass implements ColorPickerProps {
-  /**
-   * Whether the color picker includes an alpha (transparency) channel for selecting semi-transparent colors.
-   *
-   * @default false
-   */
   accessor alpha: boolean;
-  /**
-   * The callback that's triggered when the selected color changes and the picker loses focus.
-   */
   accessor onchange: CallbackEventListener<typeof tagName> | null;
-  /**
-   * The callback that's triggered when the selected color changes as the user interacts with the picker.
-   */
   accessor oninput: CallbackEventListener<typeof tagName> | null;
   /**
-   * The name of the picker, used when submitting form data.
+   * The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.
    */
   accessor name: string;
-  /**
-   * The initial color value when the picker first renders, formatted as a hex color string (e.g., `#FF0000` or `#FF0000FF` with alpha).
-   */
   accessor defaultValue: string;
-  /**
-   * The current color value, formatted as a hex color string (e.g., `#FF0000` or `#FF0000FF` with alpha).
-   */
   get value(): string;
-  /**
-   * The current color value, formatted as a hex color string (e.g., `#FF0000` or `#FF0000FF` with alpha).
-   */
   set value(value: string);
-  /** @private */
+  /**
+   * A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`.
+   */
   formResetCallback(): void;
   constructor();
 }
@@ -217,23 +177,13 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-color-picker';
-/**
- * The JSX props interface for the color picker component when used in React/Preact.
- * @publicDocs
- */
 export interface ColorPickerJSXProps
   extends Partial<ColorPickerProps>,
     Pick<
       ColorPickerProps$1,
       'id' | 'alpha' | 'value' | 'defaultValue' | 'name'
     > {
-  /**
-   * A callback that's triggered when the selected color changes as the user interacts with the picker.
-   */
   onInput?: (event: CallbackEvent<typeof tagName>) => void | null;
-  /**
-   * A callback that's triggered when the selected color changes and the picker loses focus.
-   */
   onChange?: (event: CallbackEvent<typeof tagName>) => void | null;
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
@@ -1,205 +1,160 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   DateAutocompleteField,
   DateFieldProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event object with a strongly-typed currentTarget property that references the specific HTML element type.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The DOM element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function or null that receives a typed callback event.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
-      /**
-       * The callback function that's invoked when the event fires.
-       */
       (event: CallbackEvent<T>): void;
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles to be applied to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object containing information about keyboard and mouse button states during an activation event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta (Command on Mac, Windows key on PC) key was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the event.
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for programmatically triggering a click event on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The required props for input elements that all form controls must implement.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/**
- * The base class for form input elements that participate in form submission.
- */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
-  /** @private */
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * The callback that's triggered when the input value changes and the field loses focus.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * The callback that's triggered when the input value changes as the user types.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the input is disabled and can't be interacted with.
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * The unique identifier for the input element.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * The name of the input, used when submitting form data.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value of the input.
-   */
   get value(): PreactInputProps['value'];
-  /**
-   * The current value of the input.
-   */
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The common props shared by all form field components in the admin UI.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -218,18 +173,19 @@ export type PreactFieldProps<Autocomplete extends string = string> =
       >
     > & {
       /**
-       * Controls browser autofill behavior for the field.
+       * A hint as to the intended content of the field.
        *
-       * Basic values:
-       * - `on` - Enables autofill without specifying content type (default)
-       * - `off` - Disables autofill for sensitive data or one-time codes
+       * When set to `on` (the default), this property indicates that the field should support
+       * autofill, but you do not have any more semantic information on the intended
+       * contents.
        *
-       * Specific field values describe the expected data type. You can optionally prefix these with:
-       * - `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)
-       * - `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes
-       * - Both section and group (for example, `section-primary shipping email`)
+       * When set to `off`, you are indicating that this field contains sensitive
+       * information, or contents that are never saved, like one-time codes.
        *
-       * Providing a specific autofill token helps browsers suggest more relevant saved data. Learn more about [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens).
+       * Alternatively, you can provide value which describes the
+       * specific data you would like to be entered into this field during autofill.
+       *
+       * @see Learn more about the set of {@link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens|autocomplete values} supported in browsers.
        *
        * @default 'tel' for PhoneField
        * @default 'email' for EmailField
@@ -238,63 +194,27 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/**
- * The base class for form field elements that includes label, error, and validation support.
- */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * The callback that's triggered when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * The callback that's triggered when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint about the intended content of the field for browser autofill.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value of the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * The additional text displayed below the field to provide helpful context.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * The error message displayed when the field validation fails.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label displayed above the field.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * The visibility of the label for accessibility purposes. Available values: `hidden`, `visible`.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The hint text displayed inside the field when it's empty.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only and can't be edited by the user.
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before the form can be submitted.
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
    * ignore keystrokes originating from within input elements. Unfortunately,
-   * these never account for a custom element being the input element.
+   * these never account for a Custom Element being the input element.
    *
-   * To fix this, we spoof getAttribute and hasAttribute to make a PreactFieldElement
+   * To fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement
    * appear as a contentEditable "input" when it contains a focused input element.
    * @private technically not private, but we don't want to expose this as public API
    */
@@ -304,8 +224,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
    */
   hasAttribute(qualifiedName: string): boolean;
   /**
-   * Checks if the shadow tree contains a focused input (input, textarea, select, contentEditable element).
-   * Note: this doesn't return true for focused non-field form elements like buttons.
+   * Checks if the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).
+   * Note: this does _not_ return true for focussed non-field form elements like buttons.
    * @private
    */
   get isContentEditable(): boolean;
@@ -317,14 +237,10 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the date field component. These properties configure an input field that allows merchants to select dates using an integrated calendar picker with optional text input, date constraints, and day-of-week restrictions.
- * @publicDocs
+ * Configure the following properties on the date field component.
  */
 export interface DateFieldProps
-  extends Omit<
-      PreactFieldProps<DateAutocompleteField>,
-      'value' | 'defaultValue'
-    >,
+  extends PreactFieldProps<DateAutocompleteField>,
     Required<
       Pick<
         DateFieldProps$1,
@@ -337,51 +253,51 @@ export interface DateFieldProps
         | 'view'
         | 'defaultView'
       >
-    > {}
+    > {
+  /**
+   * The currently selected date in `YYYY-MM-DD` format. An empty string means no date is selected.
+   *
+   * @default ""
+   */
+  value: Required<DateFieldProps$1>['value'];
+  /**
+   * The initial date value when the field first renders, in `YYYY-MM-DD` format. An empty string means no date is initially selected.
+   *
+   * @default ""
+   */
+  defaultValue: Required<DateFieldProps$1>['defaultValue'];
+}
+
+declare abstract class DateFieldBase
+  extends PreactFieldElement<DateFieldProps['autocomplete']>
+  implements
+    Pick<
+      DateFieldProps,
+      | 'allow'
+      | 'disallow'
+      | 'allowDays'
+      | 'disallowDays'
+      | 'view'
+      | 'defaultView'
+    >
+{
+  accessor allow: DateFieldProps['allow'];
+  accessor disallow: DateFieldProps['disallow'];
+  accessor allowDays: DateFieldProps['allowDays'];
+  accessor disallowDays: DateFieldProps['disallowDays'];
+  set view(view: string);
+  get view(): string;
+  accessor defaultView: DateFieldProps['defaultView'];
+  accessor onviewchange: CallbackEventListener<'s-date-field'> | null;
+  accessor oninvalid: CallbackEventListener<'s-date-field'> | null;
+  constructor(renderImpl: RenderImpl);
+}
 
 /**
- * The date field custom element class that renders a date input field with integrated calendar picker in the Shopify admin interface. This component allows merchants to select dates by typing or using a visual calendar, with support for date range restrictions and day-of-week constraints.
+ * Configure the following properties on the date field component.
+ * @publicDocs
  */
-declare class DateField
-  extends PreactFieldElement<DateFieldProps['autocomplete']>
-  implements DateFieldProps
-{
-  /**
-   * The dates that are allowed to be selected, specified as ISO 8601 date strings or date ranges.
-   */
-  accessor allow: DateFieldProps['allow'];
-  /**
-   * The dates that aren't allowed to be selected, specified as ISO 8601 date strings or date ranges.
-   */
-  accessor disallow: DateFieldProps['disallow'];
-  /**
-   * The days of the week that are allowed to be selected. Available values: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`.
-   */
-  accessor allowDays: DateFieldProps['allowDays'];
-  /**
-   * The days of the week that aren't allowed to be selected. Available values: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`.
-   */
-  accessor disallowDays: DateFieldProps['disallowDays'];
-  /**
-   * The currently visible month and year in the calendar picker, formatted as an ISO 8601 date string.
-   */
-  set view(view: string);
-  /**
-   * The currently visible month and year in the calendar picker, formatted as an ISO 8601 date string.
-   */
-  get view(): string;
-  /**
-   * The initial month and year shown when the calendar picker first opens, formatted as an ISO 8601 date string.
-   */
-  accessor defaultView: DateFieldProps['defaultView'];
-  /**
-   * The callback that's triggered when the visible month or year in the calendar changes.
-   */
-  accessor onviewchange: CallbackEventListener<typeof tagName> | null;
-  /**
-   * The callback that's triggered when the user attempts to enter an invalid date.
-   */
-  accessor oninvalid: CallbackEventListener<typeof tagName> | null;
+declare class DateField extends DateFieldBase implements DateFieldProps {
   constructor();
 }
 declare global {
@@ -392,41 +308,40 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: DateFieldJSXProps & PreactBaseElementProps<DateField>;
+      [tagName]: Omit<DateFieldJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<DateField>;
     }
   }
 }
 
 declare const tagName = 's-date-field';
-/**
- * The JSX props for the date field component. These properties extend `DateFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including specialized callbacks for view changes and invalid date attempts.
- * @publicDocs
- */
 export interface DateFieldJSXProps
-  extends Partial<Omit<DateFieldProps, 'value' | 'defaultValue'>>,
-    Pick<DateFieldProps$1, 'id' | 'value' | 'defaultValue'> {
+  extends Partial<Omit<DateFieldProps, 'error' | 'details'>>,
+    Pick<DateFieldProps$1, 'id'>,
+    FieldSlotInternalReactProps {
   /**
-   * A callback that's triggered when the field loses focus.
+   * A callback fired when the date field loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the field's value changes and the field loses focus.
+   * A callback fired when the user has finished editing the date and the field value changes.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the field receives focus.
+   * A callback fired when the date field receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the field's value changes as the user types or selects.
+   * A callback fired when the user makes any changes to the date value.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the user attempts to enter an invalid date.
+   * A callback fired when the field contains an invalid date.
    */
   onInvalid?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the visible month or year in the calendar changes.
+   * A callback fired when the calendar view changes, such as when navigating between months.
    */
   onViewChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -53,19 +48,19 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
@@ -1,16 +1,26 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {DatePickerProps$1, ComponentChildren} from './shared.d.ts';
+import type {
+  DatePickerProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * The properties for the date picker component. These properties configure a standalone calendar interface for selecting single dates or date ranges, with support for date constraints, day-of-week restrictions, and month/year navigation.
- * @publicDocs
+ * Configure the following properties on the date picker component.
  */
 export interface DatePickerProps
   extends Required<
@@ -36,231 +46,227 @@ export interface DatePickerProps
    * @default "single"
    */
   type: Extract<DatePickerProps$1['type'], 'single' | 'range'>;
+  /**
+   * The currently selected date(s). An empty string means no date is selected.
+   *
+   * - Single date in `YYYY-MM-DD` format when `type` is set to `"single"`
+   * - Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `"range"`
+   *
+   * @default ""
+   */
+  value: Required<DatePickerProps$1>['value'];
+  /**
+   * The initially selected date(s) when the component first renders. An empty string means no date is initially selected.
+   *
+   * - Single date in `YYYY-MM-DD` format when `type` is set to `"single"`
+   * - Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `"range"`
+   *
+   * @default ""
+   */
+  defaultValue: Required<DatePickerProps$1>['defaultValue'];
+  /**
+   * Specifies which dates can be selected as a comma-separated list. An empty string (default) allows all dates.
+   *
+   * **Formats:**
+   * - `YYYY-MM-DD`: Single date
+   * - `YYYY-MM`: Whole month
+   * - `YYYY`: Whole year
+   * - `start--end`: Date range (inclusive, unbounded if start/end omitted)
+   *
+   * **Examples:**
+   * - `2024-02--2025`: February 2024 through end of 2025
+   * - `2024-05-09, 2024-05-11`: Only May 9th and 11th, 2024
+   *
+   * @default ""
+   */
+  allow: Required<DatePickerProps$1>['allow'];
+  /**
+   * Specifies which days of the week can be selected as a comma-separated list. Further restricts dates from `allow` and `disallow`. An empty string (default) has no effect.
+   *
+   * **Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`
+   *
+   * **Example:** `saturday, sunday` (only weekends)
+   *
+   * @default ""
+   */
+  allowDays: Required<DatePickerProps$1>['allowDays'];
+  /**
+   * Specifies which dates can't be selected as a comma-separated list. These dates are excluded from those specified in `allow`. An empty string (default) has no effect.
+   *
+   * **Formats:**
+   * - `YYYY-MM-DD`: Single date
+   * - `YYYY-MM`: Whole month
+   * - `YYYY`: Whole year
+   * - `start--end`: Date range (inclusive, unbounded if start/end omitted)
+   *
+   * **Examples:**
+   * - `--2024-02`: All dates before February 2024
+   * - `2024-05-09, 2024-05-11`: May 9th and 11th, 2024
+   *
+   * @default ""
+   */
+  disallow: Required<DatePickerProps$1>['disallow'];
+  /**
+   * Specifies which days of the week can't be selected as a comma-separated list. Excludes days from `allowDays` and intersects with `allow` and `disallow`. An empty string (default) has no effect.
+   *
+   * **Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`
+   *
+   * **Example:** `saturday, sunday` (no weekends)
+   *
+   * @default ""
+   */
+  disallowDays: Required<DatePickerProps$1>['disallowDays'];
+  /**
+   * The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`.
+   */
+  view: Required<DatePickerProps$1>['view'];
+  /**
+   * The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale.
+   */
+  defaultView: Required<DatePickerProps$1>['defaultView'];
+  /**
+   * Controls how many months are displayed.
+   *
+   * - `'auto'`: Context-driven. Today this renders a single month, matching `'1'`.
+   * - `'1'`: Renders one month at a time.
+   * - `'2'`: Renders two consecutive months side-by-side.
+   *
+   * @default 'auto'
+   */
+  visibleMonths: 'auto' | '1' | '2';
+}
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
 
 /**
- * An event object with a strongly-typed currentTarget property that references the specific HTML element type.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The DOM element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function or null that receives a typed callback event.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
-      /**
-       * The callback function that's invoked when the event fires.
-       */
       (event: CallbackEvent<T>): void;
     })
   | null;
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles to be applied to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
-};
-/**
- * An object containing information about keyboard and mouse button states during an activation event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta (Command on Mac, Windows key on PC) key was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the event.
-   */
-  button: number;
-}
-/**
- * The options for programmatically triggering a click event on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass$1: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass$1 {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 declare const dirtyStateSymbol: unique symbol;
-/**
- * The base class for form-associated components that can participate in form submission.
- */
-declare class BaseClass extends PreactCustomElement {
-  /**
-   * Whether this element can participate in form submission.
-   */
+declare abstract class DatePickerBase<
+    TagName extends 's-date-picker' | 's-internal-date-picker',
+  >
+  extends PolarisCustomElement
+  implements DatePickerProps
+{
   static formAssociated: boolean;
   constructor(renderImpl: RenderImpl);
   /** @private */
   [internals]: ElementInternals;
-}
-/**
- * The date picker custom element class that renders a standalone calendar interface in the Shopify admin. This component allows merchants to select single dates or date ranges using an interactive calendar with month/year navigation, date constraints, and day-of-week restrictions.
- */
-declare class DatePicker extends BaseClass implements DatePickerProps {
-  /**
-   * The initial month and year shown when the calendar first renders, formatted as an ISO 8601 date string.
-   */
   accessor defaultView: string;
-  /**
-   * The currently visible month and year in the calendar, formatted as an ISO 8601 date string.
-   */
   set view(view: string);
-  /**
-   * The currently visible month and year in the calendar, formatted as an ISO 8601 date string.
-   */
   get view(): string;
-  /**
-   * The dates that are allowed to be selected, specified as ISO 8601 date strings or date ranges.
-   */
   accessor allow: DatePickerProps['allow'];
-  /**
-   * The dates that aren't allowed to be selected, specified as ISO 8601 date strings or date ranges.
-   */
   accessor disallow: DatePickerProps['disallow'];
-  /**
-   * The days of the week that are allowed to be selected. Available values: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`.
-   */
   accessor allowDays: DatePickerProps['allowDays'];
-  /**
-   * The days of the week that aren't allowed to be selected. Available values: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`.
-   */
   accessor disallowDays: DatePickerProps['disallowDays'];
-  /**
-   * The type of date selection allowed. Available values: `single`, `range`.
-   */
   accessor type: DatePickerProps['type'];
-  /**
-   * The initial selected date or date range when the picker first renders, formatted as an ISO 8601 date string.
-   */
   accessor defaultValue: DatePickerProps['defaultValue'];
-  /**
-   * The name of the picker, used when submitting form data.
-   */
   accessor name: DatePickerProps['name'];
-  /**
-   * The currently selected date or date range, formatted as an ISO 8601 date string.
-   */
+  accessor visibleMonths: DatePickerProps['visibleMonths'];
   set value(value: string);
-  /**
-   * The currently selected date or date range, formatted as an ISO 8601 date string.
-   */
   get value(): string;
   /** @private */
   [dirtyStateSymbol]: boolean;
   /** @private */
   formResetCallback(): void;
-  /**
-   * The callback that's triggered when the visible month or year in the calendar changes.
-   */
-  accessor onviewchange: CallbackEventListener<typeof tagName> | null;
-  /**
-   * The callback that's triggered when the picker receives focus.
-   */
-  accessor onfocus: CallbackEventListener<typeof tagName> | null;
-  /**
-   * The callback that's triggered when the picker loses focus.
-   */
-  accessor onblur: CallbackEventListener<typeof tagName> | null;
-  /**
-   * The callback that's triggered when the selected date changes as the user interacts with the picker.
-   */
-  accessor oninput: CallbackEventListener<typeof tagName> | null;
-  /**
-   * The callback that's triggered when the selected date changes and the picker loses focus.
-   */
-  accessor onchange: CallbackEventListener<typeof tagName> | null;
+  accessor onviewchange: CallbackEventListener<TagName> | null;
+  accessor onfocus: CallbackEventListener<TagName> | null;
+  accessor onblur: CallbackEventListener<TagName> | null;
+  accessor oninput: CallbackEventListener<TagName> | null;
+  accessor onchange: CallbackEventListener<TagName> | null;
+}
+
+/**
+ * Configure the following properties on the date picker component.
+ * @publicDocs
+ */
+declare class DatePicker
+  extends DatePickerBase<typeof tagName>
+  implements DatePickerProps
+{
   constructor();
 }
 declare global {
@@ -277,31 +283,27 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-date-picker';
-/**
- * The JSX props for the date picker component. These properties extend `DatePickerProps` with JSX-specific event callbacks for React-style event handling when used in Preact, including callbacks for date selection, focus events, and view changes.
- * @publicDocs
- */
 export interface DatePickerJSXProps
   extends Partial<DatePickerProps>,
     Pick<DatePickerProps$1, 'id'> {
   /**
-   * A callback that's triggered when the visible month or year in the calendar changes.
+   * A callback fired when the calendar view changes, such as when navigating between months.
    */
   onViewChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the picker receives focus.
+   * A callback fired when the date picker receives focus.
    */
   onFocus?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the picker loses focus.
+   * A callback fired when the date picker loses focus.
    */
   onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the selected date changes as the user interacts with the picker.
+   * A callback fired when the user makes any changes to the selected date.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the selected date changes and the picker loses focus.
+   * A callback fired when the user has finished selecting a date and the value changes.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
@@ -1,16 +1,26 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {DividerProps$1, ComponentChildren} from './shared.d.ts';
+import type {
+  DividerProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * The properties for the divider component. A divider creates a visual separator to distinguish different sections of content.
- * @publicDocs
+ * Configure the following properties on the divider component.
  */
 export interface DividerProps
   extends Pick<DividerProps$1, 'direction' | 'color'> {
@@ -34,143 +44,74 @@ export interface DividerProps
   color: Extract<DividerProps$1['color'], 'base' | 'strong'>;
 }
 
-/**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An interface representing the properties of an activation event, such as a click or keypress.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on PC) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
 /**
- * A divider is a visual separator that creates a line between different sections of content.
+ * Configure the following properties on the divider component.
+ * @publicDocs
  */
-declare class Divider extends PreactCustomElement implements DividerProps {
-  /**
-   * The orientation of the divider line, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
-   *
-   * - `inline`: Horizontal divider for separating vertically stacked content
-   * - `block`: Vertical divider for separating horizontally arranged content
-   *
-   * @default 'inline'
-   */
+declare class Divider extends PolarisCustomElement implements DividerProps {
   accessor direction: DividerProps['direction'];
-  /**
-   * The visual prominence of the divider line.
-   *
-   * - `base`: Standard divider for most separations (default)
-   * - `strong`: More prominent divider for major section breaks
-   *
-   * @default 'base'
-   */
   accessor color: DividerProps['color'];
   constructor();
 }
@@ -188,10 +129,6 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-divider';
-/**
- * The properties for the divider component when it's used in JSX.
- * @publicDocs
- */
 export interface DividerJSXProps
   extends Partial<DividerProps>,
     Pick<DividerProps$1, 'id'> {}

--- a/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Divider.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -126,7 +121,7 @@ export interface DropZoneProps
 }
 
 export type ReadOnlyPropKeys<Config> = Config extends {
-  readonly readOnlyProps: readonly (infer Key)[];
+  readonly readOnlyProps: ReadonlyArray<infer Key>;
 }
   ? Extract<Key, string>
   : never;
@@ -221,6 +216,7 @@ declare abstract class DropZoneBase extends PolarisCustomElement {
     Element,
     HTMLInputElement
   >;
+
   /** @private */
   formResetCallback(): void;
   /** @private */

--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.38.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -12,32 +17,70 @@ import type {
   PreactCustomElement,
   RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
+/**
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
+ * @publicDocs
+ */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
   currentTarget: HTMLElementTagNameMap[T];
 };
+/**
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
+ * @publicDocs
+ */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
       (event: CallbackEvent<T>): void;
     })
   | null;
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
-  /** Assigns a unique key to this element. */
+  /**
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
+   */
   key?: preact.Key;
-  /** Assigns a ref (generally from `useRef()`) to this element. */
+  /**
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
+   */
   ref?: preact.Ref<TClass>;
-  /** Assigns this element to a parent's slot. */
+  /**
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
+   */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
-/**  * @publicDocs
+
+/**
+ * Configure the following properties on the drop zone component.
  */
 export interface DropZoneProps
   extends Required<
@@ -55,12 +98,80 @@ export interface DropZoneProps
       | 'required'
       | 'value'
     >
-  > {}
+  > {
+  /**
+   * A label that describes the purpose or contents of the item. When set,
+   * it will be announced to buyers using assistive technologies and will
+   * provide them with more context.
+   */
+  accessibilityLabel: Required<DropZoneProps$1>['accessibilityLabel'];
+  /**
+   * Whether multiple files can be selected or dropped at once.
+   *
+   * @default false
+   */
+  multiple: Required<DropZoneProps$1>['multiple'];
+  /**
+   * A string representing the types of files that are accepted by the drop zone.
+   * This string is a comma-separated list of unique file type specifiers which can be one of the following:
+   * - A file extension starting with a period (".") character (e.g. .jpg, .pdf, .doc)
+   * - A valid MIME type string with no extensions
+   *
+   * If omitted, all file types are accepted.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept
+   * @default ''
+   */
+  accept: Required<DropZoneProps$1>['accept'];
+}
+
+export type ReadOnlyPropKeys<Config> = Config extends {
+  readonly readOnlyProps: readonly (infer Key)[];
+}
+  ? Extract<Key, string>
+  : never;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 declare class PolarisCustomElement extends PreactCustomElement {
   constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
 }
-/**  * @publicDocs
+
+/**
+ * A utility type that replaces occurrences of one type with another within a union type. Useful for type transformations where you need to swap out specific types.
+ * @publicDocs
  */
 export type ReplaceType<TType, TFrom, TTo> = Exclude<TType, TFrom> | TTo;
 
@@ -79,8 +190,23 @@ declare abstract class DropZoneBase extends PolarisCustomElement {
   accessor multiple: DropZoneProps['multiple'];
   accessor name: DropZoneProps['name'];
   accessor required: DropZoneProps['required'];
+  /**
+   * A callback fired when the user selects files through the file picker or drops valid
+   * files onto the drop zone. Access the selected files through `event.currentTarget.files`.
+   * Use to process uploads, generate previews, or validate file contents.
+   */
   accessor onchange: CallbackEventListener<typeof tagName>;
+  /**
+   * A callback fired when files are selected or dropped. Similar to `onChange` but may
+   * fire more frequently during drag operations. Use when you need immediate feedback as
+   * files are being dragged over the drop zone.
+   */
   accessor oninput: CallbackEventListener<typeof tagName>;
+  /**
+   * A callback fired when dropped or selected files don't match the `accept` criteria.
+   * Use to display error messages explaining which file types are allowed. Rejected files
+   * are not added to the `files` array.
+   */
   accessor ondroprejected: CallbackEventListener<typeof tagName>;
   get value(): string;
   /** This sets the input value for a file type, which cannot be set programatically, so it can only be reset. */
@@ -95,7 +221,6 @@ declare abstract class DropZoneBase extends PolarisCustomElement {
     Element,
     HTMLInputElement
   >;
-
   /** @private */
   formResetCallback(): void;
   /** @private */
@@ -103,6 +228,10 @@ declare abstract class DropZoneBase extends PolarisCustomElement {
   constructor(renderImpl: RenderImpl);
 }
 
+/**
+ * Configure the following properties on the drop zone component.
+ * @publicDocs
+ */
 declare class DropZone extends DropZoneBase implements DropZoneProps {
   constructor();
 }
@@ -114,8 +243,12 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: DropZoneJSXProps &
-        PreactBaseElementPropsWithChildren<DropZone>;
+      [tagName]: Omit<
+        DropZoneJSXProps,
+        ReadOnlyPropKeys<typeof reactWrapperConfig>
+      > & {
+        value?: '' | null;
+      } & PreactBaseElementPropsWithChildren<DropZone>;
     }
   }
 }
@@ -125,13 +258,25 @@ export interface DropZoneJSXProps
   extends Partial<DropZoneProps>,
     Pick<DropZoneProps$1, 'id'> {
   /**
-   * Content to include inside the DropZone container
+   * The content to include inside the drop zone container
    */
   children?: ComponentChildren;
+  /**
+   * A callback fired when the user has finished selecting files and the value changes.
+   */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
+  /**
+   * A callback fired when files are selected or dropped.
+   */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
+  /**
+   * A callback fired when a dropped file is rejected due to file type or size restrictions.
+   */
   onDropRejected?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
+declare const reactWrapperConfig: {
+  readonly readOnlyProps: readonly ['files', 'value'];
+};
 
 export {DropZone};
 export type {DropZoneJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -45,7 +40,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -62,7 +57,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -70,19 +65,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField.d.ts
@@ -1,29 +1,43 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   EmailFieldProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event with a strongly-typed currentTarget property for a specific HTML element.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A callback function that receives a strongly-typed event for a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -31,189 +45,133 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * The React-style event callback props for form field components.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's invoked when the user makes any changes in the field. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
+};
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles for the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a Preact component in a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's Preact elements into the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * The properties from an event that indicate how the user activated an element.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down when the event occurred.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on macOS) was held down when the event occurred.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down when the event occurred.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed when the event occurred. A value of 0 indicates the primary button (usually left), 1 indicates the middle button, and 2 indicates the secondary button (usually right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for influencing a programmatic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The base properties for an input element that participates in form submission.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/** @private */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the user makes any changes in the field.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the field is disabled, disallowing any interaction.
-   *
-   * @default false
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * An identifier for the field.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * An identifier for the field that's unique within the nearest containing form.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value for the field.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The base properties for form field elements that support labels, validation, and autocomplete.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -235,10 +193,10 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        * A hint as to the intended content of the field.
        *
        * When set to `on` (the default), this property indicates that the field should support
-       * autofill, but you don't have any more semantic information on the intended
+       * autofill, but you do not have any more semantic information on the intended
        * contents.
        *
-       * When set to `off`, you're indicating that this field contains sensitive
+       * When set to `off`, you are indicating that this field contains sensitive
        * information, or contents that are never saved, like one-time codes.
        *
        * Alternatively, you can provide value which describes the
@@ -253,58 +211,20 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/** @private */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * A callback that's invoked when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint as to the intended content of the field for autocomplete purposes.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value for the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * Additional descriptive text to display below the field that provides supplementary information.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * An error message to display below the field, indicating validation failure or other issues.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label to display for the field, describing what the user should enter.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * Controls the visibility of the label for accessibility purposes.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The placeholder text that's displayed inside the field when it's empty, providing a hint about expected input.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only, preventing edits while still allowing focus and selection.
-   *
-   * @default false
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before form submission.
-   *
-   * @default false
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
@@ -334,7 +254,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the email field component. These properties configure a specialized text input field for entering email addresses with built-in validation and appropriate keyboard support.
+ * Represents the props for email input field components. Extends `PreactFieldProps` with autocomplete support for email-related fields.
  * @publicDocs
  */
 export type EmailFieldProps = PreactFieldProps<
@@ -342,32 +262,21 @@ export type EmailFieldProps = PreactFieldProps<
 > &
   Required<Pick<EmailFieldProps$1, 'maxLength' | 'minLength'>>;
 
-/**
- * The email field custom element class that renders an email input field in the Shopify admin interface. This component allows merchants to enter email addresses with automatic validation and optimized mobile keyboard layouts.
- */
-declare class EmailField
+declare abstract class EmailFieldBase
   extends PreactFieldElement<EmailFieldProps['autocomplete']>
-  implements EmailFieldProps
+  implements Pick<EmailFieldProps, 'autocomplete' | 'maxLength' | 'minLength'>
 {
-  /**
-   * A hint as to the intended content of the field for autocomplete purposes.
-   *
-   * @default 'email'
-   */
   accessor autocomplete: EmailFieldProps['autocomplete'];
-  /**
-   * The maximum number of characters the user can enter in the field.
-   */
   accessor maxLength: EmailFieldProps['maxLength'];
-  /**
-   * The minimum number of characters required in the field for validation.
-   */
   accessor minLength: EmailFieldProps['minLength'];
-  /**
-   * The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing.
-   */
-  get value(): string;
-  set value(value: string);
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the email field component.
+ * @publicDocs
+ */
+declare class EmailField extends EmailFieldBase implements EmailFieldProps {
   constructor();
 }
 declare global {
@@ -378,20 +287,19 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: EmailFieldJSXProps & PreactBaseElementProps<EmailField>;
+      [tagName]: Omit<EmailFieldJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<EmailField>;
     }
   }
 }
 
 declare const tagName = 's-email-field';
-/**
- * The JSX props for the email field component. These properties extend `EmailFieldProps` with JSX-specific event callbacks for React-style event handling.
- * @publicDocs
- */
 export interface EmailFieldJSXProps
-  extends Partial<Omit<EmailFieldProps, 'accessory'>>,
+  extends Partial<Omit<EmailFieldProps, 'accessory' | 'error' | 'details'>>,
     Pick<EmailFieldProps$1, 'id'>,
-    FieldReactProps<typeof tagName> {}
+    FieldReactProps<typeof tagName>,
+    FieldSlotInternalReactProps {}
 
 export {EmailField};
 export type {EmailFieldJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/EmptyState.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmptyState.d.ts
@@ -1,8 +1,14 @@
-/** VERSION: 2.21.2 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/EmptyState.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmptyState.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/EmptyState.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmptyState.d.ts
@@ -1,0 +1,144 @@
+/** VERSION: 2.21.2 **/
+/* eslint-disable import/extensions */
+
+/* eslint-disable @typescript-eslint/no-namespace */
+
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
+/// <reference lib="DOM" />
+import type {
+  ComponentChildren,
+  EmptyStateProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export interface EmptyStateProps
+  extends Required<Pick<EmptyStateProps$1, 'heading'>> {}
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
+ */
+export interface PreactBaseElementProps<TClass extends HTMLElement> {
+  /**
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
+   */
+  key?: preact.Key;
+  /**
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
+   */
+  ref?: preact.Ref<TClass>;
+  /**
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
+   */
+  slot?: Lowercase<string>;
+}
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
+ */
+export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
+  extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
+  children?: preact.ComponentChildren;
+}
+
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+}
+
+/**
+ * Configure the following properties on the empty state component.
+ * @publicDocs
+ */
+declare class EmptyState
+  extends PolarisCustomElement
+  implements EmptyStateProps
+{
+  constructor();
+  accessor heading: EmptyStateProps['heading'];
+}
+declare global {
+  interface HTMLElementTagNameMap {
+    [tagName]: EmptyState;
+  }
+}
+declare module 'preact' {
+  namespace createElement.JSX {
+    interface IntrinsicElements {
+      [tagName]: Omit<
+        EmptyStateJSXProps,
+        'primaryAction' | 'secondaryActions' | 'graphic' | 'subheading'
+      > &
+        PreactBaseElementPropsWithChildren<EmptyState>;
+    }
+  }
+}
+
+declare const tagName = 's-empty-state';
+export interface EmptyStateJSXProps
+  extends Partial<EmptyStateProps>,
+    Pick<EmptyStateProps$1, 'id'> {
+  /**
+   * The main call to action, rendered below the text content. Accepts a single `Button` with a `variant` of `primary`; anything else is ignored with a development warning.
+   */
+  primaryAction?: ComponentChildren;
+  /**
+   * An alternative action, rendered beside the primary one. Accepts a single `Button` with a `variant` of `secondary` or `auto` — despite the plural name, only one is rendered.
+   */
+  secondaryActions?: ComponentChildren;
+  /**
+   * An illustration or symbol shown above the heading. Accepts a single `Image` or `Icon`, either directly or as the only child of a wrapping element.
+   */
+  graphic?: ComponentChildren;
+  /**
+   * Supporting text below the heading, explaining what's missing or what to do next. Accepts `Text` and `Link` components.
+   */
+  subheading?: ComponentChildren;
+}
+
+export {EmptyState};
+export type {EmptyStateJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form.d.ts
@@ -1,29 +1,41 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   ExtendableEvent,
   FormProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
 
 /**
- * A callback event with a strongly-typed `currentTarget` property that corresponds to a specific HTML element. This provides better type safety when handling events from custom elements.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to, strongly typed based on the element's tag name.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
-
 /**
- * An event listener function type for callback events with a strongly-typed `currentTarget`. This ensures the event handler receives the correct element type.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -31,18 +43,12 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-
-/**
- * A callback event that includes the `waitUntil` method for extending asynchronous operations. This allows you to delay form submission until promises resolve, enabling async validation or data processing before the form completes its action.
- * @publicDocs
- */
 export interface CallbackExtendableEvent<
   TTagName extends keyof HTMLElementTagNameMap,
 > extends CallbackEvent<TTagName>,
     Pick<ExtendableEvent, 'waitUntil'> {}
-
 /**
- * An event listener function type for extendable callback events. This combines strong typing with the ability to extend the event lifecycle using `waitUntil`.
+ * A function that handles extendable events from UI components. This type represents an event listener callback that can use `waitUntil` to extend the event lifetime.
  * @publicDocs
  */
 export type CallbackExtendableEventListener<
@@ -54,135 +60,42 @@ export type CallbackExtendableEventListener<
   | null;
 
 /**
- * The properties for the form component. These properties configure the form's identifier for targeting and referencing within the admin extension.
- * @publicDocs
+ * Configure the following properties on the form component.
  */
 export interface FormProps extends Pick<FormProps$1, 'id'> {}
 
 declare const tagName = 's-form';
-
-/**
- * The JSX props for the form component. These properties extend `FormProps` with event callbacks for form submission and reset actions in JSX rendering.
- * @publicDocs
- */
 export interface FormJSXProps extends Partial<FormProps> {
   /**
-   * A callback that's invoked when the form is submitted. Use the event's `waitUntil` method to perform async operations like validation or data processing before the submission completes.
+   * A callback that is run when the form is submitted.
    */
   onSubmit?: ((event: CallbackExtendableEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's invoked when the form is reset, restoring all form fields to their initial values.
+   * A callback that is run when the form is reset.
    */
   onReset?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
 
-/**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
-}
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The form custom element class that renders a form container in the Shopify admin interface. This component manages form submission, validation, and reset behavior for collecting merchant input.
+ * Configure the following properties on the form component.
+ * @publicDocs
  */
-declare class Form extends PreactCustomElement implements FormProps {
+declare class Form extends PolarisCustomElement implements FormProps {
   constructor();
-
   /**
-   * A callback that's invoked when the form is submitted. Use the event's `waitUntil` method to perform async operations like validation, data processing, or API calls before the submission completes.
+   * A callback that is run when the form is submitted.
    */
   accessor onsubmit: CallbackExtendableEventListener<typeof tagName> | null;
-
   /**
-   * A callback that's invoked when the form is reset, restoring all form fields to their initial values.
+   * A callback that is run when the form is reset.
    */
   accessor onreset: CallbackEventListener<typeof tagName> | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
@@ -1,29 +1,40 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   FunctionSettingsProps$1,
   ExtendableEvent,
-  ComponentChildren,
+  PreactCustomElement,
 } from './shared.d.ts';
 
 /**
- * A callback event with a strongly-typed `currentTarget` property that corresponds to a specific HTML element. This provides better type safety when handling events from custom elements.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to, strongly typed based on the element's tag name.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
-
 /**
- * An event listener function type for callback events with a strongly-typed `currentTarget`. This ensures the event handler receives the correct element type.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -31,9 +42,8 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-
 /**
- * An event listener function type for error events that includes an `error` property. This is used for handling validation errors and submission failures in forms.
+ * A function that handles error events from UI components. This type represents an event listener callback that receives both the event and an error object.
  * @publicDocs
  */
 export type CallbackErrorEventListener<
@@ -43,26 +53,17 @@ export type CallbackErrorEventListener<
   | (EventListener & {
       (
         event: CallbackEvent<TTagName> & {
-          /**
-           * The error that occurred during the operation.
-           */
           error: TError;
         },
       ): void;
     })
   | null;
-
-/**
- * A callback event that includes the `waitUntil` method for extending asynchronous operations. This allows you to delay event completion until promises resolve, enabling async operations during event handling.
- * @publicDocs
- */
 export interface CallbackExtendableEvent<
   TTagName extends keyof HTMLElementTagNameMap,
 > extends CallbackEvent<TTagName>,
     Pick<ExtendableEvent, 'waitUntil'> {}
-
 /**
- * An event listener function type for extendable callback events. This combines strong typing with the ability to extend the event lifecycle using `waitUntil`.
+ * A function that handles extendable events from UI components. This type represents an event listener callback that can use `waitUntil` to extend the event lifetime.
  * @publicDocs
  */
 export type CallbackExtendableEventListener<
@@ -74,24 +75,18 @@ export type CallbackExtendableEventListener<
   | null;
 
 /**
- * The properties for the function settings component. These properties configure the form's identifier for configuring Shopify Function settings in the admin interface.
- * @publicDocs
+ * Configure the following properties on the function settings component.
  */
 export interface FunctionSettingsProps
   extends Pick<FunctionSettingsProps$1, 'id'> {}
 
 declare const tagName = 's-function-settings';
-
-/**
- * The JSX props for the function settings component. These properties extend `FunctionSettingsProps` with event callbacks for form submission, reset, and error handling in JSX rendering.
- * @publicDocs
- */
 export interface FunctionSettingsJSXProps
   extends Partial<
     FunctionSettingsProps & Pick<FunctionSettingsProps$1, 'onError'>
   > {
   /**
-   * An optional callback function that'll be run by the admin when the user
+   * An optional callback function that will be run by the admin when the user
    * commits their changes in the admin-rendered part of the function settings
    * experience. If `event.waitUntil` is called with a promise, the admin will wait for the
    * promise to resolve before committing any changes to Shopify’s servers. If
@@ -100,115 +95,21 @@ export interface FunctionSettingsJSXProps
    */
   onSubmit?: ((event: CallbackExtendableEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's invoked when the function settings form is reset, restoring all form fields to their initial values.
+   * A callback that is run when the function settings form is reset.
    */
   onReset?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
 
 /**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
-}
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
-  /** @private */
-  connectedCallback(): void;
-  /** @private */
-  disconnectedCallback(): void;
-  /** @private */
-  adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
-}
-
-/**
- * The error event type that's passed to the `onError` callback of function settings. This event contains validation errors that occurred when committing function settings to Shopify's servers.
+ * Represents the event type for function settings errors. Extracted from the parameters of the `onFunctionSettingsError` callback.
  * @publicDocs
  */
 export type FunctionSettingsErrorEvent = Parameters<
   NonNullable<FunctionSettingsProps$1['onError']>
 >[0];
-
 /**
- * The function settings custom element class that renders a specialized form for configuring Shopify Function settings in the admin interface. This component manages function configuration submission, validation, and error handling.
+ * Configure the following properties on the function settings component.
+ * @publicDocs
  */
 declare class FunctionSettings
   extends PreactCustomElement
@@ -216,7 +117,7 @@ declare class FunctionSettings
 {
   constructor();
   /**
-   * An optional callback function that'll be run by the admin when the user
+   * An optional callback function that will be run by the admin when the user
    * commits their changes in the admin-rendered part of the function settings
    * experience. If `event.waitUntil` is called with a promise, the admin will wait for the
    * promise to resolve before committing any changes to Shopify’s servers. If
@@ -224,13 +125,12 @@ declare class FunctionSettings
    * using the `message` property of the error you reject with.
    */
   accessor onsubmit: CallbackExtendableEventListener<typeof tagName> | null;
-
   /**
-   * An optional callback function that'll be run by the admin when
+   * An optional callback function that will be run by the admin when
    * committing the changes to Shopify’s servers fails. The error event you receive includes
-   * an `error` property that's an `AggregateError` object. This object includes
+   * an `error` property that is an `AggregateError` object. This object includes
    * an array of errors that were caused by data your extension provided.
-   * Network errors and user errors that are out of your control won't be reported here.
+   * Network errors and user errors that are out of your control will not be reported here.
    *
    * In the `onError` callback, you should update your extension’s UI to
    * highlight the fields that caused the errors, and display the error messages
@@ -240,9 +140,8 @@ declare class FunctionSettings
     typeof tagName,
     FunctionSettingsErrorEvent['error']['errors'][0]
   > | null;
-
   /**
-   * A callback that's invoked when the function settings form is reset, restoring all form fields to their initial values.
+   * A callback that is run when the function settings form is reset.
    */
   accessor onreset: CallbackEventListener<typeof tagName> | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -140,6 +134,7 @@ declare class FunctionSettings
     typeof tagName,
     FunctionSettingsErrorEvent['error']['errors'][0]
   > | null;
+
   /**
    * A callback that is run when the function settings form is reset.
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -1,8 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -17,10 +23,45 @@ import type {
   JustifyItemsKeyword,
   AlignContentKeyword,
   JustifyContentKeyword,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * A type that allows a value to be responsive using container query syntax.
+ * Makes a type responsive by allowing it to be either the base value or a container query string. This enables conditional styling based on container dimensions.
  * @publicDocs
  */
 export type MakeResponsive<T> = T | `@container${string}`;
@@ -46,12 +87,21 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * A version of the box properties with all fields required.
+ * Represents the box component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The allowed border radius values for a box component.
+ * Represents the subset of border radius values supported by the component.
+ *
+ * - `small-200`: Extra small radius for subtle rounding.
+ * - `small-100`: Small radius for minimal corner rounding.
+ * - `small`: Standard small radius.
+ * - `base`: Medium radius for moderate corner rounding.
+ * - `large`: Standard large radius for pronounced rounding.
+ * - `large-100`: Large radius for more prominent corner rounding.
+ * - `large-200`: Extra large radius for maximum rounding.
+ * - `none`: No border radius (sharp corners).
  * @publicDocs
  */
 export type BoxBorderRadii = Extract<
@@ -66,7 +116,12 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The allowed border style values for a box component.
+ * Represents the subset of border style values supported by the box component.
+ *
+ * - `auto`: Default border style determined by the system.
+ * - `none`: No border style (removes the border).
+ * - `solid`: Continuous line border.
+ * - `dashed`: Border made up of dashes.
  * @publicDocs
  */
 export type BoxBorderStyles = Extract<
@@ -74,7 +129,9 @@ export type BoxBorderStyles = Extract<
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The box properties that support responsive values through container queries.
+ * Represents box props with responsive capabilities for layout properties.
+ *
+ * This enables conditional styling based on container queries.
  * @publicDocs
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
@@ -109,7 +166,7 @@ export interface BoxProps
     | 'overflow'
   > {
   /**
-   * The background color of the grid container.
+   * The background color of the component.
    *
    * @default 'transparent'
    */
@@ -118,10 +175,13 @@ export interface BoxProps
     'transparent' | 'base' | 'subdued' | 'strong'
   >;
   /**
-   * Controls the thickness of the border on all sides.
+   * A border applied using shorthand syntax to specify width, color, and style in a single property.
    *
-   * When set, this overrides the width value specified in the `border` property.
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.
+   * @default 'none'
+   */
+  border: RequiredBoxProps['border'];
+  /**
+   * The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -134,10 +194,7 @@ export interface BoxProps
       >
     | Extract<RequiredBoxProps['borderWidth'], ''>;
   /**
-   * Controls the visual style of the border on all sides (solid, dashed, auto, or none).
-   *
-   * When set, this overrides the style value specified in the `border` property.
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.
+   * The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -145,10 +202,7 @@ export interface BoxProps
     | MaybeAllValuesShorthandProperty<BoxBorderStyles>
     | Extract<RequiredBoxProps['borderStyle'], ''>;
   /**
-   * Controls the color of the border using the design system's color scale.
-   *
-   * When set, this overrides the color value specified in the `border` property.
-   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.
+   * The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -157,101 +211,85 @@ export interface BoxProps
     'subdued' | 'base' | 'strong' | ''
   >;
   /**
-   * Controls the roundedness of the element's corners using the design system's radius scale.
-   *
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.
+   * The roundedness of the element's corners using the design system's radius scale.
    *
    * @default 'none'
    */
   borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;
   /**
-   * The padding applied to all edges of the grid container.
+   * The padding applied to all edges of the component.
    *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
+   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:
+   * - 1 value applies to all sides
+   * - 2 values apply to block (top/bottom) and inline (left/right)
+   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)
+   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)
    *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
+   * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
-   *
-   * `padding` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
   padding: ResponsiveBoxProps['padding'];
   /**
-   * The padding applied to the block axis (top and bottom in horizontal writing modes).
+   * The block-direction padding (top and bottom in horizontal writing modes).
    *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for block-start and block-end.
    *
-   * This overrides the block value of `padding`.
+   * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlock: ResponsiveBoxProps['paddingBlock'];
   /**
-   * The padding applied to the block-start edge (top in horizontal writing modes).
+   * The block-start padding (top in horizontal writing modes).
    *
-   * This overrides the block-start value of `paddingBlock`.
-   *
-   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];
   /**
-   * The padding applied to the block-end edge (bottom in horizontal writing modes).
+   * The block-end padding (bottom in horizontal writing modes).
    *
-   * This overrides the block-end value of `paddingBlock`.
-   *
-   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];
   /**
-   * The padding applied to the inline axis (left and right in horizontal writing modes).
+   * The inline-direction padding (left and right in horizontal writing modes).
    *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.
    *
-   * This overrides the inline value of `padding`.
+   * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInline: ResponsiveBoxProps['paddingInline'];
   /**
-   * The padding applied to the inline-start edge (left in left-to-right languages).
+   * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * This overrides the inline-start value of `paddingInline`.
-   *
-   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];
   /**
-   * The padding applied to the inline-end edge (right in left-to-right languages).
+   * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * This overrides the inline-end value of `paddingInline`.
-   *
-   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];
   /**
-   * Sets the outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
    *
    * - `auto` the component's initial value. The actual value depends on the component and context.
    * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
@@ -260,7 +298,7 @@ export interface BoxProps
    */
   display: ResponsiveBoxProps['display'];
   /**
-   * The vertical size of the grid in standard layouts (height in left-to-right or right-to-left writing modes).
+   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).
    *
    * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;
    * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.
@@ -271,31 +309,44 @@ export interface BoxProps
    */
   blockSize: SizeUnitsOrAuto;
   /**
-   * The [minimum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) (minimum height in horizontal writing modes) of the grid container.
+   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize: SizeUnits;
   /**
-   * The [maximum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) (maximum height in horizontal writing modes) of the grid container.
+   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize: SizeUnitsOrNone;
   /**
-   * The [inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size) (width in horizontal writing modes) of the grid container.
+   * The width in horizontal writing modes, or height in vertical writing modes.
+   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize: SizeUnitsOrAuto;
   /**
-   * The [minimum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) (minimum width in horizontal writing modes) of the grid container.
+   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize: SizeUnits;
   /**
-   * The [maximum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) (maximum width in horizontal writing modes) of the grid container.
+   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
@@ -303,12 +354,14 @@ export interface BoxProps
 }
 
 /**
- * A version of the grid properties with all fields required.
+ * Represents the grid component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredAlignedProps = Required<GridProps$1>;
 /**
- * The grid properties that support responsive values through container queries.
+ * Represents grid props with responsive capabilities for layout properties.
+ *
+ * This enables conditional styling based on container queries.
  * @publicDocs
  */
 export type ResponsiveGridProps = MakeResponsivePick<
@@ -316,8 +369,7 @@ export type ResponsiveGridProps = MakeResponsivePick<
   'rowGap' | 'columnGap' | 'gap' | 'gridTemplateColumns' | 'gridTemplateRows'
 >;
 /**
- * The properties for the grid component. A grid provides precise control over rows and columns, with powerful alignment and sizing options for both individual items and the entire grid structure.
- * @publicDocs
+ * Configure the following properties on the grid component.
  */
 export interface GridProps
   extends BoxProps,
@@ -333,37 +385,37 @@ export interface GridProps
       >
     > {
   /**
-   * The alignment of grid items along the block axis (vertical in horizontal writing modes). You can choose values like `'start'`, `'center'`, `'end'`, or `'stretch'` to control how items are positioned within their grid areas.
+   * Aligns the grid items along the block axis.
    *
    * @default '' - meaning no override
    */
   alignItems: AlignItemsKeyword | '';
   /**
-   * The alignment of grid items along the inline axis (horizontal in left-to-right languages). You can choose values like `'start'`, `'center'`, or `'end'` to control how items are positioned within their grid areas.
+   * Aligns the grid items along the inline axis.
    *
    * @default '' - meaning no override
    */
   justifyItems: JustifyItemsKeyword | '';
   /**
-   * A shorthand property for setting both `justifyItems` and `alignItems` at once. You can provide either a single value (which applies to both axes) or two values separated by a space (the first for `alignItems`, the second for `justifyItems`).
+   * A shorthand property for `justify-items` and `align-items`.
    *
    * @default 'normal normal'
    */
   placeItems: `${AlignItemsKeyword} ${JustifyItemsKeyword}` | AlignItemsKeyword;
   /**
-   * The alignment of the entire grid along the block axis when there's extra space in the grid container. This property overrides the block-axis value set by the `placeContent` property.
+   * Aligns the grid along the block axis. This overrides the block value of `placeContent`.
    *
    * @default '' - meaning no override
    */
   alignContent: AlignContentKeyword | '';
   /**
-   * The alignment of the entire grid along the inline axis when there's extra space in the grid container. This property overrides the inline-axis value set by the `placeContent` property.
+   * Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.
    *
    * @default '' - meaning no override
    */
   justifyContent: JustifyContentKeyword | '';
   /**
-   * A shorthand property for setting both `justifyContent` and `alignContent` at once. You can provide either a single value (which applies to both axes) or two values separated by a space (the first for `alignContent`, the second for `justifyContent`).
+   * A shorthand property for `justify-content` and `align-content`.
    *
    * @default 'normal normal'
    */
@@ -371,31 +423,52 @@ export interface GridProps
     | `${AlignContentKeyword} ${JustifyContentKeyword}`
     | AlignContentKeyword;
   /**
-   * The spacing between grid rows and columns. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for rows and columns. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * Adjusts spacing between elements.
+   *
+   * Accepts:
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`
+   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default 'none'
    */
   gap: ResponsiveGridProps['gap'];
   /**
-   * The spacing between grid rows. This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.
+   *
+   * Accepts:
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
   rowGap: ResponsiveGridProps['rowGap'];
   /**
-   * The spacing between grid columns. This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.
+   *
+   * Accepts:
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
   columnGap: ResponsiveGridProps['columnGap'];
   /**
-   * The number of columns and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 1fr)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The columns in the grid and their sizes.
+   *
+   * Accepts:
+   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value
    *
    * @default 'none'
    */
   gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];
   /**
-   * The number of rows and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 100px)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The rows in the grid and their sizes.
+   *
+   * Accepts:
+   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value
    *
    * @default 'none'
    */
@@ -403,288 +476,91 @@ export interface GridProps
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * An interface representing the properties of an activation event, such as a click or keypress.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on PC) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/**
- * The base element class for Box components with all Box properties as accessors.
- */
-declare class BoxElement extends PreactCustomElement implements BoxProps {
+declare class BoxElement extends PolarisCustomElement implements BoxProps {
   constructor(renderImpl: RenderImpl);
-  /**
-   * The ARIA role that defines the semantic meaning of the grid for assistive technologies.
-   */
   accessor accessibilityRole: BoxProps['accessibilityRole'];
-  /**
-   * The background color of the grid using the design system's color scale. Choose from `transparent`, `subdued`, `base`, or `strong`.
-   */
   accessor background: BoxProps['background'];
-  /**
-   * The height of the grid in horizontal writing modes, or width in vertical writing modes.
-   * Use this for flow-relative sizing that adapts to text direction.
-   */
   accessor blockSize: BoxProps['blockSize'];
-  /**
-   * The minimum height of the grid in horizontal writing modes, or minimum width in vertical writing modes.
-   * Prevents the grid from shrinking below this size.
-   */
   accessor minBlockSize: BoxProps['minBlockSize'];
-  /**
-   * The maximum height of the grid in horizontal writing modes, or maximum width in vertical writing modes.
-   * Prevents the grid from growing beyond this size.
-   */
   accessor maxBlockSize: BoxProps['maxBlockSize'];
-  /**
-   * The width of the grid in horizontal writing modes, or height in vertical writing modes.
-   * Use this for flow-relative sizing that adapts to text direction.
-   */
   accessor inlineSize: BoxProps['inlineSize'];
-  /**
-   * The minimum width of the grid in horizontal writing modes, or minimum height in vertical writing modes.
-   * Prevents the grid from shrinking below this size.
-   */
   accessor minInlineSize: BoxProps['minInlineSize'];
-  /**
-   * The maximum width of the grid in horizontal writing modes, or maximum height in vertical writing modes.
-   * Prevents the grid from growing beyond this size.
-   */
   accessor maxInlineSize: BoxProps['maxInlineSize'];
-  /**
-   * Controls how content that exceeds the grid's boundaries is displayed. Use `hidden` to clip overflow or `visible` to allow content to extend beyond boundaries.
-   */
   accessor overflow: BoxProps['overflow'];
-  /**
-   * The padding on all sides of the grid.
-   */
   accessor padding: BoxProps['padding'];
-  /**
-   * The vertical padding (top and bottom) in horizontal writing modes.
-   * Use this for flow-relative padding that adapts to text direction.
-   */
   accessor paddingBlock: BoxProps['paddingBlock'];
-  /**
-   * The padding at the top in horizontal writing modes, or at the start edge in vertical writing modes.
-   */
   accessor paddingBlockStart: BoxProps['paddingBlockStart'];
-  /**
-   * The padding at the bottom in horizontal writing modes, or at the end edge in vertical writing modes.
-   */
   accessor paddingBlockEnd: BoxProps['paddingBlockEnd'];
-  /**
-   * The horizontal padding (left and right) in horizontal writing modes.
-   * Use this for flow-relative padding that adapts to text direction.
-   */
   accessor paddingInline: BoxProps['paddingInline'];
-  /**
-   * The padding at the left in left-to-right languages, or at the right in right-to-left languages.
-   */
   accessor paddingInlineStart: BoxProps['paddingInlineStart'];
-  /**
-   * The padding at the right in left-to-right languages, or at the left in right-to-left languages.
-   */
   accessor paddingInlineEnd: BoxProps['paddingInlineEnd'];
-  /**
-   * Applies a border using shorthand syntax to specify width, color, and style in a single property.
-   */
   accessor border: BoxProps['border'];
-  /**
-   * Controls the thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
-   */
   accessor borderWidth: BoxProps['borderWidth'];
-  /**
-   * Controls the visual style of the border on all sides (solid, dashed, auto, or none). When set, this overrides the style value specified in the `border` property.
-   */
   accessor borderStyle: BoxProps['borderStyle'];
-  /**
-   * Controls the color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
-   */
   accessor borderColor: BoxProps['borderColor'];
-  /**
-   * Controls the roundedness of the element's corners using the design system's radius scale.
-   */
   accessor borderRadius: BoxProps['borderRadius'];
-  /**
-   * A text description of the grid for screen readers, used when the visual context isn't sufficient for understanding.
-   */
   accessor accessibilityLabel: BoxProps['accessibilityLabel'];
-  /**
-   * Controls the visibility of the grid for both visual and assistive technology users. Use `hidden` to hide from screen readers or `exclusive` to hide visually but announce to screen readers.
-   */
   accessor accessibilityVisibility: BoxProps['accessibilityVisibility'];
-  /**
-   * Controls how the grid is displayed in the layout, such as block, inline, or none.
-   */
   accessor display: BoxProps['display'];
 }
 
 /**
- * A grid is a layout component that arranges its children in rows and columns with precise control over sizing and alignment.
+ * Configure the following properties on the grid component.
+ * @publicDocs
  */
 declare class Grid extends BoxElement implements GridProps {
   constructor();
-  /**
-   * The template that defines the grid columns.
-   */
   accessor gridTemplateColumns: GridProps['gridTemplateColumns'];
-  /**
-   * The template that defines the grid rows.
-   */
   accessor gridTemplateRows: GridProps['gridTemplateRows'];
-  /**
-   * The alignment of grid items along the inline axis.
-   */
   accessor justifyItems: GridProps['justifyItems'];
-  /**
-   * The alignment of grid items along the block axis.
-   */
   accessor alignItems: GridProps['alignItems'];
-  /**
-   * A shorthand for setting both `alignItems` and `justifyItems`.
-   */
   accessor placeItems: GridProps['placeItems'];
-  /**
-   * The alignment of the grid along the inline axis.
-   */
   accessor justifyContent: GridProps['justifyContent'];
-  /**
-   * The alignment of the grid along the block axis.
-   */
   accessor alignContent: GridProps['alignContent'];
-  /**
-   * A shorthand for setting both `alignContent` and `justifyContent`.
-   */
   accessor placeContent: GridProps['placeContent'];
-  /**
-   * The spacing between grid rows and columns.
-   */
   accessor gap: GridProps['gap'];
-  /**
-   * The spacing between grid rows.
-   */
   accessor rowGap: GridProps['rowGap'];
-  /**
-   * The spacing between grid columns.
-   */
   accessor columnGap: GridProps['columnGap'];
 }
 declare global {
@@ -701,15 +577,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-grid';
-/**
- * The properties for the grid component when it's used in JSX.
- * @publicDocs
- */
 export interface GridJSXProps
   extends Partial<GridProps>,
     Pick<GridProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the grid.
+   * The child elements displayed within the grid component, which are arranged in a flexible grid layout with configurable columns, rows, and spacing.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -14,10 +19,45 @@ import type {
   SizeUnitsOrAuto,
   SizeUnits,
   SizeUnitsOrNone,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * A type that allows a value to be responsive using container query syntax.
+ * Makes a type responsive by allowing it to be either the base value or a container query string. This enables conditional styling based on container dimensions.
  * @publicDocs
  */
 export type MakeResponsive<T> = T | `@container${string}`;
@@ -43,12 +83,21 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * A version of the box properties with all fields required.
+ * Represents the box component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The allowed border radius values for a box component.
+ * Represents the subset of border radius values supported by the component.
+ *
+ * - `small-200`: Extra small radius for subtle rounding.
+ * - `small-100`: Small radius for minimal corner rounding.
+ * - `small`: Standard small radius.
+ * - `base`: Medium radius for moderate corner rounding.
+ * - `large`: Standard large radius for pronounced rounding.
+ * - `large-100`: Large radius for more prominent corner rounding.
+ * - `large-200`: Extra large radius for maximum rounding.
+ * - `none`: No border radius (sharp corners).
  * @publicDocs
  */
 export type BoxBorderRadii = Extract<
@@ -63,7 +112,12 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The allowed border style values for a box component.
+ * Represents the subset of border style values supported by the box component.
+ *
+ * - `auto`: Default border style determined by the system.
+ * - `none`: No border style (removes the border).
+ * - `solid`: Continuous line border.
+ * - `dashed`: Border made up of dashes.
  * @publicDocs
  */
 export type BoxBorderStyles = Extract<
@@ -71,7 +125,9 @@ export type BoxBorderStyles = Extract<
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The box properties that support responsive values through container queries.
+ * Represents box props with responsive capabilities for layout properties.
+ *
+ * This enables conditional styling based on container queries.
  * @publicDocs
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
@@ -106,7 +162,7 @@ export interface BoxProps
     | 'overflow'
   > {
   /**
-   * The background color of the grid item.
+   * The background color of the component.
    *
    * @default 'transparent'
    */
@@ -115,16 +171,13 @@ export interface BoxProps
     'transparent' | 'base' | 'subdued' | 'strong'
   >;
   /**
-   * Controls the thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
+   * A border applied using shorthand syntax to specify width, color, and style in a single property.
    *
-   * - `small`: Thin border for subtle definition.
-   * - `small-100`: Extra thin border for minimal emphasis.
-   * - `base`: Standard border width.
-   * - `large`: Thick border for strong emphasis.
-   * - `large-100`: Extra thick border for maximum prominence.
-   * - `none`: No border.
-   *
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.
+   * @default 'none'
+   */
+  border: RequiredBoxProps['border'];
+  /**
+   * The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -137,7 +190,7 @@ export interface BoxProps
       >
     | Extract<RequiredBoxProps['borderWidth'], ''>;
   /**
-   * The visual style of the border (solid, dashed, auto, or none).
+   * The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -145,7 +198,7 @@ export interface BoxProps
     | MaybeAllValuesShorthandProperty<BoxBorderStyles>
     | Extract<RequiredBoxProps['borderStyle'], ''>;
   /**
-   * The color of the border using the design system's color scale.
+   * The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -154,99 +207,85 @@ export interface BoxProps
     'subdued' | 'base' | 'strong' | ''
   >;
   /**
-   * The roundedness of the corners using the design system's radius scale.
+   * The roundedness of the element's corners using the design system's radius scale.
    *
    * @default 'none'
    */
   borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;
   /**
-   * The padding applied to all edges of the grid item.
+   * The padding applied to all edges of the component.
    *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
+   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:
+   * - 1 value applies to all sides
+   * - 2 values apply to block (top/bottom) and inline (left/right)
+   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)
+   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)
    *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
+   * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
-   *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
   padding: ResponsiveBoxProps['padding'];
   /**
-   * The padding applied to the block axis (top and bottom in horizontal writing modes).
+   * The block-direction padding (top and bottom in horizontal writing modes).
    *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for block-start and block-end.
    *
-   * This overrides the block value of `padding`.
+   * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlock: ResponsiveBoxProps['paddingBlock'];
   /**
-   * The padding applied to the block-start edge (top in horizontal writing modes).
+   * The block-start padding (top in horizontal writing modes).
    *
-   * This overrides the block-start value of `paddingBlock`.
-   *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];
   /**
-   * The padding applied to the block-end edge (bottom in horizontal writing modes).
+   * The block-end padding (bottom in horizontal writing modes).
    *
-   * This overrides the block-end value of `paddingBlock`.
-   *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];
   /**
-   * The padding applied to the inline axis (left and right in horizontal writing modes).
+   * The inline-direction padding (left and right in horizontal writing modes).
    *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.
    *
-   * This overrides the inline value of `padding`.
+   * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInline: ResponsiveBoxProps['paddingInline'];
   /**
-   * The padding applied to the inline-start edge (left in left-to-right languages).
+   * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * This overrides the inline-start value of `paddingInline`.
-   *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];
   /**
-   * The padding applied to the inline-end edge (right in left-to-right languages).
+   * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * This overrides the inline-end value of `paddingInline`.
-   *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];
   /**
-   * Sets the outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
    *
    * - `auto` the component's initial value. The actual value depends on the component and context.
    * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
@@ -255,7 +294,7 @@ export interface BoxProps
    */
   display: ResponsiveBoxProps['display'];
   /**
-   * The vertical size of the grid item in standard layouts (height in left-to-right or right-to-left writing modes).
+   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).
    *
    * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;
    * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.
@@ -266,31 +305,44 @@ export interface BoxProps
    */
   blockSize: SizeUnitsOrAuto;
   /**
-   * The [minimum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) (minimum height in horizontal writing modes) of the grid item.
+   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize: SizeUnits;
   /**
-   * The [maximum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) (maximum height in horizontal writing modes) of the grid item.
+   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize: SizeUnitsOrNone;
   /**
-   * The [inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size) (width in horizontal writing modes) of the grid item.
+   * The width in horizontal writing modes, or height in vertical writing modes.
+   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize: SizeUnitsOrAuto;
   /**
-   * The [minimum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) (minimum width in horizontal writing modes) of the grid item.
+   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize: SizeUnits;
   /**
-   * The [maximum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) (maximum width in horizontal writing modes) of the grid item.
+   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
@@ -298,273 +350,114 @@ export interface BoxProps
 }
 
 /**
- * A version of the grid item properties with all fields required.
+ * Represents the grid item component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredGridItemProps = Required<GridItemProps$1>;
 /**
- * The properties for the grid item component. A grid item can be positioned within specific rows and columns of a grid, with control over how many rows or columns it spans.
- * @publicDocs
+ * The grid item component represents a single cell within a grid layout, allowing you to control how content is positioned and sized within the grid. Use grid item as a child of grid to specify column span, row span, and positioning for individual content areas.
+ *
+ * Grid item supports precise placement control through column and row properties, enabling you to create complex layouts where different items occupy varying amounts of space or appear in specific grid positions.
  */
 export interface GridItemProps
   extends BoxProps,
     Required<Pick<GridItemProps$1, 'gridColumn' | 'gridRow'>> {
   /**
-   * The column position and span of the grid item. You can specify a starting column number, an ending column number, or both (for example, `'1 / 3'` starts at column 1 and ends before column 3, spanning 2 columns). You can also use `'span 2'` to make the item span 2 columns.
+   * The number of columns the item will span across.
+   *
+   * Learn more about the [grid-column property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column).
+   *
+   * @default 'auto'
    */
   gridColumn: RequiredGridItemProps['gridColumn'];
   /**
-   * The row position and span of the grid item. You can specify a starting row number, an ending row number, or both (for example, `'1 / 3'` starts at row 1 and ends before row 3, spanning 2 rows). You can also use `'span 2'` to make the item span 2 rows.
+   * The number of rows the item will span across.
+   *
+   * Learn more about the [grid-row property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row).
+   *
+   * @default 'auto'
    */
   gridRow: RequiredGridItemProps['gridRow'];
 }
 
-/**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * An interface representing the properties of an activation event, such as a click or keypress.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on PC) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/**
- * The base element class for Box components with all Box properties as accessors.
- */
-declare class BoxElement extends PreactCustomElement implements BoxProps {
+declare class BoxElement extends PolarisCustomElement implements BoxProps {
   constructor(renderImpl: RenderImpl);
-  /**
-   * The ARIA role that defines the semantic meaning of the grid item for assistive technologies.
-   */
   accessor accessibilityRole: BoxProps['accessibilityRole'];
-  /**
-   * The background color of the grid item using the design system's color scale. Choose from `transparent`, `subdued`, `base`, or `strong`.
-   */
   accessor background: BoxProps['background'];
-  /**
-   * The height of the grid item in horizontal writing modes, or width in vertical writing modes.
-   * Use this for flow-relative sizing that adapts to text direction.
-   */
   accessor blockSize: BoxProps['blockSize'];
-  /**
-   * The minimum height of the grid item in horizontal writing modes, or minimum width in vertical writing modes.
-   * Prevents the grid item from shrinking below this size.
-   */
   accessor minBlockSize: BoxProps['minBlockSize'];
-  /**
-   * The maximum height of the grid item in horizontal writing modes, or maximum width in vertical writing modes.
-   * Prevents the grid item from growing beyond this size.
-   */
   accessor maxBlockSize: BoxProps['maxBlockSize'];
-  /**
-   * The width of the grid item in horizontal writing modes, or height in vertical writing modes.
-   * Use this for flow-relative sizing that adapts to text direction.
-   */
   accessor inlineSize: BoxProps['inlineSize'];
-  /**
-   * The minimum width of the grid item in horizontal writing modes, or minimum height in vertical writing modes.
-   * Prevents the grid item from shrinking below this size.
-   */
   accessor minInlineSize: BoxProps['minInlineSize'];
-  /**
-   * The maximum width of the grid item in horizontal writing modes, or maximum height in vertical writing modes.
-   * Prevents the grid item from growing beyond this size.
-   */
   accessor maxInlineSize: BoxProps['maxInlineSize'];
-  /**
-   * Controls how content that exceeds the grid item's boundaries is displayed. Use `hidden` to clip overflow or `visible` to allow content to extend beyond boundaries.
-   */
   accessor overflow: BoxProps['overflow'];
-  /**
-   * The spacing applied inside the grid item on all sides, creating distance between the item's edges and its content.
-   */
   accessor padding: BoxProps['padding'];
-  /**
-   * The vertical padding (top and bottom) in horizontal writing modes.
-   * Use this for flow-relative padding that adapts to text direction.
-   */
   accessor paddingBlock: BoxProps['paddingBlock'];
-  /**
-   * The padding at the top in horizontal writing modes, or at the start edge in vertical writing modes.
-   */
   accessor paddingBlockStart: BoxProps['paddingBlockStart'];
-  /**
-   * The padding at the bottom in horizontal writing modes, or at the end edge in vertical writing modes.
-   */
   accessor paddingBlockEnd: BoxProps['paddingBlockEnd'];
-  /**
-   * The horizontal padding (left and right) in horizontal writing modes.
-   * Use this for flow-relative padding that adapts to text direction.
-   */
   accessor paddingInline: BoxProps['paddingInline'];
-  /**
-   * The padding at the left in left-to-right languages, or at the right in right-to-left languages.
-   */
   accessor paddingInlineStart: BoxProps['paddingInlineStart'];
-  /**
-   * The padding at the right in left-to-right languages, or at the left in right-to-left languages.
-   */
   accessor paddingInlineEnd: BoxProps['paddingInlineEnd'];
-  /**
-   * Applies a border using shorthand syntax to specify width, color, and style in a single property.
-   */
   accessor border: BoxProps['border'];
-  /**
-   * The width of the border.
-   */
   accessor borderWidth: BoxProps['borderWidth'];
-  /**
-   * The style of the border.
-   */
   accessor borderStyle: BoxProps['borderStyle'];
-  /**
-   * The color of the border.
-   */
   accessor borderColor: BoxProps['borderColor'];
-  /**
-   * The radius of the border corners.
-   */
   accessor borderRadius: BoxProps['borderRadius'];
-  /**
-   * A text description of the grid item for screen readers, used when the visual context isn't sufficient for understanding.
-   */
   accessor accessibilityLabel: BoxProps['accessibilityLabel'];
-  /**
-   * Controls the visibility of the grid item for both visual and assistive technology users. Use `hidden` to hide from screen readers or `exclusive` to hide visually but announce to screen readers.
-   */
   accessor accessibilityVisibility: BoxProps['accessibilityVisibility'];
-  /**
-   * Controls how the grid item is displayed in the layout, such as block, inline, or none.
-   */
   accessor display: BoxProps['display'];
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A grid item is a child of a grid that can be positioned within specific rows and columns.
+ * The grid item component represents a single cell within a grid layout, allowing you to control how content is positioned and sized within the grid. Use grid item as a child of grid to specify column span, row span, and positioning for individual content areas.
+ *
+ * Grid item supports precise placement control through column and row properties, enabling you to create complex layouts where different items occupy varying amounts of space or appear in specific grid positions.
+ * @publicDocs
  */
 declare class GridItem extends BoxElement implements GridItemProps {
-  /**
-   * The column position and span of the grid item.
-   */
   accessor gridColumn: GridItemProps['gridColumn'];
-  /**
-   * The row position and span of the grid item.
-   */
   accessor gridRow: GridItemProps['gridRow'];
   constructor();
 }
@@ -583,15 +476,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-grid-item';
-/**
- * The properties for the grid item component when it's used in JSX.
- * @publicDocs
- */
 export interface GridItemJSXProps
   extends Partial<GridItemProps>,
     Pick<GridItemProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the grid item.
+   * The content displayed within the grid item component, which represents a single cell in the grid layout and can span multiple columns or rows.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
@@ -1,16 +1,70 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, HeadingProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  HeadingProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+declare const headingFontSizes: readonly [
+  'auto',
+  'small',
+  'base',
+  'large',
+  'large-100',
+  'large-200',
+  'large-300',
+  'large-400',
+];
+export type HeadingFontSize = (typeof headingFontSizes)[number];
 
 /**
- * The properties for the heading component. These properties define hierarchical section titles and headings with appropriate semantic meaning and visual hierarchy.
- * @publicDocs
+ * Configure the following properties on the heading component.
  */
 export interface HeadingProps
   extends Required<
@@ -18,146 +72,101 @@ export interface HeadingProps
       HeadingProps$1,
       'accessibilityRole' | 'accessibilityVisibility' | 'lineClamp'
     >
-  > {}
-
-/**
- * A string containing CSS styles.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  > {
   /**
-   * The function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * Optional CSS styles to apply to the shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * An object that represents the state of modifier keys and mouse button
- * during an activation event like a click.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta (Command on Mac, Windows key on PC) key was pressed.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * Options for customizing click behavior on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
-  /** @private */
-  connectedCallback(): void;
-  /** @private */
-  disconnectedCallback(): void;
-  /** @private */
-  adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
+   * The font size of the heading. The named values also apply their matching
+   * line-height and letter-spacing:
    *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
+   * - 'small' maps to headingXs
+   * - 'base' maps to headingSm
+   * - 'large' / 'large-100' maps to headingMd
+   * - 'large-200' maps to headingLg
+   * - 'large-300' maps to headingXl
+   * - 'large-400' maps to heading2xl
+   *
+   * @default 'auto'
    */
-  click({sourceEvent}?: ClickOptions): void;
+  fontSize: HeadingFontSize;
+  /**
+   * The semantic meaning of the component’s content. When set,
+   * the role will be used by assistive technologies to help users
+   * navigate the page.
+   *
+   * - `heading`: Identifies the element as a heading for assistive technologies.
+   * - `none`: Removes semantic meaning from the heading element.
+   * - `presentation`: Removes semantic meaning from the heading element.
+   *
+   * @default 'heading'
+   *
+   * @implementation The `heading` role doesn't need to be applied if
+   * the host applies it for you; for example, an HTML host rendering
+   * an `<h2>` element should not apply the `heading` role.
+   */
+  accessibilityRole: Required<HeadingProps$1>['accessibilityRole'];
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/**
- * A custom element for displaying hierarchical section titles and headings with appropriate semantic meaning and visual styling. Use Heading to structure your content with proper heading levels for both visual hierarchy and accessibility.
- */
-declare class Heading extends PreactCustomElement implements HeadingProps {
-  /**
-   * The ARIA role for the heading. Set to `'heading'` (the default) for standard heading semantics, or `'presentation'` / `'none'` to remove heading semantics for decorative use.
-   */
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+}
+
+declare abstract class HeadingBase
+  extends PolarisCustomElement
+  implements
+    Pick<
+      HeadingProps,
+      'accessibilityRole' | 'accessibilityVisibility' | 'fontSize' | 'lineClamp'
+    >
+{
+  accessor fontSize: HeadingProps['fontSize'];
   accessor accessibilityRole: HeadingProps['accessibilityRole'];
-  /**
-   * The maximum number of lines to display before the text is truncated with an ellipsis.
-   */
   accessor lineClamp: HeadingProps['lineClamp'];
-  /**
-   * The visibility of the element to assistive technologies.
-   */
   accessor accessibilityVisibility: HeadingProps['accessibilityVisibility'];
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the heading component.
+ * @publicDocs
+ */
+declare class Heading extends HeadingBase implements HeadingProps {
   constructor();
 }
 declare global {
@@ -174,15 +183,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-heading';
-/**
- * The JSX properties for the heading component. These properties define how a heading is rendered in Preact or JSX.
- * @publicDocs
- */
 export interface HeadingJSXProps
   extends Partial<HeadingProps>,
     Pick<HeadingProps$1, 'id' | 'children'> {
   /**
-   * The content of the heading.
+   * The heading text displayed within the heading component, which provides a title or section header for content.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
@@ -1,24 +1,81 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {IconProps$1, IconType, ComponentChildren} from './shared.d.ts';
+import type {
+  IconProps$1,
+  IconType,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+/**
+ * Configure the following properties on the icon component.
+ */
 export interface IconProps
-  extends Pick<
-    IconProps$1,
-    'type' | 'tone' | 'color' | 'size' | 'interestFor'
+  extends Required<
+    Pick<IconProps$1, 'type' | 'tone' | 'color' | 'size' | 'interestFor'>
   > {
   /**
-   * The type of icon that will be displayed. You can specify an icon name from the available icon set, or use an empty string to show no icon.
+   * The icon to display from the icon library.
+   *
+   * Set to a valid icon name to display that icon. To hide the icon completely,
+   * use an empty string `''`. To reserve the icon's space without displaying an icon,
+   * use `'empty'`.
    */
   type: '' | IconType | 'empty';
   /**
-   * The color tone of the icon based on its semantic meaning. Choose from `'auto'` to let the icon inherit its context, `'neutral'` for standard icons, `'info'` for informational content, `'success'` for positive actions, `'caution'` or `'warning'` for warnings, or `'critical'` for errors.
+   * The semantic meaning and color treatment of the component.
+   *
+   * - `info`: Informational content or helpful tips.
+   * - `success`: Positive outcomes or successful states.
+   * - `warning`: Important warnings about potential issues.
+   * - `critical`: Urgent problems or destructive actions.
+   * - `auto`: Automatically determined based on context.
+   * - `neutral`: General information without specific intent.
+   * - `caution`: Advisory notices that need attention.
    *
    * @default 'auto'
    */
@@ -27,159 +84,73 @@ export interface IconProps
     'auto' | 'neutral' | 'info' | 'success' | 'caution' | 'warning' | 'critical'
   >;
   /**
-   * The color emphasis of the icon. Use `'base'` for the standard color intensity, or `'subdued'` for a lighter, less prominent appearance.
+   * The color emphasis level that controls visual intensity.
+   *
+   * - `base`: Primary color for body text, standard UI elements, and general content with good readability.
+   * - `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.
    *
    * @default 'base'
    */
   color: Extract<IconProps$1['color'], 'base' | 'subdued'>;
   /**
-   * The size of the icon. Use `'small'` for compact layouts, or `'base'` for standard sizing.
+   * The size of the icon.
    *
-   * @default 'base'
+   * - `small`: Smaller icon suitable for inline use within text or compact UI elements.
+   * - `base`: Default size that works well for standalone icons and standard use cases.
    */
   size: Extract<IconProps$1['size'], 'small' | 'base'>;
 }
 
-/**
- * A string containing CSS styles for the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * Optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event, such as a click or keypress. These properties capture which modifier keys were pressed and which mouse button was used during the event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during activation.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on Windows) was pressed during activation.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during activation.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during activation.
-   */
-  button: number;
-}
-/**
- * The options for customizing synthetic click behavior.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of `HTMLElement` to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queues a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to `@property` values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in a background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
+}
+
+declare abstract class IconBase
+  extends PolarisCustomElement
+  implements Pick<IconProps, 'color' | 'size' | 'interestFor'>
+{
+  accessor color: IconProps['color'];
+  accessor size: IconProps['size'];
+  accessor interestFor: IconProps['interestFor'];
+  abstract tone: string;
+  abstract type: string;
+  constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
 /**
- * An icon displays a graphical symbol from the icon library.
+ * Configure the following properties on the icon component.
+ * @publicDocs
  */
-declare class Icon extends PreactCustomElement implements IconProps {
-  /**
-   * The color emphasis of the icon.
-   */
-  accessor color: IconProps['color'];
-  /**
-   * The color tone of the icon based on its semantic meaning.
-   */
+declare class Icon extends IconBase implements IconProps {
   accessor tone: IconProps['tone'];
-  /**
-   * The type of icon to display.
-   */
   accessor type: IconProps['type'];
-  /**
-   * The size of the icon.
-   */
-  accessor size: IconProps['size'];
-  /**
-   * The element that this icon should show interest for when activated.
-   */
-  accessor interestFor: string;
   constructor();
 }
 declare global {
@@ -196,10 +167,6 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-icon';
-/**
- * The properties for the icon component when it's used in JSX.
- * @publicDocs
- */
 export interface IconJSXProps
   extends Partial<IconProps>,
     Pick<IconProps$1, 'id'> {}

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -13,21 +18,30 @@ import type {
   SizeUnitsOrAuto,
   SizeUnits,
   SizeUnitsOrNone,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * A callback event that's typed to a specific HTML element. This type provides access to the element that triggered the event.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that currently has the event listener attached.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener for callback events, typed to a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -36,26 +50,61 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
 /**
- * Makes a type value responsive by allowing container query strings.
+ * Makes a type responsive by allowing it to be either the base value or a container query string. This enables conditional styling based on container dimensions.
  * @publicDocs
  */
 export type MakeResponsive<T> = T | `@container${string}`;
@@ -81,12 +130,21 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * The box properties with all fields marked as required.
+ * Represents the box component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The available border radius values for Box components.
+ * Represents the subset of border radius values supported by the component.
+ *
+ * - `small-200`: Extra small radius for subtle rounding.
+ * - `small-100`: Small radius for minimal corner rounding.
+ * - `small`: Standard small radius.
+ * - `base`: Medium radius for moderate corner rounding.
+ * - `large`: Standard large radius for pronounced rounding.
+ * - `large-100`: Large radius for more prominent corner rounding.
+ * - `large-200`: Extra large radius for maximum rounding.
+ * - `none`: No border radius (sharp corners).
  * @publicDocs
  */
 export type BoxBorderRadii = Extract<
@@ -101,7 +159,12 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The available border style values for Box components.
+ * Represents the subset of border style values supported by the box component.
+ *
+ * - `auto`: Default border style determined by the system.
+ * - `none`: No border style (removes the border).
+ * - `solid`: Continuous line border.
+ * - `dashed`: Border made up of dashes.
  * @publicDocs
  */
 export type BoxBorderStyles = Extract<
@@ -109,7 +172,9 @@ export type BoxBorderStyles = Extract<
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The box properties that support responsive values through container queries.
+ * Represents box props with responsive capabilities for layout properties.
+ *
+ * This enables conditional styling based on container queries.
  * @publicDocs
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
@@ -144,7 +209,7 @@ export interface BoxProps
     | 'overflow'
   > {
   /**
-   * The background color of the image container.
+   * The background color of the component.
    *
    * @default 'transparent'
    */
@@ -153,16 +218,13 @@ export interface BoxProps
     'transparent' | 'base' | 'subdued' | 'strong'
   >;
   /**
-   * Controls the thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
+   * A border applied using shorthand syntax to specify width, color, and style in a single property.
    *
-   * - `small`: Thin border for subtle definition.
-   * - `small-100`: Extra thin border for minimal emphasis.
-   * - `base`: Standard border width.
-   * - `large`: Thick border for strong emphasis.
-   * - `large-100`: Extra thick border for maximum prominence.
-   * - `none`: No border.
-   *
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.
+   * @default 'none'
+   */
+  border: RequiredBoxProps['border'];
+  /**
+   * The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -175,7 +237,7 @@ export interface BoxProps
       >
     | Extract<RequiredBoxProps['borderWidth'], ''>;
   /**
-   * The visual style of the border (solid, dashed, auto, or none).
+   * The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -183,7 +245,7 @@ export interface BoxProps
     | MaybeAllValuesShorthandProperty<BoxBorderStyles>
     | Extract<RequiredBoxProps['borderStyle'], ''>;
   /**
-   * The color of the border using the design system's color scale.
+   * The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -192,99 +254,85 @@ export interface BoxProps
     'subdued' | 'base' | 'strong' | ''
   >;
   /**
-   * The roundedness of the corners using the design system's radius scale.
+   * The roundedness of the element's corners using the design system's radius scale.
    *
    * @default 'none'
    */
   borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;
   /**
-   * The padding applied to all edges of the image container.
+   * The padding applied to all edges of the component.
    *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
+   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:
+   * - 1 value applies to all sides
+   * - 2 values apply to block (top/bottom) and inline (left/right)
+   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)
+   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)
    *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
+   * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
-   *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
   padding: ResponsiveBoxProps['padding'];
   /**
-   * The padding applied to the block axis (top and bottom in horizontal writing modes).
+   * The block-direction padding (top and bottom in horizontal writing modes).
    *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for block-start and block-end.
    *
-   * This overrides the block value of `padding`.
+   * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlock: ResponsiveBoxProps['paddingBlock'];
   /**
-   * The padding applied to the block-start edge (top in horizontal writing modes).
+   * The block-start padding (top in horizontal writing modes).
    *
-   * This overrides the block-start value of `paddingBlock`.
-   *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];
   /**
-   * The padding applied to the block-end edge (bottom in horizontal writing modes).
+   * The block-end padding (bottom in horizontal writing modes).
    *
-   * This overrides the block-end value of `paddingBlock`.
-   *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];
   /**
-   * The padding applied to the inline axis (left and right in horizontal writing modes).
+   * The inline-direction padding (left and right in horizontal writing modes).
    *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.
    *
-   * This overrides the inline value of `padding`.
+   * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInline: ResponsiveBoxProps['paddingInline'];
   /**
-   * The padding applied to the inline-start edge (left in left-to-right languages).
+   * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * This overrides the inline-start value of `paddingInline`.
-   *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];
   /**
-   * The padding applied to the inline-end edge (right in left-to-right languages).
+   * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * This overrides the inline-end value of `paddingInline`.
-   *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];
   /**
-   * Sets the outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
    *
    * - `auto` the component's initial value. The actual value depends on the component and context.
    * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
@@ -293,7 +341,7 @@ export interface BoxProps
    */
   display: ResponsiveBoxProps['display'];
   /**
-   * The vertical size of the image in standard layouts (height in left-to-right or right-to-left writing modes).
+   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).
    *
    * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;
    * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.
@@ -304,31 +352,44 @@ export interface BoxProps
    */
   blockSize: SizeUnitsOrAuto;
   /**
-   * The [minimum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) (minimum height in horizontal writing modes) of the image.
+   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize: SizeUnits;
   /**
-   * The [maximum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) (maximum height in horizontal writing modes) of the image.
+   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize: SizeUnitsOrNone;
   /**
-   * The [inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size) (width in horizontal writing modes) of the image.
+   * The width in horizontal writing modes, or height in vertical writing modes.
+   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize: SizeUnitsOrAuto;
   /**
-   * The [minimum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) (minimum width in horizontal writing modes) of the image.
+   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize: SizeUnits;
   /**
-   * The [maximum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) (maximum width in horizontal writing modes) of the image.
+   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
@@ -336,8 +397,7 @@ export interface BoxProps
 }
 
 /**
- * The properties for the image component. An image displays pictures with configurable sizing, loading behavior, and borders. Properties include `src` for the image URL, `alt` for accessibility text, `aspectRatio` for sizing, `loading` for lazy loading, and border styling options.
- * @publicDocs
+ * Configure the following properties on the image component.
  */
 export interface ImageProps
   extends Required<
@@ -365,227 +425,141 @@ export interface ImageProps
       >
     > {
   /**
-   * The URL of the image to display. You can provide an absolute or relative URL pointing to the image file.
+   * The loading strategy for the image.
+   *
+   * - `eager`: Immediately loads the image, irrespective of its position within the visible viewport.
+   * - `lazy`: Delays loading the image until it approaches a specified distance from the viewport.
+   *
+   * Learn more about the [loading attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading).
+   *
+   * @default 'eager'
    */
-  src: ImageProps$1['src'];
+  loading: Required<ImageProps$1>['loading'];
   /**
-   * A set of source images with different sizes for responsive loading. Use this to provide multiple image sizes for different screen resolutions (for example, `'image-320w.jpg 320w, image-640w.jpg 640w'`).
+   * The semantic meaning of the component’s content. When set,
+   * the role will be used by assistive technologies to help users
+   * navigate the page.
+   *
+   * - `none`: Completely hides the element and its content from assistive technologies
+   * - `presentation`: Removes semantic meaning, making the image purely decorative and ignored by screen readers.
+   * - `img`: Identifies the element as an image that conveys meaningful information to users.
+   *
+   * @default 'img'
+   *
+   * @implementation The `img` role doesn't need to be applied if
+   * the host applies it for you; for example, an HTML host rendering
+   * an `<img>` element should not apply the `img` role.
    */
-  srcSet: ImageProps$1['srcSet'];
+  accessibilityRole: Required<ImageProps$1>['accessibilityRole'];
   /**
-   * The sizes of the image at different viewport widths. Use this with `srcSet` to tell the browser which image to load (for example, `'(max-width: 320px) 280px, 640px'`).
+   * The displayed inline width of the image.
+   *
+   * - `fill`: the image will take up 100% of the available inline size.
+   * - `auto`: the image will be displayed at its natural size.
+   *
+   * Learn more about the [width attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
+   *
+   * @default 'fill'
    */
-  sizes: ImageProps$1['sizes'];
+  inlineSize: Required<ImageProps$1>['inlineSize'];
   /**
-   * Alternative text that describes the image for screen readers. This text should convey the meaning or content of the image to users who can't see it.
+   * The aspect ratio of the image.
+   *
+   * The rendering of the image will depend on the `inlineSize` value:
+   *
+   * - `inlineSize="fill"`: the aspect ratio will be respected and the image will take the necessary space.
+   * - `inlineSize="auto"`: the image will not render until it has loaded and the aspect ratio will be ignored.
+   *
+   * For example, if the value is set as `50 / 100`, the getter returns `50 / 100`.
+   * If the value is set as `0.5`, the getter returns `0.5 / 1`.
+   *
+   * Learn more about the [aspect-ratio property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).
+   *
+   * @default '1/1'
    */
-  alt: ImageProps$1['alt'];
+  aspectRatio: Required<ImageProps$1>['aspectRatio'];
   /**
-   * The aspect ratio of the image as a width-to-height ratio (for example, `'16/9'` or `'1'`). This helps prevent layout shifts while the image loads.
+   * The image resizing behavior to fit within its container.
+   *
+   * - `contain`: Scales the image to fit within the container while maintaining its aspect ratio. The entire image is visible, but might leave empty space.
+   * - `cover`: Scales the image to fill the entire container while maintaining its aspect ratio. The image might be cropped to fit.
+   *
+   * The image is always positioned in the center of the container.
+   *
+   * Learn more about the [object-fit property](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
+   *
+   * @default 'contain'
    */
-  aspectRatio: ImageProps$1['aspectRatio'];
-  /**
-   * How the image should be resized to fit its container. Choose `'cover'` to fill the container while maintaining aspect ratio (cropping if needed), or `'contain'` to fit the entire image within the container.
-   */
-  objectFit: ImageProps$1['objectFit'];
-  /**
-   * When the image should be loaded. Use `'lazy'` to defer loading until the image is near the viewport, or `'eager'` to load immediately.
-   */
-  loading: ImageProps$1['loading'];
-  /**
-   * The accessibility role for the image. Set this to provide semantic meaning for screen readers.
-   */
-  accessibilityRole: ImageProps$1['accessibilityRole'];
-  /**
-   * The inline size (width in horizontal writing modes) of the image. You can use size units like `'100px'` or `'50%'`.
-   */
-  inlineSize: ImageProps$1['inlineSize'];
-  /**
-   * Whether to show a border around the image. Set to `true` to display a border, or `false` to hide it.
-   */
-  border: BoxProps['border'];
-  /**
-   * The width of the border around the image. You can use a single value to apply the same width to all sides, or use the 1-to-4-value syntax to control individual sides.
-   */
-  borderWidth: BoxProps['borderWidth'];
-  /**
-   * The style of the border around the image. You can use a single value to apply the same style to all sides, or use the 1-to-4-value syntax to control individual sides.
-   */
-  borderStyle: BoxProps['borderStyle'];
-  /**
-   * The color of the border around the image. Choose from `'subdued'`, `'base'`, or `'strong'` to control the visual emphasis.
-   */
-  borderColor: BoxProps['borderColor'];
-  /**
-   * The radius of the border corners around the image. You can use a single value to apply the same radius to all corners, or use the 1-to-4-value syntax to control individual corners.
-   */
-  borderRadius: BoxProps['borderRadius'];
+  objectFit: Required<ImageProps$1>['objectFit'];
 }
 
-/**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event, such as a click or keypress. These properties capture which modifier keys were pressed and which mouse button was used during the event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of `HTMLElement` to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queues a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to `@property` values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in a background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * An image displays pictures with configurable sizing, loading behavior, and borders.
+ * Configure the following properties on the image component.
+ * @publicDocs
  */
-declare class Image extends PreactCustomElement implements ImageProps {
+declare class Image extends PolarisCustomElement implements ImageProps {
   /**
-   * The URL of the image to display.
+   * The image source (either a remote URL or a local file resource).
+   *
+   * When the image is loading or no `src` is provided, a placeholder is rendered.
    */
   accessor src: ImageProps['src'];
   /**
-   * A set of source images with different sizes for responsive loading.
+   * A set of image sources and their width or pixel density descriptors. This overrides the `src` property.
+   *
+   * Learn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset).
    */
   accessor srcSet: ImageProps['srcSet'];
   /**
-   * The sizes of the image at different viewport widths.
+   * A set of media conditions and their corresponding sizes.
+   *
+   * Learn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes).
    */
   accessor sizes: ImageProps['sizes'];
   /**
-   * Alternative text that describes the image for screen readers.
+   * Alternative text that describes the image for accessibility.
+   *
+   * Provides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.
+   *
+   * When a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.
+   *
+   * Learn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).
    */
   accessor alt: ImageProps['alt'];
-  /**
-   * The aspect ratio of the image as a width-to-height ratio.
-   */
   accessor aspectRatio: ImageProps['aspectRatio'];
-  /**
-   * How the image should be resized to fit its container.
-   */
   accessor objectFit: ImageProps['objectFit'];
-  /**
-   * When the image should be loaded.
-   */
   accessor loading: ImageProps['loading'];
-  /**
-   * The accessibility role for the image.
-   */
   accessor accessibilityRole: ImageProps['accessibilityRole'];
-  /**
-   * The inline size (width in horizontal writing modes) of the image.
-   */
   accessor inlineSize: ImageProps['inlineSize'];
   /**
-   * Whether to show a border around the image.
+   * A border applied around the image using shorthand syntax to specify width, color, and style in a single property.
    */
   accessor border: ImageProps['border'];
   /**
-   * The width of the border around the image.
+   * The thickness of the border around the image. When set, this overrides the width value specified in the `border` property.
    */
   accessor borderWidth: ImageProps['borderWidth'];
   /**
-   * The style of the border around the image.
+   * The visual style of the border around the image, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.
    */
   accessor borderStyle: ImageProps['borderStyle'];
   /**
-   * The color of the border around the image.
+   * The color of the border around the image using the design system's color scale. When set, this overrides the color value specified in the `border` property.
    */
   accessor borderColor: ImageProps['borderColor'];
   /**
-   * The radius of the border corners around the image.
+   * The roundedness of the image's corners using the design system's radius scale.
    */
   accessor borderRadius: ImageProps['borderRadius'];
-  /**
-   * A callback that's fired when the image has loaded successfully.
-   */
   accessor onload: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's fired when the image fails to load.
-   */
   accessor onerror: OnErrorEventHandler;
   constructor();
 }
@@ -603,19 +577,15 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-image';
-/**
- * The properties for the image component when it's used in JSX.
- * @publicDocs
- */
 export interface ImageJSXProps
   extends Partial<ImageProps>,
     Pick<ImageProps$1, 'id'> {
   /**
-   * A callback that's fired when the image fails to load.
+   * A callback fired when the image fails to load.
    */
   onError?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's fired when the image has loaded successfully.
+   * A callback fired when the image loads successfully.
    */
   onLoad?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
@@ -1,54 +1,125 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   ComponentChildren,
   LinkProps$1,
   InteractionProps,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
+/**
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
+ * @publicDocs
+ */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
   currentTarget: HTMLElementTagNameMap[T];
 };
+/**
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
+ * @publicDocs
+ */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
       (event: CallbackEvent<T>): void;
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
-/**  * @publicDocs
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+/**
+ * Represents the link component props with all properties marked as required.
+ * @publicDocs
  */
 export type RequiredLinkProps = Required<LinkProps$1>;
+/**
+ * Represents the base link props with all core properties marked as required.
+ * @publicDocs
+ */
 export type LinkBaseProps = Required<
   Pick<
     LinkProps$1,
@@ -64,95 +135,46 @@ export type LinkBaseProps = Required<
   >
 >;
 /**
- * The properties for the link component. These properties define a clickable link that navigates users to different pages or sections with customizable visual styles and semantic meaning.
- * @publicDocs
+ * Configure the following properties on the link component.
  */
 export interface LinkProps extends LinkBaseProps {
   /**
-   * The visual appearance and semantic meaning of the link. Links rely on the tone system for semantic meaning, so using custom styling might not clearly convey intent to merchants. Available options:
-   * - `'auto'` - The system automatically chooses the appropriate tone based on context.
-   * - `'neutral'` - Standard styling for general navigation without specific semantic meaning.
-   * - `'critical'` - Red styling for links that lead to destructive actions or important warnings.
+   * The semantic meaning and color treatment of the component.
+   *
+   * - `critical`: Urgent problems or destructive actions.
+   * - `auto`: Automatically determined based on context.
+   * - `neutral`: General information without specific intent.
    *
    * @default 'auto'
    */
   tone: Extract<RequiredLinkProps['tone'], 'auto' | 'neutral' | 'critical'>;
-}
-/**  * @publicDocs
- */
-export type Styles = string;
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  ShadowRoot: (element: any) => ComponentChildren;
-  styles?: Styles;
-};
-export interface ActivationEventEsque {
-  shiftKey: boolean;
-  metaKey: boolean;
-  ctrlKey: boolean;
-  button: number;
-}
-/**  *
- * @publicDocs
- */
-export interface ClickOptions {
   /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
+   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
    */
-  sourceEvent?: ActivationEventEsque;
+  accessibilityLabel: Required<LinkProps$1>['accessibilityLabel'];
+  /**
+   * The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
+   */
+  lang: Required<LinkProps$1>['lang'];
 }
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
-/**  * @publicDocs
- */
+
 export interface PreactOverlayControlProps
   extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
   /**
-   * The action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated. The supported actions vary by target component type.
+   * The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
    *
-   * - `--auto`: Performs the default action appropriate for the target component.
-   * - `--show`: Displays the target component if it's currently hidden.
-   * - `--hide`: Conceals the target component from view.
-   * - `--toggle`: Alternates the target component between visible and hidden states.
+   * - `--auto`: A default action for the target component.
+   * - `--show`: Shows the target component.
+   * - `--hide`: Hides the target component.
+   * - `--toggle`: Toggles the visibility of the target component.
    *
    * @default '--auto'
    */
@@ -161,27 +183,48 @@ export interface PreactOverlayControlProps
     '--show' | '--hide' | '--toggle' | '--auto'
   >;
   /**
-   * Sets the element the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
+   * The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
    */
   commandFor: Extract<InteractionProps['commandFor'], string>;
   /**
-   * Sets the element the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this component is activated.
+   * The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.
    */
   interestFor: Extract<InteractionProps['interestFor'], string>;
 }
 
-declare const Link_base: (abstract new (
-  args_0: RenderImpl,
-) => PreactCustomElement & PreactOverlayControlProps) &
-  Pick<typeof PreactCustomElement, 'prototype' | 'observedAttributes'>;
-declare class Link extends Link_base implements LinkProps {
-  accessor tone: LinkProps['tone'];
+declare const LinkBase_base: (abstract new (
+  renderImpl: Omit<RenderImpl, 'globalShadowCSS'>,
+) => PolarisCustomElement & PreactOverlayControlProps) &
+  Pick<typeof PolarisCustomElement, 'prototype' | 'observedAttributes'>;
+declare abstract class LinkBase<TTagName extends keyof HTMLElementTagNameMap>
+  extends LinkBase_base
+  implements
+    Pick<
+      LinkProps,
+      | 'accessibilityLabel'
+      | 'interestFor'
+      | 'href'
+      | 'target'
+      | 'download'
+      | 'lang'
+    >
+{
   accessor accessibilityLabel: LinkProps['accessibilityLabel'];
   accessor href: LinkProps['href'];
   accessor target: LinkProps['target'];
   accessor download: LinkProps['download'];
   accessor lang: LinkProps['lang'];
-  accessor onclick: CallbackEventListener<typeof tagName> | null;
+  accessor onclick: CallbackEventListener<TTagName> | null;
+  abstract tone: string;
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the link component.
+ * @publicDocs
+ */
+declare class Link extends LinkBase<typeof tagName> implements LinkProps {
+  accessor tone: LinkProps['tone'];
   constructor();
 }
 declare global {
@@ -198,56 +241,17 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-link';
-/**
- * The JSX properties for the link component. These properties define how a link is rendered in Preact or JSX.
- * @publicDocs
- */
 export interface LinkJSXProps
   extends Partial<LinkProps>,
     Pick<LinkProps$1, 'id' | 'lang' | 'children'> {
   /**
-   * The text or content to display inside the link. This typically describes the destination or action the link performs.
+   * The text or elements displayed within the link component, which navigates users to a different location when activated.
    */
   children?: ComponentChildren;
   /**
-   * A callback function that's invoked when the link is clicked. It receives the click event as an argument.
+   * A callback fired when the link is clicked.
    */
   onClick?: ((event: CallbackEvent<typeof tagName>) => void) | null;
-  /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
-   *
-   * @default ''
-   */
-  accessibilityLabel?: string;
-  /**
-   * The URL that the link navigates to when clicked. This is the primary property that defines where the link leads.
-   *
-   * @default ''
-   */
-  href?: LinkProps['href'];
-  /**
-   * Where to open the linked document. Available options:
-   * - `''` - Opens in the same frame (default behavior).
-   * - `'_blank'` - Opens in a new window or tab.
-   * - `'_self'` - Opens in the same frame (explicit version of default).
-   * - `'_parent'` - Opens in the parent frame.
-   * - `'_top'` - Opens in the full body of the window.
-   *
-   * @default ''
-   */
-  target?: LinkProps['target'];
-  /**
-   * The filename to save the linked URL as when downloaded. When provided, clicking the link will download the resource instead of navigating to it.
-   *
-   * @default ''
-   */
-  download?: LinkProps['download'];
-  /**
-   * The language of the link's content, specified as a BCP 47 language tag (such as `'en'` or `'fr'`). This helps assistive technologies pronounce content correctly.
-   *
-   * @default ''
-   */
-  lang?: string;
 }
 
 export {Link};

--- a/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
@@ -1,146 +1,117 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, ListItemProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  ListItemProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
-/**
- * The properties that you can set on a list item component.
- * @publicDocs
- */
-export interface ListItemProps extends ListItemProps$1 {}
-
-/**
- * A string that contains CSS styles.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the shadow DOM.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object that represents the state of modifier keys and mouse button
- * during an activation event like a click.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+/**
+ * The list item component represents a single entry within an ordered list or unordered list. Use list item to structure individual points, steps, or items within a list, with each item automatically receiving appropriate list markers (bullets or numbers) from its parent list.
+ *
+ * List item must be used as a direct child of ordered list or unordered list components. Each list item can contain text, inline formatting, or other components to create rich list content.
+ */
+export interface ListItemProps extends ListItemProps$1 {
+  /**
+   * The content displayed within the list item, which represents a single entry in an ordered or unordered list.
+   */
+  children?: ListItemProps$1['children'];
+}
+
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A component that represents a single item within an ordered list or unordered list.
+ * The list item component represents a single entry within an ordered list or unordered list. Use list item to structure individual points, steps, or items within a list, with each item automatically receiving appropriate list markers (bullets or numbers) from its parent list.
  *
- * Use list item as a child of ordered list or unordered list to create properly structured and accessible list content.
+ * List item must be used as a direct child of ordered list or unordered list components. Each list item can contain text, inline formatting, or other components to create rich list content.
+ * @publicDocs
  */
-declare class ListItem extends PreactCustomElement implements ListItemProps {
+declare class ListItem extends PolarisCustomElement implements ListItemProps {
   constructor();
 }
 declare global {
@@ -158,15 +129,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-list-item';
-/**
- * The JSX properties you can set on a list item component.
- * @publicDocs
- */
 export interface ListItemJSXProps
   extends Partial<ListItemProps>,
     Pick<ListItemProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the list item.
+   * The content displayed within the list item, which represents a single entry in an ordered or unordered list.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ListItem.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
@@ -1,160 +1,119 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   ComponentChildren,
   MenuProps$1,
+  PreactCustomElement,
+  RenderImpl,
   InteractionProps,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The properties you can set on a menu component.
- * @publicDocs
+ * Configure the following properties on the menu component.
  */
 export interface MenuProps
-  extends Required<Pick<MenuProps$1, 'id' | 'accessibilityLabel'>> {}
+  extends Required<Pick<MenuProps$1, 'id' | 'accessibilityLabel'>> {
+  /**
+   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   */
+  accessibilityLabel: Required<MenuProps$1>['accessibilityLabel'];
+}
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
-};
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
-}
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/**
- * The properties for controlling overlay elements like popovers, tooltips, and menus through command interactions.
- * @publicDocs
- */
 export interface PreactOverlayControlProps
   extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
   /**
-   * The action that the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
+   * The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
    *
-   * See the documentation of specific components for the actions they support.
-   *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
+   * - `--auto`: A default action for the target component.
+   * - `--show`: Shows the target component.
+   * - `--hide`: Hides the target component.
+   * - `--toggle`: Toggles the visibility of the target component.
    *
    * @default '--auto'
    */
@@ -163,11 +122,11 @@ export interface PreactOverlayControlProps
     '--show' | '--hide' | '--toggle' | '--auto'
   >;
   /**
-   * The element that the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
+   * The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
    */
   commandFor: Extract<InteractionProps['commandFor'], string>;
   /**
-   * The element that the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this component is activated.
+   * The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.
    */
   interestFor: Extract<InteractionProps['interestFor'], string>;
 }
@@ -175,43 +134,37 @@ export interface PreactOverlayControlProps
 /**
  * Shared symbols for overlay control functionality.
  * These symbols are used by components that implement overlay behavior
- * (such as Popover, Tooltip, and Modal) to communicate with the overlay control system.
+ * (like Popover, Tooltip, Modal, etc.) to communicate with the overlay control system.
  */
-/** @private */
+/**
+ * Symbol used to track the open or closed state of the overlay.
+ */
 declare const overlayHidden: unique symbol;
-/** @private */
+/**
+ * Symbol used to track the element that opened the overlay. In some cases, like tooltips and popovers, the overlay is positioned against this element. In all cases, focus should be restored to this element when the overlay is closed.
+ */
 declare const overlayActivator: unique symbol;
-/** @private */
 declare const overlayHideFrameId: unique symbol;
 /**
- * The initialization object for creating a polyfill command event.
+ * Represents the initialization object for creating a polyfill command event. Used for overlay control commands in environments that require polyfills.
  * @publicDocs
  */
 export type PolyfillCommandEventInit = EventInit & {
-  /**
-   * The element that triggered the command.
-   */
   source: HTMLElement | null | undefined;
-  /**
-   * The command action that should be performed.
-   */
   command: PreactOverlayControlProps['command'];
+  rootActivator?: HTMLElement | null;
 };
 /**
- * A polyfill event for the command interaction pattern, which is used to control overlay elements.
+ * Represents a polyfill command event for overlay controls. Used in environments where native command events are not available.
  * @publicDocs
  */
 export type PolyfillCommandEvent = Event & {
-  /**
-   * The element that triggered the command.
-   */
   source: PolyfillCommandEventInit['source'];
-  /**
-   * The command action that should be performed.
-   */
   command: PolyfillCommandEventInit['command'];
-  /** You have to use `_s_shadowSource` because `source` is retargeted to the shadow host by browsers. */
+  /** Have to use `_s_shadowSource` because `source` is retargeted to the shadow host by browsers */
   _s_shadowSource: PolyfillCommandEventInit['source'];
+  /** Root activator for nested overlays (e.g., menu button when modal opened from menu item) */
+  _s_rootActivator?: HTMLElement | null;
 };
 declare global {
   interface GlobalEventHandlersEventMap {
@@ -219,14 +172,10 @@ declare global {
   }
 }
 
-/**
- * The base class for overlay elements that can be shown and hidden through command interactions.
- */
-declare class PreactOverlayElement extends PreactCustomElement {
-  /**
-   * Creates a new overlay element with the given render implementation.
-   */
+declare class PreactOverlayElement extends PolarisCustomElement {
   constructor(renderImpl: RenderImpl);
+  /** @private */
+  disconnectedCallback(): void;
   /** @private */
   [overlayHidden]: boolean;
   /** @private */
@@ -236,16 +185,11 @@ declare class PreactOverlayElement extends PreactCustomElement {
 }
 
 /**
- * A component that displays a contextual list of actions or options, which is typically triggered by a button or other activator element.
+ * Configure the following properties on the menu component.
+ * @publicDocs
  */
 declare class Menu extends PreactOverlayElement implements MenuProps {
-  /**
-   * A label that describes the menu for assistive technologies.
-   */
   accessor accessibilityLabel: string;
-  /**
-   * Creates a new Menu instance.
-   */
   constructor();
   /** @private */
   connectedCallback(): void;
@@ -265,19 +209,12 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the menu component.
- */
 declare const tagName = 's-menu';
-/**
- * The JSX properties you can set on a menu component.
- * @publicDocs
- */
 export interface MenuJSXProps
   extends Partial<MenuProps>,
     Pick<MenuProps$1, 'id' | 'children'> {
   /**
-   * The menu items to display, which should include button and section components.
+   * The items displayed within the menu. Only accepts button and section components. Use button for individual menu actions and section to group related items.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.38.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -13,34 +18,107 @@ import type {
   RenderImpl,
   InteractionProps,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
+/**
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
+ * @publicDocs
+ */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
   currentTarget: HTMLElementTagNameMap[T];
 };
+/**
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
+ * @publicDocs
+ */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
       (event: CallbackEvent<T>): void;
     })
   | null;
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
-  /** Assigns a unique key to this element. */
+  /**
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
+   */
   key?: preact.Key;
-  /** Assigns a ref (generally from `useRef()`) to this element. */
+  /**
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
+   */
   ref?: preact.Ref<TClass>;
-  /** Assigns this element to a parent's slot. */
+  /**
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
+   */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
-/**  * @publicDocs
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+/**
+ * Represents the modal component props with all properties marked as required.
+ * @publicDocs
  */
 export type RequiredAlignedModalProps = Required<ModalProps$1>;
+/**
+ * Configure the following properties on the modal component.
+ */
 export interface ModalProps
   extends Pick<
     RequiredAlignedModalProps,
@@ -53,30 +131,56 @@ export interface ModalProps
     | 'toggleOverlay'
   > {
   /**
-   * Adjust the size of the Modal.
+   * The size of the modal component, controlling its width and height. Larger sizes provide more space for content while smaller sizes are more compact.
    */
   size: Extract<
     ModalProps$1['size'],
     'small-100' | 'small' | 'base' | 'large' | 'large-100'
   >;
+  /**
+   * A title that describes the content of the modal.
+   *
+   */
+  heading: RequiredAlignedModalProps['heading'];
+  /**
+   * A label that describes the purpose of the modal. When set,
+   * it will be announced to users using assistive technologies and will
+   * provide them with more context.
+   *
+   * This overrides the `heading` prop for screen readers.
+   */
+  accessibilityLabel: RequiredAlignedModalProps['accessibilityLabel'];
+  /**
+   * Adjust the padding around the modal content.
+   *
+   * `base`: applies padding that is appropriate for the element.
+   *
+   * `none`: removes all padding from the element. This can be useful when elements inside the modal need to span
+   * to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base'
+   * to bring back the desired padding for the rest of the content.
+   *
+   * @default 'base'
+   */
+  padding: RequiredAlignedModalProps['padding'];
 }
 
 declare class PolarisCustomElement extends PreactCustomElement {
   constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
 }
-/**  * @publicDocs
- */
+
 export interface PreactOverlayControlProps
   extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
   /**
-   * Sets the action the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this clickable is activated.
+   * The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
    *
-   * See the documentation of particular components for the actions they support.
-   *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
+   * - `--auto`: A default action for the target component.
+   * - `--show`: Shows the target component.
+   * - `--hide`: Hides the target component.
+   * - `--toggle`: Toggles the visibility of the target component.
    *
    * @default '--auto'
    */
@@ -85,11 +189,11 @@ export interface PreactOverlayControlProps
     '--show' | '--hide' | '--toggle' | '--auto'
   >;
   /**
-   * Sets the element the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this clickable is activated.
+   * The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
    */
   commandFor: Extract<InteractionProps['commandFor'], string>;
   /**
-   * Sets the element the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this clickable is activated.
+   * The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.
    */
   interestFor: Extract<InteractionProps['interestFor'], string>;
 }
@@ -108,11 +212,19 @@ declare const overlayHidden: unique symbol;
  */
 declare const overlayActivator: unique symbol;
 declare const overlayHideFrameId: unique symbol;
+/**
+ * Represents the initialization object for creating a polyfill command event. Used for overlay control commands in environments that require polyfills.
+ * @publicDocs
+ */
 export type PolyfillCommandEventInit = EventInit & {
   source: HTMLElement | null | undefined;
   command: PreactOverlayControlProps['command'];
   rootActivator?: HTMLElement | null;
 };
+/**
+ * Represents a polyfill command event for overlay controls. Used in environments where native command events are not available.
+ * @publicDocs
+ */
 export type PolyfillCommandEvent = Event & {
   source: PolyfillCommandEventInit['source'];
   command: PolyfillCommandEventInit['command'];
@@ -129,6 +241,8 @@ declare global {
 
 declare class PreactOverlayElement extends PolarisCustomElement {
   constructor(renderImpl: RenderImpl);
+  /** @private */
+  disconnectedCallback(): void;
   /** @private */
   [overlayHidden]: boolean;
   /** @private */
@@ -148,11 +262,19 @@ declare const focusedElement: unique symbol;
 declare const rootActivator: unique symbol;
 declare const onEscape: unique symbol;
 declare const nestedModals: unique symbol;
+declare const onKeyUp: unique symbol;
+declare const onBackdropMouseDown: unique symbol;
+declare const onBackdropMouseUp: unique symbol;
 declare const onBackdropClick: unique symbol;
+declare const backdropMouseDownOnDialog: unique symbol;
+declare const backdropMouseUpOnDialog: unique symbol;
 declare const abortController: unique symbol;
 declare const onChildModalChange: unique symbol;
 declare const childrenRerenderObserver: unique symbol;
 declare const shadowDomRerenderObserver: unique symbol;
+declare const focusTrapController: unique symbol;
+declare const escapeKeyUpController: unique symbol;
+declare const ensureDialogRef: unique symbol;
 declare abstract class ModalBase<TTagName extends keyof HTMLElementTagNameMap>
   extends PreactOverlayElement
   implements
@@ -162,9 +284,25 @@ declare abstract class ModalBase<TTagName extends keyof HTMLElementTagNameMap>
   accessor heading: ModalProps['heading'];
   accessor padding: ModalProps['padding'];
   accessor size: ModalProps['size'];
+  /**
+   * A callback fired when the modal closes.
+   * Use to perform cleanup or trigger side effects when the modal is dismissed.
+   */
   accessor onhide: CallbackEventListener<TTagName> | null;
+  /**
+   * A callback fired when the modal starts to open, before any entrance animation begins.
+   * Use to prepare content or fetch data needed for the modal.
+   */
   accessor onshow: CallbackEventListener<TTagName> | null;
+  /**
+   * A callback fired after the modal has fully closed and any exit animation completes.
+   * Use to reset form state, clear temporary data, or update the page after dismissal.
+   */
   accessor onafterhide: CallbackEventListener<TTagName> | null;
+  /**
+   * A callback fired after the modal has fully opened and any entrance animation completes.
+   * Use to focus an input field or initialize content once the modal is visible.
+   */
   accessor onaftershow: CallbackEventListener<TTagName> | null;
   /** @private */
   [abortController]: AbortController;
@@ -175,17 +313,74 @@ declare abstract class ModalBase<TTagName extends keyof HTMLElementTagNameMap>
   /** @private */
   [rootActivator]: HTMLElement | null;
   /** @private */
-  [nestedModals]: Map<ModalBase<TTagName>, boolean>;
+  [nestedModals]: Map<HTMLElement, boolean>;
   /** @private */
   [childrenRerenderObserver]: MutationObserver;
   /** @private */
   [shadowDomRerenderObserver]: MutationObserver;
+  /**
+   * Focus trap keydown handler reference, stored for cleanup.
+   *
+   * The focus trap is managed imperatively here in ModalBase rather than
+   * via a Preact useEffect in foundation.tsx. This is because aftershow
+   * (fired after CSS animations complete) and useEffect (fired after
+   * Preact's async effect scheduling) are independent async chains with
+   * no synchronization — the useEffect could run before or after
+   * aftershow, making tests non-deterministic.
+   *
+   * By attaching the focus trap in the same .then() chain as aftershow,
+   * we guarantee it is active before aftershow dispatches.
+   *
+   * Lifecycle (mirrors the old useEffect's isActiveModal dependency):
+   * - Attached: in aftershow chain, right before aftershow dispatches
+   * - Detached: on dismiss(), disconnectedCallback(), or child modal open
+   * - Re-attached: when all child modals close
+   * @private
+   */
+  [focusTrapController]: AbortController | null;
+  /**
+   * Holds the in-flight document keyup suppressor below so a second Escape
+   * close replaces it instead of stacking another one.
+   * @private
+   */
+  [escapeKeyUpController]: AbortController | null;
   /** @private */
   [onEscape]: (event: KeyboardEvent) => void;
+  /** @private */
+  [onKeyUp]: (event: KeyboardEvent) => void;
+  /**
+   * Whether the most recent mousedown / mouseup on the dialog landed on the
+   * backdrop area (the `<dialog>` element itself, outside its content box)
+   * rather than inside the modal content.
+   *
+   * Used by [onBackdropClick] to distinguish a true backdrop click from a
+   * `click` event whose target is the dialog only because the user dragged
+   * across the content/backdrop boundary. Reset on every backdrop
+   * interaction (or when no click follows).
+   * @private
+   */
+  [backdropMouseDownOnDialog]: boolean;
+  /** @private */
+  [backdropMouseUpOnDialog]: boolean;
+  /** @private */
+  [onBackdropMouseDown]: (event: MouseEvent) => void;
+  /** @private */
+  [onBackdropMouseUp]: (event: MouseEvent) => void;
   /** @private */
   [onBackdropClick]: (event: MouseEvent) => void;
   /** @private */
   [onChildModalChange]: EventListenerOrEventListenerObject;
+  /**
+   * Ensures `this[dialog]` is set by synchronously querying the shadow DOM
+   * and attaching event listeners if needed.
+   * Works around a Safari timing issue where the MutationObserver callback
+   * (which normally sets `this[dialog]`) may not have fired yet when
+   * `show()` / `dismiss()` run — especially when `heading` or
+   * `accessibilityLabel` adds child custom-elements whose own lifecycle
+   * microtasks can delay the observer.
+   * @private
+   */
+  [ensureDialogRef](): void;
   /** @private */
   get [isOpen](): boolean;
   /** @private */
@@ -203,9 +398,13 @@ declare abstract class ModalBase<TTagName extends keyof HTMLElementTagNameMap>
   connectedCallback(): void;
   /** @private */
   disconnectedCallback(): void;
-  constructor(renderImpl: RenderImpl, tagName: string);
+  constructor(renderImpl: RenderImpl);
 }
 
+/**
+ * Configure the following properties on the modal component.
+ * @publicDocs
+ */
 declare class Modal extends ModalBase<typeof tagName> implements ModalProps {
   constructor();
 }
@@ -228,24 +427,36 @@ export interface ModalJSXProps
   extends Partial<ModalProps>,
     Pick<ModalProps$1, 'id' | 'children'> {
   /**
-   * The content of the Modal.
+   * The content displayed within the modal component, typically including form fields, information, or interactive elements.
    */
   children?: ComponentChildren;
   /**
-   * The primary action to perform.
+   * The main action button displayed in the modal footer, representing the primary action users should take.
    *
-   * Only a `Button` with a variant of `primary` is allowed.
+   * Only accepts a single button component with a `variant` of `primary`. This action should align with the modal's main purpose.
    */
   primaryAction?: ComponentChildren;
   /**
-   * The secondary actions to perform.
+   * Additional action buttons displayed in the modal footer, providing alternative or supporting actions.
    *
-   * Only `Button` elements with a variant of `secondary` or `auto` are allowed.
+   * Only accepts button components with a `variant` of `secondary` or `auto`. These are visually de-emphasized to establish clear hierarchy.
    */
   secondaryActions?: ComponentChildren;
+  /**
+   * A callback fired immediately when the modal starts to hide.
+   */
   onHide?: ((event: CallbackEvent<typeof tagName>) => void) | null;
+  /**
+   * A callback fired immediately when the modal starts to show.
+   */
   onShow?: ((event: CallbackEvent<typeof tagName>) => void) | null;
+  /**
+   * A callback fired when the modal is completely hidden, after any hide animations have completed.
+   */
   onAfterHide?: ((event: CallbackEvent<typeof tagName>) => void) | null;
+  /**
+   * A callback fired when the modal is completely shown, after any show animations have completed.
+   */
   onAfterShow?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
@@ -1,29 +1,43 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   MoneyFieldProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event with a strongly-typed currentTarget property for a specific HTML element.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A callback function that receives a strongly-typed event for a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -31,189 +45,133 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * The React-style event callback props for form field components.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's invoked when the user makes any changes in the field. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
+};
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles for the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a Preact component in a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's Preact elements into the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * The properties from an event that indicate how the user activated an element.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down when the event occurred.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on macOS) was held down when the event occurred.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down when the event occurred.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed when the event occurred. A value of 0 indicates the primary button (usually left), 1 indicates the middle button, and 2 indicates the secondary button (usually right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for influencing a programmatic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The base properties for an input element that participates in form submission.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/** @private */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the user makes any changes in the field.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the field is disabled, disallowing any interaction.
-   *
-   * @default false
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * An identifier for the field.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * An identifier for the field that's unique within the nearest containing form.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value for the field.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The base properties for form field elements that support labels, validation, and autocomplete.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -235,10 +193,10 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        * A hint as to the intended content of the field.
        *
        * When set to `on` (the default), this property indicates that the field should support
-       * autofill, but you don't have any more semantic information on the intended
+       * autofill, but you do not have any more semantic information on the intended
        * contents.
        *
-       * When set to `off`, you're indicating that this field contains sensitive
+       * When set to `off`, you are indicating that this field contains sensitive
        * information, or contents that are never saved, like one-time codes.
        *
        * Alternatively, you can provide value which describes the
@@ -253,58 +211,20 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/** @private */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * A callback that's invoked when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint as to the intended content of the field for autocomplete purposes.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value for the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * Additional descriptive text to display below the field that provides supplementary information.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * An error message to display below the field, indicating validation failure or other issues.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label to display for the field, describing what the user should enter.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * Controls the visibility of the label for accessibility purposes.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The placeholder text that's displayed inside the field when it's empty, providing a hint about expected input.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only, preventing edits while still allowing focus and selection.
-   *
-   * @default false
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before form submission.
-   *
-   * @default false
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
@@ -334,43 +254,36 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The required properties from the `MoneyFieldProps$1` definition. This type ensures all properties from the shared definition are marked as required.
+ * Represents the money field component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredMoneyFieldProps = Required<MoneyFieldProps$1>;
 /**
- * The properties for the money field component. These properties configure a specialized input field for entering monetary amounts with automatic currency formatting, decimal handling, and range validation.
- * @publicDocs
+ * Configure the following properties on the money field component.
  */
 export interface MoneyFieldProps
   extends Omit<PreactFieldProps, 'value'>,
-    Pick<RequiredMoneyFieldProps, 'max' | 'min'> {
-  /**
-   * The current monetary value for the field, represented as a string.
-   */
+    Pick<RequiredMoneyFieldProps, 'max' | 'min' | 'currencyCode'> {
   value: Required<MoneyFieldProps$1>['value'];
 }
 
-/**
- * The money field custom element class that renders a monetary input field in the Shopify admin interface. This component allows merchants to enter currency amounts with automatic formatting, decimal precision, and validation against minimum and maximum values.
- */
-declare class MoneyField
+declare abstract class MoneyFieldBase
   extends PreactFieldElement<MoneyFieldProps['autocomplete']>
-  implements MoneyFieldProps
+  implements Pick<MoneyFieldProps, 'max' | 'min' | 'currencyCode' | 'value'>
 {
-  /**
-   * The maximum monetary value allowed in the field.
-   */
   accessor max: MoneyFieldProps['max'];
-  /**
-   * The minimum monetary value allowed in the field.
-   */
   accessor min: MoneyFieldProps['min'];
-  /**
-   * The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency.
-   */
+  accessor currencyCode: MoneyFieldProps['currencyCode'];
   get value(): string;
   set value(value: string);
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the money field component.
+ * @publicDocs
+ */
+declare class MoneyField extends MoneyFieldBase implements MoneyFieldProps {
   constructor();
 }
 declare global {
@@ -381,20 +294,19 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: MoneyFieldJSXProps & PreactBaseElementProps<MoneyField>;
+      [tagName]: Omit<MoneyFieldJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<MoneyField>;
     }
   }
 }
 
 declare const tagName = 's-money-field';
-/**
- * The JSX props for the money field component. These properties extend `MoneyFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
- * @publicDocs
- */
 export interface MoneyFieldJSXProps
-  extends Partial<MoneyFieldProps>,
+  extends Partial<Omit<MoneyFieldProps, 'error' | 'details'>>,
     FieldReactProps<typeof tagName>,
-    Pick<MoneyFieldProps$1, 'id'> {}
+    Pick<MoneyFieldProps$1, 'id'>,
+    FieldSlotInternalReactProps {}
 
 export {MoneyField};
 export type {MoneyFieldJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -45,7 +40,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -62,7 +57,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -70,19 +65,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/Number.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Number.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 2.21.2 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Number.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Number.d.ts
@@ -1,0 +1,193 @@
+/** VERSION: 2.21.2 **/
+/* eslint-disable import/extensions */
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/member-ordering */
+
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
+/// <reference lib="DOM" />
+import type {
+  ComponentChildren,
+  TextProps,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+declare const typographyFontWeights: readonly [
+  'auto',
+  'base',
+  'medium',
+  'semibold',
+  'bold',
+];
+export type TypographyFontWeight = (typeof typographyFontWeights)[number];
+declare const bodyFontSizes: readonly [
+  'auto',
+  'small-200',
+  'small-100',
+  'small',
+  'base',
+  'large',
+  'large-100',
+];
+export type BodyFontSize = (typeof bodyFontSizes)[number];
+
+export type NumberFontSize = BodyFontSize;
+export type NumberFontWeight = TypographyFontWeight;
+export interface NumberProps
+  extends Required<Pick<TextProps, 'accessibilityVisibility' | 'dir'>> {
+  /**
+   * The semantic tone that's applied to the number, which changes its color to convey meaning.
+   *
+   * - `info`: Informational content or helpful tips (blue).
+   * - `success`: Positive outcomes or successful states (green).
+   * - `warning`: Important warnings about potential issues (orange).
+   * - `critical`: Urgent problems or destructive actions (red).
+   * - `auto`: Automatically determined based on context.
+   * - `neutral`: General information without specific intent (gray).
+   * - `caution`: Advisory notices that need attention (yellow).
+   *
+   * @default 'auto'
+   */
+  tone: Extract<
+    TextProps['tone'],
+    'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'caution' | 'critical'
+  >;
+  /**
+   * The color emphasis applied to the number.
+   *
+   * - `base`: Standard emphasis for numeric content.
+   * - `subdued`: Deemphasized color for secondary or supporting numeric content.
+   *
+   * @default 'base'
+   */
+  color: Extract<TextProps['color'], 'base' | 'subdued'>;
+  /**
+   * Font size of the number. The named values also apply their matching
+   * line-height and letter-spacing.
+   *
+   * @default 'auto'
+   */
+  fontSize: NumberFontSize;
+  /**
+   * Font weight of the number.
+   *
+   * @default 'auto'
+   */
+  fontWeight: NumberFontWeight;
+}
+
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+}
+
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
+ */
+export interface PreactBaseElementProps<TClass extends HTMLElement> {
+  /**
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
+   */
+  key?: preact.Key;
+  /**
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
+   */
+  ref?: preact.Ref<TClass>;
+  /**
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
+   */
+  slot?: Lowercase<string>;
+}
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
+ */
+export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
+  extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
+  children?: preact.ComponentChildren;
+}
+
+/**
+ * Configure the following properties on the number component.
+ * @publicDocs
+ */
+declare class Number extends PolarisCustomElement implements NumberProps {
+  accessor tone: NumberProps['tone'];
+  accessor color: NumberProps['color'];
+  accessor fontSize: NumberProps['fontSize'];
+  accessor fontWeight: NumberProps['fontWeight'];
+  accessor dir: NumberProps['dir'];
+  accessor accessibilityVisibility: NumberProps['accessibilityVisibility'];
+  constructor();
+}
+declare global {
+  interface HTMLElementTagNameMap {
+    [tagName]: Number;
+  }
+}
+declare module 'preact' {
+  namespace createElement.JSX {
+    interface IntrinsicElements {
+      [tagName]: NumberJSXProps & PreactBaseElementPropsWithChildren<Number>;
+    }
+  }
+}
+
+declare const tagName = 's-number';
+
+export interface NumberJSXProps
+  extends Partial<NumberProps>,
+    Pick<TextProps, 'id' | 'lang' | 'children'> {
+  /**
+   * The number to display. The component styles the value you pass in — typography, tone, and color — and renders it as given, so format and localize it yourself.
+   */
+  children?: ComponentChildren;
+}
+
+export {Number};
+export type {NumberJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Number.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Number.d.ts
@@ -3,12 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -45,7 +40,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -62,7 +57,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -70,19 +65,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField.d.ts
@@ -1,29 +1,43 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   NumberFieldProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event with a strongly-typed currentTarget property for a specific HTML element.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A callback function that receives a strongly-typed event for a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -31,189 +45,133 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * The React-style event callback props for form field components.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's invoked when the user makes any changes in the field. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
+};
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles for the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a Preact component in a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's Preact elements into the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * The properties from an event that indicate how the user activated an element.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down when the event occurred.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on macOS) was held down when the event occurred.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down when the event occurred.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed when the event occurred. A value of 0 indicates the primary button (usually left), 1 indicates the middle button, and 2 indicates the secondary button (usually right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for influencing a programmatic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The base properties for an input element that participates in form submission.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/** @private */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the user makes any changes in the field.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the field is disabled, disallowing any interaction.
-   *
-   * @default false
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * An identifier for the field.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * An identifier for the field that's unique within the nearest containing form.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value for the field.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The base properties for form field elements that support labels, validation, and autocomplete.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -235,10 +193,10 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        * A hint as to the intended content of the field.
        *
        * When set to `on` (the default), this property indicates that the field should support
-       * autofill, but you don't have any more semantic information on the intended
+       * autofill, but you do not have any more semantic information on the intended
        * contents.
        *
-       * When set to `off`, you're indicating that this field contains sensitive
+       * When set to `off`, you are indicating that this field contains sensitive
        * information, or contents that are never saved, like one-time codes.
        *
        * Alternatively, you can provide value which describes the
@@ -253,58 +211,20 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/** @private */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * A callback that's invoked when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint as to the intended content of the field for autocomplete purposes.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value for the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * Additional descriptive text to display below the field that provides supplementary information.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * An error message to display below the field, indicating validation failure or other issues.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label to display for the field, describing what the user should enter.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * Controls the visibility of the label for accessibility purposes.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The placeholder text that's displayed inside the field when it's empty, providing a hint about expected input.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only, preventing edits while still allowing focus and selection.
-   *
-   * @default false
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before form submission.
-   *
-   * @default false
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
@@ -334,8 +254,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the number field component. These properties configure a specialized input field for entering numeric values with support for validation, formatting, range constraints, and optimized mobile input modes.
- * @publicDocs
+ * Configure the following properties on the number field component.
  */
 export interface NumberFieldProps
   extends Omit<
@@ -348,51 +267,44 @@ export interface NumberFieldProps
         'inputMode' | 'max' | 'min' | 'prefix' | 'step' | 'suffix'
       >
     > {
-  /**
-   * The current value for the field, represented as a string.
-   */
   value: Required<NumberFieldProps$1>['value'];
+  /**
+   * The type of virtual keyboard to display on mobile devices.
+   *
+   * - `decimal`: Shows a numeric keyboard with a decimal point, suitable for prices or measurements.
+   * - `numeric`: Shows a numeric keyboard without a decimal point, suitable for whole numbers like quantities.
+   *
+   * Learn more about the [inputmode attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
+   *
+   * @default 'decimal'
+   */
+  inputMode: Required<NumberFieldProps$1>['inputMode'];
+}
+
+declare abstract class NumberFieldBase
+  extends PreactFieldElement<NumberFieldProps['autocomplete']>
+  implements
+    Pick<
+      NumberFieldProps,
+      'inputMode' | 'step' | 'max' | 'min' | 'prefix' | 'suffix' | 'value'
+    >
+{
+  get value(): string;
+  set value(value: string);
+  accessor inputMode: NumberFieldProps['inputMode'];
+  accessor step: NumberFieldProps['step'];
+  accessor max: NumberFieldProps['max'];
+  accessor min: NumberFieldProps['min'];
+  accessor prefix: NumberFieldProps['prefix'];
+  accessor suffix: NumberFieldProps['suffix'];
+  constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The number field custom element class that renders a numeric input field in the Shopify admin interface. This component allows merchants to enter numbers with automatic validation and prefix/suffix display.
+ * Configure the following properties on the number field component.
+ * @publicDocs
  */
-declare class NumberField
-  extends PreactFieldElement<NumberFieldProps['autocomplete']>
-  implements NumberFieldProps
-{
-  /**
-   * The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer).
-   */
-  get value(): string;
-  set value(value: string);
-  /**
-   * The input mode hint for mobile keyboards. Available values include:
-   * - `numeric`: Shows a numeric keypad optimized for entering numbers
-   * - `decimal`: Shows a numeric keypad with decimal point support
-   * - `tel`: Shows a telephone keypad
-   */
-  accessor inputMode: NumberFieldProps['inputMode'];
-  /**
-   * The granularity that the value must adhere to, or the keyword `any`. This controls the increment/decrement step size.
-   */
-  accessor step: NumberFieldProps['step'];
-  /**
-   * The maximum numeric value allowed in the field.
-   */
-  accessor max: NumberFieldProps['max'];
-  /**
-   * The minimum numeric value allowed in the field.
-   */
-  accessor min: NumberFieldProps['min'];
-  /**
-   * Text or content to display before the user's input, such as a currency symbol.
-   */
-  accessor prefix: NumberFieldProps['prefix'];
-  /**
-   * Text or content to display after the user's input, such as a unit of measurement.
-   */
-  accessor suffix: NumberFieldProps['suffix'];
+declare class NumberField extends NumberFieldBase implements NumberFieldProps {
   constructor();
 }
 declare global {
@@ -403,20 +315,19 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: NumberFieldJSXProps & PreactBaseElementProps<NumberField>;
+      [tagName]: Omit<NumberFieldJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<NumberField>;
     }
   }
 }
 
 declare const tagName = 's-number-field';
-/**
- * The JSX props for the number field component. These properties extend `NumberFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
- * @publicDocs
- */
 export interface NumberFieldJSXProps
-  extends Partial<NumberFieldProps>,
+  extends Partial<Omit<NumberFieldProps, 'error' | 'details'>>,
     Pick<NumberFieldProps$1, 'id'>,
-    FieldReactProps<typeof tagName> {}
+    FieldReactProps<typeof tagName>,
+    FieldSlotInternalReactProps {}
 
 export {NumberField};
 export type {NumberFieldJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
@@ -1,157 +1,125 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, OptionProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  OptionProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * Properties for rendering a single option within a select dropdown that users can choose from.
- * @publicDocs
+ * Represents a single option within a select component. Use only as a child of s-select components.
  */
 export interface OptionProps
   extends Required<
     Pick<OptionProps$1, 'disabled' | 'value' | 'selected' | 'defaultSelected'>
   > {}
 
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's content inside the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * CSS styles that will be applied to the shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
-}
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A single option within a select dropdown that users can choose.
+ * Represents a single option within a select component. Use only as a child of s-select components.
+ * @publicDocs
  */
-declare class Option extends PreactCustomElement implements OptionProps {
+declare class Option extends PolarisCustomElement implements OptionProps {
   /**
-   * Whether the option is currently selected.
+   * Whether the option is currently selected. Use this for controlled components where you manage the selection state.
    */
   accessor selected: OptionProps['selected'];
   /**
-   * Whether the option should be selected when it's first rendered.
+   * The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.
    */
   accessor defaultSelected: OptionProps['defaultSelected'];
   /**
-   * The value that's submitted with the form when this option is selected.
+   * The value submitted with the form when this checkbox is checked. If not specified, the default value is "on".
    */
   accessor value: OptionProps['value'];
   /**
-   * Whether the option is disabled and can't be selected.
+   * Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.
    */
   accessor disabled: OptionProps['disabled'];
   constructor();
@@ -170,15 +138,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-option';
-/**
- * Properties for using the option component in JSX with React-style props.
- * @publicDocs
- */
 export interface OptionJSXProps
   extends Partial<OptionProps>,
     Pick<OptionProps$1, 'id' | 'children'> {
   /**
-   * The content that's used as the option label, displayed in the dropdown list.
+   * The text or elements displayed as the option label, which identifies the selectable choice to users in a dropdown or selection list.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Option.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
@@ -1,151 +1,124 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, OptionGroupProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  OptionGroupProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * Properties for rendering a group of related options within a select dropdown, organized under a shared label.
- * @publicDocs
+ * Represents a group of options within a select component. Use only as a child of `s-select` components.
  */
 export interface OptionGroupProps
-  extends Required<Pick<OptionGroupProps$1, 'disabled' | 'label'>> {}
-
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  extends Required<Pick<OptionGroupProps$1, 'disabled' | 'label'>> {
   /**
-   * A function that renders the component's content inside the shadow root.
+   * Whether the options within this group can be selected or not.
+   *
+   * @default false
    */
-  ShadowRoot: (element: any) => ComponentChildren;
+  disabled: Required<OptionGroupProps$1>['disabled'];
   /**
-   * CSS styles that will be applied to the shadow DOM.
+   * The user-facing label for this group of options.
    */
-  styles?: Styles;
-};
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
+  label: Required<OptionGroupProps$1>['label'];
 }
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A group of related options within a select dropdown, displayed with a label.
+ * Represents a group of options within a select component. Use only as a child of `s-select` components.
+ * @publicDocs
  */
 declare class OptionGroup
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements OptionGroupProps
 {
-  /**
-   * Whether all options in the group are disabled and can't be selected.
-   */
   accessor disabled: OptionGroupProps['disabled'];
-  /**
-   * The text that describes what this group of options represents.
-   */
   accessor label: OptionGroupProps['label'];
   constructor();
 }
@@ -164,10 +137,6 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-option-group';
-/**
- * Properties for using the option group component in JSX with React-style props.
- * @publicDocs
- */
 export interface OptionGroupJSXProps
   extends Partial<OptionGroupProps>,
     Pick<OptionGroupProps$1, 'id' | 'children'> {

--- a/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OptionGroup.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
@@ -1,145 +1,109 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, OrderedListProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  OrderedListProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * The properties for the ordered list component. These properties define a numbered list of items with automatic numbering and proper list semantics.
- * @publicDocs
+ * Configure the following properties on the ordered list component.
  */
 export interface OrderedListProps extends OrderedListProps$1 {}
 
-/**
- * A string containing CSS styles.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * Optional CSS styles to apply to the shadow DOM.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object that represents the state of modifier keys and mouse button
- * during an activation event like a click.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta (Command on Mac, Windows key on PC) key was pressed.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * Options for customizing click behavior on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A custom element for displaying a numbered list of items with automatic numbering and proper list semantics. Use ordered list when the sequence or order of items matters, such as instructions, rankings, or step-by-step processes.
+ * Configure the following properties on the ordered list component.
+ * @publicDocs
  */
 declare class OrderedList
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements OrderedListProps
 {
   constructor();
@@ -159,15 +123,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-ordered-list';
-/**
- * The JSX properties for the ordered list component. These properties define how an ordered list is rendered in Preact or JSX.
- * @publicDocs
- */
 export interface OrderedListJSXProps
   extends Partial<OrderedListProps>,
     Pick<OrderedListProps$1, 'id'> {
   /**
-   * The items in the ordered list. Only list item components are accepted.
+   * The list entries displayed within the ordered list, where each item is numbered sequentially. Only accepts list item components as children. Each list item represents a single numbered entry in the sequence.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.38.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -12,31 +17,99 @@ import type {
   PreactCustomElement,
   RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
+/**
+ * Use as the outer wrapper of a page.
+ */
 export interface PageProps
   extends Required<Pick<PageProps$1, 'inlineSize' | 'heading'>> {
+  /**
+   * The inline size of the page
+   * - `base` corresponds to a set default inline size
+   * - `large` full width with whitespace
+   *
+   * @default 'base'
+   */
   inlineSize: Extract<PageProps$1['inlineSize'], 'base' | 'large' | 'small'>;
+  /**
+   * The main page heading
+   */
+  heading: Required<PageProps$1>['heading'];
 }
 
-/** Used when an element does not have children. * @publicDocs
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
-  /** Assigns a unique key to this element. */
+  /**
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
+   */
   key?: preact.Key;
-  /** Assigns a ref (generally from `useRef()`) to this element. */
+  /**
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
+   */
   ref?: preact.Ref<TClass>;
-  /** Assigns this element to a parent's slot. */
+  /**
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
+   */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 declare class PolarisCustomElement extends PreactCustomElement {
   constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
 }
 
 declare abstract class PageBase
@@ -52,6 +125,10 @@ declare abstract class PageBase
   disconnectedCallback(): void;
 }
 
+/**
+ * Use as the outer wrapper of a page.
+ * @publicDocs
+ */
 declare class Page extends PageBase implements PageProps {
   constructor();
 }
@@ -65,7 +142,11 @@ declare module 'preact' {
     interface IntrinsicElements {
       [tagName]: Omit<
         PageJSXProps,
-        'aside' | 'primaryAction' | 'secondaryActions' | 'breadcrumbActions'
+        | 'aside'
+        | 'primaryAction'
+        | 'secondaryActions'
+        | 'breadcrumbActions'
+        | 'supplementalStart'
       > &
         PreactBaseElementPropsWithChildren<Page>;
     }
@@ -77,7 +158,7 @@ export interface PageJSXProps
   extends Partial<PageProps>,
     Pick<PageProps$1, 'id' | 'children'> {
   /**
-   * The content of the Page.
+   * The main page content displayed within the page component, which serves as the primary container for the page's information and interface elements.
    */
   children?: ComponentChildren;
   /**
@@ -89,22 +170,26 @@ export interface PageJSXProps
   /**
    * The primary action for the page.
    *
-   * Only accepts a single `Button` component with a `variant` of `primary`.
+   * Only accepts a single button component with a `variant` of `primary`.
    *
    */
   primaryAction?: ComponentChildren;
   /**
-   * Secondary actions for the page.
+   * The secondary actions for the page.
    *
-   * Only accepts `ButtonGroup` and `Button` components with a `variant` of `secondary` or `auto`.
+   * Only accepts button group and button components with a `variant` of `secondary` or `auto`.
    */
   secondaryActions?: ComponentChildren;
   /**
-   * Navigations back actions for the page.
+   * The navigation back actions for the page.
    *
-   * Only accepts `Link` components.
+   * Only accepts link components.
    */
   breadcrumbActions?: ComponentChildren;
+  /**
+   * A slot for content that comes before the main content, such as an `s-banner`.
+   */
+  supplementalStart?: ComponentChildren;
 }
 
 export {Page};

--- a/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
@@ -1,16 +1,79 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, ParagraphProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  ParagraphProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+declare const typographyFontWeights: readonly [
+  'auto',
+  'base',
+  'medium',
+  'semibold',
+  'bold',
+];
+export type TypographyFontWeight = (typeof typographyFontWeights)[number];
+declare const bodyFontSizes: readonly [
+  'auto',
+  'small-200',
+  'small-100',
+  'small',
+  'base',
+  'large',
+  'large-100',
+];
+export type BodyFontSize = (typeof bodyFontSizes)[number];
+
+export type ParagraphFontSize = BodyFontSize;
+export type ParagraphFontWeight = TypographyFontWeight;
 /**
- * The properties for the paragraph component. These properties define blocks of text content with consistent spacing and styling for readable body copy.
- * @publicDocs
+ * Configure the following properties on the paragraph component.
  */
 export interface ParagraphProps
   extends Required<
@@ -24,6 +87,7 @@ export interface ParagraphProps
       | 'lineClamp'
     >
   > {
+  color: Extract<ParagraphProps$1['color'], 'base' | 'subdued'>;
   /**
    * The semantic tone that's applied to the paragraph text, which changes its color to convey meaning.
    *
@@ -35,173 +99,106 @@ export interface ParagraphProps
    */
   tone: Extract<
     ParagraphProps$1['tone'],
-    'info' | 'success' | 'caution' | 'warning' | 'critical'
+    'auto' | 'neutral' | 'info' | 'success' | 'caution' | 'warning' | 'critical'
   >;
   /**
-   * The color of the paragraph text. Available options:
-   * - `'base'` - The default text color.
-   * - `'subdued'` - A lighter text color for secondary information.
-   */
-  color: Extract<ParagraphProps$1['color'], 'base' | 'subdued'>;
-}
-
-/**
- * A string containing CSS styles.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * Optional CSS styles to apply to the shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * An object that represents the state of modifier keys and mouse button
- * during an activation event like a click.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta (Command on Mac, Windows key on PC) key was pressed.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * Options for customizing click behavior on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
-  /** @private */
-  connectedCallback(): void;
-  /** @private */
-  disconnectedCallback(): void;
-  /** @private */
-  adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
+   * Font size of the paragraph. The named values also apply their matching
+   * line-height and letter-spacing.
    *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
+   * @default 'auto'
    */
-  click({sourceEvent}?: ClickOptions): void;
+  fontSize: ParagraphFontSize;
+  /**
+   * Font weight of the paragraph.
+   *
+   * @default 'auto'
+   */
+  fontWeight: ParagraphFontWeight;
+  /**
+   * @deprecated Use `Number` for inline numeric values instead.
+   */
+  fontVariantNumeric: Extract<
+    ParagraphProps$1['fontVariantNumeric'],
+    'auto' | 'normal' | 'tabular-nums'
+  >;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/**
- * A custom element for displaying blocks of text content with consistent spacing and styling for readable body copy. Use Paragraph to render longer text content with proper line height and spacing between paragraphs.
- */
-declare class Paragraph extends PreactCustomElement implements ParagraphProps {
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+}
+
+declare abstract class ParagraphBase
+  extends PolarisCustomElement
+  implements
+    Pick<
+      ParagraphProps,
+      | 'fontVariantNumeric'
+      | 'fontSize'
+      | 'fontWeight'
+      | 'lineClamp'
+      | 'color'
+      | 'dir'
+      | 'accessibilityVisibility'
+    >
+{
+  accessor fontSize: ParagraphProps['fontSize'];
+  accessor fontWeight: ParagraphProps['fontWeight'];
   /**
-   * The numeric font variant for the paragraph text.
+   * @deprecated Use `Number` for inline numeric values instead.
    */
   accessor fontVariantNumeric: ParagraphProps['fontVariantNumeric'];
-  /**
-   * The maximum number of lines to display before the text is truncated with an ellipsis.
-   */
   accessor lineClamp: ParagraphProps['lineClamp'];
-  /**
-   * The semantic tone that's applied to the paragraph text, which changes its color to convey meaning.
-   *
-   * - `info`: Informational content or helpful tips (blue).
-   * - `success`: Positive outcomes or successful states (green).
-   * - `warning`: Important warnings about potential issues (orange).
-   * - `critical`: Urgent problems or destructive actions (red).
-   * - `caution`: Advisory notices that need attention (yellow).
-   */
-  accessor tone: ParagraphProps['tone'];
-
-  /**
-   * The color of the paragraph text.
-   */
+  abstract tone: string;
   accessor color: ParagraphProps['color'];
-  /**
-   * The text direction (left-to-right or right-to-left).
-   */
   accessor dir: ParagraphProps['dir'];
-  /**
-   * The visibility of the element to assistive technologies.
-   */
   accessor accessibilityVisibility: ParagraphProps['accessibilityVisibility'];
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the paragraph component.
+ * @publicDocs
+ */
+declare class Paragraph extends ParagraphBase implements ParagraphProps {
+  accessor tone: ParagraphProps['tone'];
   constructor();
 }
 declare global {
@@ -219,15 +216,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-paragraph';
-/**
- * The JSX properties for the paragraph component. These properties define how a paragraph is rendered in Preact or JSX.
- * @publicDocs
- */
 export interface ParagraphJSXProps
   extends Partial<ParagraphProps>,
     Pick<ParagraphProps$1, 'id' | 'children'> {
   /**
-   * The content of the paragraph.
+   * The paragraph text content displayed within the paragraph component, which presents a block of related text with appropriate styling.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
@@ -1,226 +1,177 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   PasswordFieldProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event object with a strongly-typed currentTarget property that references the specific HTML element type.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The DOM element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function or null that receives a typed callback event.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
-      /**
-       * The callback function that's invoked when the event fires.
-       */
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * The React-style event handler props for form field components.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's triggered when the field's value changes as the user types.
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field's value changes and the field loses focus.
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field receives focus.
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field loses focus.
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
+};
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles to be applied to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object containing information about keyboard and mouse button states during an activation event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta (Command on Mac, Windows key on PC) key was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the event.
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for programmatically triggering a click event on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The required props for input elements that all form controls must implement.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/**
- * The base class for form input elements that participate in form submission.
- */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
-  /** @private */
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * The callback that's triggered when the input value changes and the field loses focus.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * The callback that's triggered when the input value changes as the user types.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the input is disabled and can't be interacted with.
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * The unique identifier for the input element.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * The name of the input, used when submitting form data.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value of the input.
-   */
   get value(): PreactInputProps['value'];
-  /**
-   * The current value of the input.
-   */
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The common props shared by all form field components in the admin UI.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -239,17 +190,17 @@ export type PreactFieldProps<Autocomplete extends string = string> =
       >
     > & {
       /**
-       * A hint about the intended content of the field for browser autofill.
+       * A hint as to the intended content of the field.
        *
        * When set to `on` (the default), this property indicates that the field should support
-       * autofill, but you don't have any more semantic information on the intended
+       * autofill, but you do not have any more semantic information on the intended
        * contents.
        *
-       * When set to `off`, you're indicating that this field contains sensitive
+       * When set to `off`, you are indicating that this field contains sensitive
        * information, or contents that are never saved, like one-time codes.
        *
-       * Alternatively, you can provide a value which describes the
-       * specific data you'd like to be entered into this field during autofill.
+       * Alternatively, you can provide value which describes the
+       * specific data you would like to be entered into this field during autofill.
        *
        * @see Learn more about the set of {@link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens|autocomplete values} supported in browsers.
        *
@@ -260,63 +211,27 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/**
- * The base class for form field elements that includes label, error, and validation support.
- */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * The callback that's triggered when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * The callback that's triggered when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint about the intended content of the field for browser autofill.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value of the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * The additional text displayed below the field to provide helpful context.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * The error message displayed when the field validation fails.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label displayed above the field.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * The visibility of the label for accessibility purposes. Available values: `hidden`, `visible`.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The hint text displayed inside the field when it's empty.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only and can't be edited by the user.
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before the form can be submitted.
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
    * ignore keystrokes originating from within input elements. Unfortunately,
-   * these never account for a custom element being the input element.
+   * these never account for a Custom Element being the input element.
    *
-   * To fix this, we spoof getAttribute and hasAttribute to make a PreactFieldElement
+   * To fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement
    * appear as a contentEditable "input" when it contains a focused input element.
    * @private technically not private, but we don't want to expose this as public API
    */
@@ -326,8 +241,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
    */
   hasAttribute(qualifiedName: string): boolean;
   /**
-   * Checks if the shadow tree contains a focused input (input, textarea, select, contentEditable element).
-   * Note: this doesn't return true for focused non-field form elements like buttons.
+   * Checks if the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).
+   * Note: this does _not_ return true for focussed non-field form elements like buttons.
    * @private
    */
   get isContentEditable(): boolean;
@@ -339,7 +254,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the password field component. These properties configure a secure input field that collects sensitive password input from merchants with masked characters.
+ * Represents the props for password input field components. Extends `PreactFieldProps` with autocomplete support for password-related fields.
  * @publicDocs
  */
 export type PasswordFieldProps = PreactFieldProps<
@@ -364,26 +279,23 @@ export type PasswordFieldProps = PreactFieldProps<
     >
   >;
 
+declare abstract class PasswordFieldBase
+  extends PreactFieldElement<PasswordFieldProps['autocomplete']>
+  implements Pick<PasswordFieldProps, 'maxLength' | 'minLength'>
+{
+  accessor maxLength: PasswordFieldProps['maxLength'];
+  accessor minLength: PasswordFieldProps['minLength'];
+  constructor(renderImpl: RenderImpl);
+}
+
 /**
- * The password field custom element class that renders a password input field in the Shopify admin interface. This component allows merchants to enter passwords securely with characters automatically masked for privacy.
+ * Configure the following properties on the password field component.
+ * @publicDocs
  */
 declare class PasswordField
-  extends PreactFieldElement<PasswordFieldProps['autocomplete']>
+  extends PasswordFieldBase
   implements PasswordFieldProps
 {
-  /**
-   * The maximum number of characters allowed in the password.
-   */
-  accessor maxLength: PasswordFieldProps['maxLength'];
-  /**
-   * The minimum number of characters required in the password.
-   */
-  accessor minLength: PasswordFieldProps['minLength'];
-  /**
-   * The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security.
-   */
-  get value(): string;
-  set value(value: string);
   constructor();
 }
 declare global {
@@ -394,20 +306,19 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: PasswordFieldJSXProps & PreactBaseElementProps<PasswordField>;
+      [tagName]: Omit<PasswordFieldJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<PasswordField>;
     }
   }
 }
 
 declare const tagName = 's-password-field';
-/**
- * The JSX props for the password field component. These properties extend `PasswordFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
- * @publicDocs
- */
 export interface PasswordFieldJSXProps
-  extends Partial<PasswordFieldProps>,
+  extends Partial<Omit<PasswordFieldProps, 'error' | 'details'>>,
     Pick<PasswordFieldProps$1, 'id'>,
-    FieldReactProps<typeof tagName> {}
+    FieldReactProps<typeof tagName>,
+    FieldSlotInternalReactProps {}
 
 export {PasswordField};
 export type {PasswordFieldJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -45,7 +40,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -62,7 +57,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -70,19 +65,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/Popover.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Popover.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 2.19.1 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -44,6 +49,11 @@ export type CallbackToggleEvent<
  * A function that handles events from UI components.
  *
  * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -223,6 +233,19 @@ declare class PreactOverlayElement extends PolarisCustomElement {
 export type MakeResponsive<T> = T | `@container${string}`;
 /**
  * Makes a property's value potentially responsive.
+ *
+ * @example
+ * type Example = {
+ *   color: boolean;
+ *   margin: string;
+ *   padding: number;
+ * }
+ * type Result = MakeResponsivePick<Example, 'color' | 'margin' | 'padding'>;
+ * // Result = {
+ *   color: boolean | `@container${string}`;
+ *   margin: string | `@container${string}`;
+ *   padding: number | `@container${string}`;
+ * }
  * @publicDocs
  */
 export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
@@ -370,7 +393,7 @@ export interface BoxProps
    *
    * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -382,7 +405,7 @@ export interface BoxProps
    *
    * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -390,7 +413,7 @@ export interface BoxProps
   /**
    * The block-start padding (top in horizontal writing modes).
    *
-   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -398,7 +421,7 @@ export interface BoxProps
   /**
    * The block-end padding (bottom in horizontal writing modes).
    *
-   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -410,7 +433,7 @@ export interface BoxProps
    *
    * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -418,7 +441,7 @@ export interface BoxProps
   /**
    * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -426,7 +449,7 @@ export interface BoxProps
   /**
    * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Popover.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Popover.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer.d.ts
@@ -1,157 +1,130 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, QueryContainerProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  QueryContainerProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+}
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
-};
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
-}
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
-  /** @private */
-  connectedCallback(): void;
-  /** @private */
-  disconnectedCallback(): void;
-  /** @private */
-  adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
-}
-
-/**
- * The properties you can set on a query container component.
- * @publicDocs
+ * Configure the following properties on the query container component.
  */
 export interface QueryContainerProps
-  extends Required<Pick<QueryContainerProps$1, 'id' | 'containerName'>> {}
+  extends Required<Pick<QueryContainerProps$1, 'id' | 'containerName'>> {
+  /**
+   * An identifier for this container that you can reference in CSS container queries to apply styles based on this specific container's size.
+   *
+   * All query container components automatically receive a container name of `s-default`. You can omit the container name in your queries, so `@container (inline-size <= 300px)` is equivalent to `@container s-default (inline-size <= 300px)`.
+   *
+   * When you provide a custom `containerName`, it's added alongside `s-default`. For example, `containerName="product-card"` results in `s-default product-card` being set on the `container-name` CSS property, allowing you to target this container with `@container product-card (inline-size <= 300px)`.
+   *
+   * Learn more about the [container-name property](https://developer.mozilla.org/en-US/docs/Web/CSS/container-name).
+   *
+   * @default ''
+   *
+   * @implementation You must always have a CSS `container-name` of `s-default` for this component.
+   */
+  containerName: Required<QueryContainerProps$1>['containerName'];
+}
 
 /**
- * A component that sets up a container query context, which lets child elements style themselves based on the container's size instead of the viewport size.
+ * Configure the following properties on the query container component.
+ * @publicDocs
  */
 declare class QueryContainer
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements QueryContainerProps
 {
-  /**
-   * The name of the container, which you can reference in CSS container queries.
-   */
   accessor containerName: QueryContainerProps['containerName'];
   /** @private */
   static globalStylesApplied: boolean;
-  /**
-   * Creates a new QueryContainer instance.
-   */
   constructor();
 }
 declare global {
@@ -168,19 +141,12 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the query container component.
- */
 declare const tagName = 's-query-container';
-/**
- * The JSX properties you can set on a query container component.
- * @publicDocs
- */
 export interface QueryContainerJSXProps
   extends Partial<QueryContainerProps$1>,
     Pick<QueryContainerProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the container.
+   * The content displayed within the query container component, which enables container queries for responsive styling based on the container's size rather than the viewport.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
@@ -1,25 +1,42 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {TextFieldProps, ComponentChildren} from './shared.d.ts';
+import type {
+  TextFieldProps,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event that includes a strongly-typed reference to the element that triggered it.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event handler was attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A function that handles events for a specific element type, or null if no handler is set.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -27,190 +44,133 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * Event handlers for field interactions in React-style syntax.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's triggered when the field's value changes as the user types.
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field's value changes and the field loses focus.
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field receives focus.
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field loses focus.
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
-/** Used when an element does not have children. * @publicDocs
+};
+/**
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's content inside the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * CSS styles that will be applied to the shadow DOM.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The core properties that all input elements need to function within forms.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/**
- * Base class for input elements that participate in form submission.
- */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
-  /**
-   * Indicates that this element can participate in form submission.
-   */
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's triggered when the input's value changes and the field loses focus.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's triggered when the input's value changes as the user types.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the input is disabled and can't be interacted with.
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * A unique identifier for the input element.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * The name that identifies this input when the form is submitted.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value of the input.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * Properties that are common to all text-based field components.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -250,56 +210,20 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/**
- * Base class for text-based field elements that support labels, errors, and other form field features.
- */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * A callback that's triggered when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * A callback that's triggered when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint about what kind of information should go in the field for autofill purposes.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value that the field should display when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * Additional text to provide context or guidance for the input.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * An error message that's displayed below the field when validation fails.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text that describes what the field is for.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * Controls whether the label is visible to all users or only to screen readers.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * Text that appears in the field when it's empty to provide a hint about what to enter.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field can be edited by the user.
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled in before the form can be submitted.
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
@@ -329,7 +253,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * Properties for rendering a search field that lets users enter search queries with validation constraints and autofill support.
+ * Represents the props for search input field components. Extends `PreactFieldProps` for search-specific functionality.
  * @publicDocs
  */
 export type SearchFieldProps = PreactFieldProps<
@@ -357,26 +281,20 @@ export type SearchFieldProps = PreactFieldProps<
     >
   >;
 
-/**
- * A search field that lets users enter search queries with a search-specific input type.
- */
-declare class SearchField
+declare abstract class SearchFieldBase
   extends PreactFieldElement<SearchFieldProps['autocomplete']>
-  implements SearchFieldProps
+  implements Pick<SearchFieldProps, 'maxLength' | 'minLength'>
 {
-  /**
-   * The maximum number of characters that can be entered in the field.
-   */
   accessor maxLength: SearchFieldProps['maxLength'];
-  /**
-   * The minimum number of characters that must be entered for the field to be valid.
-   */
   accessor minLength: SearchFieldProps['minLength'];
-  /**
-   * The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.
-   */
-  get value(): string;
-  set value(value: string);
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the search field component.
+ * @publicDocs
+ */
+declare class SearchField extends SearchFieldBase implements SearchFieldProps {
   constructor();
 }
 declare global {
@@ -387,20 +305,19 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: SearchFieldJSXProps & PreactBaseElementProps<SearchField>;
+      [tagName]: Omit<SearchFieldJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<SearchField>;
     }
   }
 }
 
 declare const tagName = 's-search-field';
-/**
- * Props for using the search field component in JSX with React-style event handlers.
- * @publicDocs
- */
 export interface SearchFieldJSXProps
-  extends Partial<SearchFieldProps>,
+  extends Partial<Omit<SearchFieldProps, 'error' | 'details'>>,
     Pick<TextFieldProps, 'id'>,
-    FieldReactProps<typeof tagName> {}
+    FieldReactProps<typeof tagName>,
+    FieldSlotInternalReactProps {}
 
 export {SearchField};
 export type {SearchFieldJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -44,7 +39,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -61,7 +56,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -69,19 +64,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
@@ -1,8 +1,14 @@
-/** VERSION: 2.21.2 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section.d.ts
@@ -1,20 +1,57 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.21.2 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, SectionProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  SectionProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * A version of the section properties with all fields required.
+ * Represents the section component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredSectionProps = Required<SectionProps$1>;
 /**
- * The properties for the section component. A section groups related content together with an optional heading, providing semantic structure and visual separation.
- * @publicDocs
+ * Configure the following properties on the section component.
  */
 export interface SectionProps
   extends Pick<
@@ -22,162 +59,97 @@ export interface SectionProps
     'accessibilityLabel' | 'heading' | 'padding'
   > {
   /**
-   * An accessibility label for screen readers that provides additional context when the heading isn't descriptive enough on its own.
+   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
    */
   accessibilityLabel: RequiredSectionProps['accessibilityLabel'];
   /**
-   * The heading text that appears at the top of the section, helping users understand what content the section contains.
+   * The heading text displayed at the top of the section. This heading provides a title for the section's content and automatically uses the appropriate semantic heading level (h2, h3, h4) based on nesting depth to maintain proper document structure.
    */
   heading: RequiredSectionProps['heading'];
   /**
-   * Whether the section has padding around its content. Set to `true` to add padding, or `false` to remove it.
+   * Supporting text that expands on the heading, rendered beneath it in a subdued treatment.
+   *
+   * This is not a heading: it adds no entry to the document outline, doesn't change the heading level of the section's children, and isn't announced as part of the heading. Keep whatever distinguishes this section from another in `heading`, since that is what someone navigating by heading hears.
+   */
+  subheading: string;
+  /**
+   * The padding applied to all edges of the element's content.
+   *
+   * - `base`: applies padding that is appropriate for the element. Note that it might result in no padding if
+   * this is the right design decision in a particular context.
+   * - `none`: removes all padding from the element's content. This can be useful when elements inside the section
+   * need to span to the edge of the section. For example, a full-width image. In this case, rely on `s-box` with a
+   * padding of 'base' to bring back the desired padding for the rest of the content. The `heading` and header
+   * actions keep their padding, so they can be combined with `none`.
+   *
+   * @default 'base'
    */
   padding: RequiredSectionProps['padding'];
 }
 
 /**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * An interface representing the properties of an activation event, such as a click or keypress.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on PC) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
-  /** @private */
-  connectedCallback(): void;
-  /** @private */
-  disconnectedCallback(): void;
-  /** @private */
-  adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
-}
-
-/**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/**
- * A section is a container that groups related content together with an optional heading.
- */
-declare class Section extends PreactCustomElement implements SectionProps {
-  constructor();
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
-  /**
-   * The accessibility label for screen readers.
-   */
+  /** @private */
+  adoptedCallback(): void;
+}
+
+declare abstract class SectionBase
+  extends PolarisCustomElement
+  implements SectionProps
+{
+  constructor(renderImpl: RenderImpl);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  disconnectedCallback(): void;
   accessor accessibilityLabel: SectionProps['accessibilityLabel'];
-  /**
-   * The heading text for the section.
-   */
   accessor heading: SectionProps['heading'];
-  /**
-   * Whether the section has padding.
-   */
+  accessor subheading: SectionProps['subheading'];
   accessor padding: SectionProps['padding'];
+}
+
+/**
+ * Configure the following properties on the section component.
+ * @publicDocs
+ */
+declare class Section extends SectionBase implements SectionProps {
+  constructor();
 }
 declare global {
   interface HTMLElementTagNameMap {
@@ -187,23 +159,55 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: SectionJSXProps & PreactBaseElementPropsWithChildren<Section>;
+      [tagName]: Omit<
+        SectionJSXProps,
+        | 'primaryAction'
+        | 'secondaryActions'
+        | 'graphic'
+        | 'accessory'
+        | 'supplemental'
+      > &
+        PreactBaseElementPropsWithChildren<Section>;
     }
   }
 }
 
 declare const tagName = 's-section';
-/**
- * The properties for the section component when it's used in JSX.
- * @publicDocs
- */
 export interface SectionJSXProps
   extends Partial<SectionProps>,
     Pick<SectionProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the section.
+   * The content displayed within the section component, which groups related elements together in a logical unit with an optional heading.
    */
   children?: ComponentChildren;
+  /**
+   * The primary action button or link, representing the main or most important action available in this context. Typically displayed with higher visual prominence than secondary actions to establish clear hierarchy.
+   */
+  primaryAction?: ComponentChildren;
+  /**
+   * Additional action buttons or links that provide alternative or supporting actions. Visually de-emphasized compared to the primary action.
+   *
+   * A ButtonGroup holding an action and the icon-only activator for its Menu renders as one segmented group with a chevron activator. The group needs an `accessibilityLabel`, and must hold exactly one Button with text followed by one Button with no text that has an `accessibilityLabel` and a `commandFor` opening a Menu, both with a `variant` of `secondary` or `auto`.
+   */
+  secondaryActions?: ComponentChildren;
+  /**
+   * A decorative visual that reinforces the heading, rendered before it.
+   *
+   * Accepts a single icon-only Badge (`icon` set, no text content) with a `size` of `large`. The heading identifies the section, so this content is not announced by assistive technologies, and it is not rendered at all when the section has no `heading`.
+   */
+  graphic?: ComponentChildren;
+  /**
+   * Additional contextual information that qualifies the heading, rendered inline beside the heading text.
+   *
+   * Only accepts Badge, Icon, Button, Menu, Text, Avatar, and Thumbnail elements. Text must use `tone`, `fontSize`, and `fontWeight` of `auto`; Icon, Avatar, and Thumbnail must use `size="base"`; Badge must use `size="base"` and `color="base"`; Button must use `inlineSize="auto"`.
+   */
+  accessory?: ComponentChildren;
+  /**
+   * Status or metadata that describes the section as a whole rather than qualifying its heading, rendered at the inline-end of the header before any actions.
+   *
+   * This is not an action. Only accepts Badge, Avatar, Text, Icon, and Thumbnail elements, under the same prop constraints as `accessory`.
+   */
+  supplemental?: ComponentChildren;
 }
 
 export {Section};

--- a/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -55,19 +50,19 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select.d.ts
@@ -1,9 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -11,21 +16,31 @@ import type {
   TextFieldProps,
   IconProps$1,
   SelectProps$1,
+  PreactCustomElement,
+  RenderImpl,
   IconType,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event that includes a strongly-typed reference to the element that triggered it.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event handler was attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A function that handles events for a specific element type, or null if no handler is set.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -33,205 +48,176 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
-/** Used when an element has children. * @publicDocs
+/**
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
+ * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's content inside the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * CSS styles that will be applied to the shadow DOM.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The core properties that all input elements need to function within forms.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/**
- * Base class for input elements that participate in form submission.
- */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
-  /**
-   * Indicates that this element can participate in form submission.
-   */
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's triggered when the input's value changes and the field loses focus.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's triggered when the input's value changes as the user types.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the input is disabled and can't be interacted with.
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * A unique identifier for the input element.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * The name that identifies this input when the form is submitted.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value of the input.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * Properties for displaying an icon within a component.
- * @publicDocs
+ * Configure the following properties on the icon component.
  */
 export interface IconProps
-  extends Pick<
-    IconProps$1,
-    'type' | 'tone' | 'color' | 'size' | 'interestFor'
+  extends Required<
+    Pick<IconProps$1, 'type' | 'tone' | 'color' | 'size' | 'interestFor'>
   > {
   /**
-   * Specifies the type of icon that will be displayed.
+   * The icon to display from the icon library.
+   *
+   * Set to a valid icon name to display that icon. To hide the icon completely,
+   * use an empty string `''`. To reserve the icon's space without displaying an icon,
+   * use `'empty'`.
    */
   type: '' | IconType | 'empty';
   /**
-   * The semantic meaning of the icon, which affects its color.
+   * The semantic meaning and color treatment of the component.
+   *
+   * - `info`: Informational content or helpful tips.
+   * - `success`: Positive outcomes or successful states.
+   * - `warning`: Important warnings about potential issues.
+   * - `critical`: Urgent problems or destructive actions.
+   * - `auto`: Automatically determined based on context.
+   * - `neutral`: General information without specific intent.
+   * - `caution`: Advisory notices that need attention.
+   *
+   * @default 'auto'
    */
   tone: Extract<
     IconProps$1['tone'],
     'auto' | 'neutral' | 'info' | 'success' | 'caution' | 'warning' | 'critical'
   >;
   /**
-   * The visual prominence of the icon.
+   * The color emphasis level that controls visual intensity.
+   *
+   * - `base`: Primary color for body text, standard UI elements, and general content with good readability.
+   * - `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.
+   *
+   * @default 'base'
    */
   color: Extract<IconProps$1['color'], 'base' | 'subdued'>;
   /**
    * The size of the icon.
+   *
+   * - `small`: Smaller icon suitable for inline use within text or compact UI elements.
+   * - `base`: Default size that works well for standalone icons and standard use cases.
    */
   size: Extract<IconProps$1['size'], 'small' | 'base'>;
 }
 
 /**
- * Properties for rendering a select dropdown that lets users choose one option from a list with optional icon and label customization.
- * @publicDocs
+ * Configure the following properties on the select component.
  */
 export interface SelectProps
   extends Omit<PreactInputProps, 'value'>,
@@ -249,59 +235,39 @@ export interface SelectProps
         | 'labelAccessibilityVisibility'
       >
     > {
-  /**
-   * The value of the currently selected option, matching one of the `value` properties from the available options.
-   */
   value: Required<SelectProps$1>['value'];
-  /**
-   * An icon that's displayed at the start of the select field to provide visual context for the selection.
-   */
   icon: IconProps['type'];
 }
 
 declare const usedFirstOptionSymbol: unique symbol;
 declare const hasInitialValueSymbol: unique symbol;
 
-/**
- * A select dropdown that lets users choose one option from a list.
- */
-declare class Select extends PreactInputElement implements SelectProps {
-  /**
-   * An icon that's displayed at the start of the select field.
-   */
+declare abstract class SelectBase
+  extends PreactInputElement
+  implements
+    Pick<
+      SelectProps,
+      | 'icon'
+      | 'details'
+      | 'error'
+      | 'label'
+      | 'placeholder'
+      | 'required'
+      | 'labelAccessibilityVisibility'
+    >
+{
   accessor icon: SelectProps['icon'];
-  /**
-   * Additional text to provide context or guidance for the select.
-   */
   accessor details: SelectProps['details'];
-  /**
-   * An error message that's displayed below the select when validation fails.
-   */
   accessor error: SelectProps['error'];
-  /**
-   * The text that describes what the select is for.
-   */
   accessor label: SelectProps['label'];
-  /**
-   * Text that appears in the select when no option is selected to provide a hint about what to choose.
-   */
   accessor placeholder: SelectProps['placeholder'];
-  /**
-   * Whether an option must be selected before the form can be submitted.
-   */
   accessor required: SelectProps['required'];
-  /**
-   * Controls whether the label is visible to all users or only to screen readers.
-   */
   accessor labelAccessibilityVisibility: SelectProps['labelAccessibilityVisibility'];
   /** @private */
   connectedCallback(): void;
-  /**
-   * A lifecycle callback that fires when the component is removed from the DOM. Performs cleanup operations.
-   * @private
-   */
+  /** @private */
   disconnectedCallback(): void;
-  constructor();
+  constructor(renderImpl: RenderImpl);
   /**
    * used to determine if no value or defaultValue was set, in which case the first non-disabled option was used
    *
@@ -313,13 +279,18 @@ declare class Select extends PreactInputElement implements SelectProps {
    * @private
    */
   [hasInitialValueSymbol]: boolean;
-  /**
-   * The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected Option component.
-   */
   get value(): string;
   set value(value: string);
   /** @private */
   formResetCallback(): void;
+}
+
+/**
+ * Configure the following properties on the select component.
+ * @publicDocs
+ */
+declare class Select extends SelectBase implements SelectProps {
+  constructor();
 }
 declare global {
   interface HTMLElementTagNameMap {
@@ -329,40 +300,25 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: SelectJSXProps & PreactBaseElementPropsWithChildren<Select>;
+      [tagName]: Omit<SelectJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementPropsWithChildren<Select>;
     }
   }
 }
 
 declare const tagName = 's-select';
-/**
- * Properties for using the select component in JSX with React-style event handlers.
- * @publicDocs
- */
 export interface SelectJSXProps
-  extends Partial<SelectProps>,
-    Pick<SelectProps$1, 'id' | 'children'> {
+  extends Partial<Omit<SelectProps, 'error' | 'details'>>,
+    Pick<SelectProps$1, 'id' | 'children'>,
+    FieldSlotInternalReactProps {
   /**
-   * The selectable options displayed in the dropdown list.
-   *
-   * Accepts option components for individual selectable items, and option group components to organize related options into logical groups with labels.
+   * The selectable options displayed in the dropdown list. Accepts option components for individual selectable items, and option group components to organize related options into logical groups with labels.
    */
   children?: ComponentChildren;
-  /**
-   * A callback that's triggered when the selected option changes and the select loses focus.
-   */
   onChange?: (event: CallbackEvent<typeof tagName>) => void;
-  /**
-   * A callback that's triggered when the selected option changes as the user interacts with the dropdown.
-   */
   onInput?: (event: CallbackEvent<typeof tagName>) => void;
-  /**
-   * A callback that's triggered when the select loses focus after the user interacts with it.
-   */
   onBlur?: (event: CallbackEvent<typeof tagName>) => void;
-  /**
-   * A callback that's triggered when the select receives focus from the user.
-   */
   onFocus?: (event: CallbackEvent<typeof tagName>) => void;
 }
 

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
@@ -1,153 +1,112 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {SpinnerProps$1, ComponentChildren} from './shared.d.ts';
+import type {
+  SpinnerProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The properties you can set on a spinner component.
- * @publicDocs
+ * Configure the following properties on the spinner component.
  */
 export interface SpinnerProps
   extends Required<Pick<SpinnerProps$1, 'accessibilityLabel'>> {
   /**
-   * The size of the spinner. Use `base` for the standard size, `large` for a larger spinner, or `large-100` for a full-width large spinner.
+   * The size of the loading spinner.
+   *
+   * - `base`: Default size suitable for inline loading indicators or standard UI contexts.
+   * - `large`: Larger spinner for more prominent loading states.
+   * - `large-100`: Extra large spinner for full-page or emphasized loading states.
    */
   size: Extract<SpinnerProps$1['size'], 'large' | 'large-100' | 'base'>;
+  /**
+   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   */
+  accessibilityLabel: Required<SpinnerProps$1>['accessibilityLabel'];
 }
 
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
-};
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
-}
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
 /**
- * A component that displays an animated loading indicator to show that content is currently being processed.
+ * Configure the following properties on the spinner component.
+ * @publicDocs
  */
-declare class Spinner extends PreactCustomElement implements SpinnerProps {
-  /**
-   * A label that describes the spinner for assistive technologies.
-   */
+declare class Spinner extends PolarisCustomElement implements SpinnerProps {
   accessor accessibilityLabel: string;
-  /**
-   * The size of the spinner.
-   */
   accessor size: SpinnerProps['size'];
-  /**
-   * Creates a new Spinner instance.
-   */
   constructor();
 }
 declare global {
@@ -163,14 +122,7 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the spinner component.
- */
 declare const tagName = 's-spinner';
-/**
- * The JSX properties you can set on a spinner component.
- * @publicDocs
- */
 export interface SpinnerJSXProps
   extends Partial<SpinnerProps>,
     Pick<SpinnerProps$1, 'id'> {}

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -1,8 +1,14 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -16,10 +22,45 @@ import type {
   JustifyContentKeyword,
   AlignItemsKeyword,
   AlignContentKeyword,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * A type that allows a value to be responsive using container query syntax.
+ * Makes a type responsive by allowing it to be either the base value or a container query string. This enables conditional styling based on container dimensions.
  * @publicDocs
  */
 export type MakeResponsive<T> = T | `@container${string}`;
@@ -45,12 +86,21 @@ export type MakeResponsivePick<TType, TProperty extends keyof TType> = {
 };
 
 /**
- * A version of the box properties with all fields required.
+ * Represents the box component props with all properties marked as required.
  * @publicDocs
  */
 export type RequiredBoxProps = Required<BoxProps$1>;
 /**
- * The allowed border radius values for a box component.
+ * Represents the subset of border radius values supported by the component.
+ *
+ * - `small-200`: Extra small radius for subtle rounding.
+ * - `small-100`: Small radius for minimal corner rounding.
+ * - `small`: Standard small radius.
+ * - `base`: Medium radius for moderate corner rounding.
+ * - `large`: Standard large radius for pronounced rounding.
+ * - `large-100`: Large radius for more prominent corner rounding.
+ * - `large-200`: Extra large radius for maximum rounding.
+ * - `none`: No border radius (sharp corners).
  * @publicDocs
  */
 export type BoxBorderRadii = Extract<
@@ -65,7 +115,12 @@ export type BoxBorderRadii = Extract<
   | 'large-200'
 >;
 /**
- * The allowed border style values for a box component.
+ * Represents the subset of border style values supported by the box component.
+ *
+ * - `auto`: Default border style determined by the system.
+ * - `none`: No border style (removes the border).
+ * - `solid`: Continuous line border.
+ * - `dashed`: Border made up of dashes.
  * @publicDocs
  */
 export type BoxBorderStyles = Extract<
@@ -73,7 +128,9 @@ export type BoxBorderStyles = Extract<
   'none' | 'solid' | 'dashed' | 'auto'
 >;
 /**
- * The box properties that support responsive values through container queries.
+ * Represents box props with responsive capabilities for layout properties.
+ *
+ * This enables conditional styling based on container queries.
  * @publicDocs
  */
 export type ResponsiveBoxProps = MakeResponsivePick<
@@ -108,7 +165,7 @@ export interface BoxProps
     | 'overflow'
   > {
   /**
-   * The background color of the stack container.
+   * The background color of the component.
    *
    * @default 'transparent'
    */
@@ -117,10 +174,13 @@ export interface BoxProps
     'transparent' | 'base' | 'subdued' | 'strong'
   >;
   /**
-   * Controls the thickness of the border on all sides.
+   * A border applied using shorthand syntax to specify width, color, and style in a single property.
    *
-   * When set, this overrides the width value specified in the `border` property.
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.
+   * @default 'none'
+   */
+  border: RequiredBoxProps['border'];
+  /**
+   * The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -133,10 +193,7 @@ export interface BoxProps
       >
     | Extract<RequiredBoxProps['borderWidth'], ''>;
   /**
-   * Controls the visual style of the border on all sides (solid, dashed, auto, or none).
-   *
-   * When set, this overrides the style value specified in the `border` property.
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.
+   * The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -144,10 +201,7 @@ export interface BoxProps
     | MaybeAllValuesShorthandProperty<BoxBorderStyles>
     | Extract<RequiredBoxProps['borderStyle'], ''>;
   /**
-   * Controls the color of the border using the design system's color scale.
-   *
-   * When set, this overrides the color value specified in the `border` property.
-   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.
+   * The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
    *
    * @default '' - meaning no override
    */
@@ -156,101 +210,85 @@ export interface BoxProps
     'subdued' | 'base' | 'strong' | ''
   >;
   /**
-   * Controls the roundedness of the element's corners using the design system's radius scale.
-   *
-   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.
+   * The roundedness of the element's corners using the design system's radius scale.
    *
    * @default 'none'
    */
   borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;
   /**
-   * The padding applied to all edges of the stack container.
+   * The padding applied to all edges of the component.
    *
-   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is supported. Note that, contrary to the CSS, it uses flow-relative values and the order is:
+   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:
+   * - 1 value applies to all sides
+   * - 2 values apply to block (top/bottom) and inline (left/right)
+   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)
+   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)
    *
-   * - 4 values: `block-start inline-end block-end inline-start`
-   * - 3 values: `block-start inline block-end`
-   * - 2 values: `block inline`
+   * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * For example:
-   * - `large` means block-start, inline-end, block-end and inline-start paddings are `large`.
-   * - `large none` means block-start and block-end paddings are `large`, inline-start and inline-end paddings are `none`.
-   * - `large none large` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `none`.
-   * - `large none large small` means block-start padding is `large`, inline-end padding is `none`, block-end padding is `large` and inline-start padding is `small`.
-   *
-   * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
-   *
-   * `padding` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
   padding: ResponsiveBoxProps['padding'];
   /**
-   * The padding applied to the block axis (top and bottom in horizontal writing modes).
+   * The block-direction padding (top and bottom in horizontal writing modes).
    *
-   * - `large none` means block-start padding is `large`, block-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for block-start and block-end.
    *
-   * This overrides the block value of `padding`.
+   * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlock: ResponsiveBoxProps['paddingBlock'];
   /**
-   * The padding applied to the block-start edge (top in horizontal writing modes).
+   * The block-start padding (top in horizontal writing modes).
    *
-   * This overrides the block-start value of `paddingBlock`.
-   *
-   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];
   /**
-   * The padding applied to the block-end edge (bottom in horizontal writing modes).
+   * The block-end padding (bottom in horizontal writing modes).
    *
-   * This overrides the block-end value of `paddingBlock`.
-   *
-   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];
   /**
-   * The padding applied to the inline axis (left and right in horizontal writing modes).
+   * The inline-direction padding (left and right in horizontal writing modes).
    *
-   * - `large none` means inline-start padding is `large`, inline-end padding is `none`.
+   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.
    *
-   * This overrides the inline value of `padding`.
+   * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInline: ResponsiveBoxProps['paddingInline'];
   /**
-   * The padding applied to the inline-start edge (left in left-to-right languages).
+   * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * This overrides the inline-start value of `paddingInline`.
-   *
-   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];
   /**
-   * The padding applied to the inline-end edge (right in left-to-right languages).
+   * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * This overrides the inline-end value of `paddingInline`.
-   *
-   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
   paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];
   /**
-   * Sets the outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
    *
    * - `auto` the component's initial value. The actual value depends on the component and context.
    * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
@@ -259,7 +297,7 @@ export interface BoxProps
    */
   display: ResponsiveBoxProps['display'];
   /**
-   * The vertical size of the stack in standard layouts (height in left-to-right or right-to-left writing modes).
+   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).
    *
    * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;
    * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.
@@ -270,31 +308,44 @@ export interface BoxProps
    */
   blockSize: SizeUnitsOrAuto;
   /**
-   * The [minimum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) (minimum height in horizontal writing modes) of the stack container.
+   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
    *
    * @default '0'
    */
   minBlockSize: SizeUnits;
   /**
-   * The [maximum block size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) (maximum height in horizontal writing modes) of the stack container.
+   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
    *
    * @default 'none'
    */
   maxBlockSize: SizeUnitsOrNone;
   /**
-   * The [inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size) (width in horizontal writing modes) of the stack container.
+   * The width in horizontal writing modes, or height in vertical writing modes.
+   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * @default 'auto'
    */
   inlineSize: SizeUnitsOrAuto;
   /**
-   * The [minimum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) (minimum width in horizontal writing modes) of the stack container.
+   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.
+   * Prevents the element from shrinking below this size.
+   *
+   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
    *
    * @default '0'
    */
   minInlineSize: SizeUnits;
   /**
-   * The [maximum inline size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) (maximum width in horizontal writing modes) of the stack container.
+   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.
+   * Prevents the element from growing beyond this size.
+   *
+   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
    *
    * @default 'none'
    */
@@ -302,12 +353,14 @@ export interface BoxProps
 }
 
 /**
- * A version of the stack properties with all fields required.
+ * Represents the stack component props with all properties marked as required.
  * @publicDocs
  */
 export type AlignedStackProps = Required<StackProps$1>;
 /**
- * The stack properties that support responsive values through container queries.
+ * Represents stack props with responsive capabilities for layout properties.
+ *
+ * This enables conditional styling based on container queries.
  * @publicDocs
  */
 export type ResponsiveStackProps = MakeResponsivePick<
@@ -315,8 +368,7 @@ export type ResponsiveStackProps = MakeResponsivePick<
   'gap' | 'rowGap' | 'columnGap' | 'direction'
 >;
 /**
- * The properties for the stack component. A stack arranges its children in a single direction with controlled spacing and alignment along both axes.
- * @publicDocs
+ * Configure the following properties on the stack component.
  */
 export interface StackProps
   extends BoxProps,
@@ -349,300 +401,132 @@ export interface StackProps
    */
   alignContent: AlignContentKeyword;
   /**
-   * The spacing between children in the stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * Adjusts spacing between elements.
+   *
+   * Accepts:
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`
+   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default 'none'
    */
   gap: ResponsiveStackProps['gap'];
   /**
-   * The spacing between children in the block axis (vertical in horizontal writing modes). This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.
+   *
+   * Accepts:
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
   rowGap: ResponsiveStackProps['rowGap'];
   /**
-   * The spacing between children in the inline axis (horizontal in left-to-right languages). This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.
+   *
+   * Accepts:
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
   columnGap: ResponsiveStackProps['columnGap'];
   /**
-   * The direction in which the stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The direction in which the stack's children are placed within the stack.
+   *
+   * Accepts:
+   * - A single value, either `inline` or `block`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value
    *
    * @default 'block'
    *
-   * @implementation The content will wrap if the direction is `'inline'`, and won't wrap if the direction is `'block'`.
+   * @implementation the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'
    */
   direction: ResponsiveStackProps['direction'];
 }
 
-/**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * An interface representing the properties of an activation event, such as a click or keypress.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on PC) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/**
- * The base element class for Box components with all Box properties as accessors.
- */
-declare class BoxElement extends PreactCustomElement implements BoxProps {
+declare class BoxElement extends PolarisCustomElement implements BoxProps {
   constructor(renderImpl: RenderImpl);
-  /**
-   * The ARIA role that defines the semantic meaning of the stack for assistive technologies.
-   */
   accessor accessibilityRole: BoxProps['accessibilityRole'];
-  /**
-   * The background color of the stack using the design system's color scale. Choose from `transparent`, `subdued`, `base`, or `strong`.
-   */
   accessor background: BoxProps['background'];
-  /**
-   * The height of the stack in horizontal writing modes, or width in vertical writing modes.
-   * Use this for flow-relative sizing that adapts to text direction.
-   */
   accessor blockSize: BoxProps['blockSize'];
-  /**
-   * The minimum height of the stack in horizontal writing modes, or minimum width in vertical writing modes.
-   * Prevents the stack from shrinking below this size.
-   */
   accessor minBlockSize: BoxProps['minBlockSize'];
-  /**
-   * The maximum height of the stack in horizontal writing modes, or maximum width in vertical writing modes.
-   * Prevents the stack from growing beyond this size.
-   */
   accessor maxBlockSize: BoxProps['maxBlockSize'];
-  /**
-   * The width of the stack in horizontal writing modes, or height in vertical writing modes.
-   * Use this for flow-relative sizing that adapts to text direction.
-   */
   accessor inlineSize: BoxProps['inlineSize'];
-  /**
-   * The minimum width of the stack in horizontal writing modes, or minimum height in vertical writing modes.
-   * Prevents the stack from shrinking below this size.
-   */
   accessor minInlineSize: BoxProps['minInlineSize'];
-  /**
-   * The maximum width of the stack in horizontal writing modes, or maximum height in vertical writing modes.
-   * Prevents the stack from growing beyond this size.
-   */
   accessor maxInlineSize: BoxProps['maxInlineSize'];
-  /**
-   * Controls how content that exceeds the stack's boundaries is displayed. Use `hidden` to clip overflow or `visible` to allow content to extend beyond boundaries.
-   */
   accessor overflow: BoxProps['overflow'];
-  /**
-   * The spacing applied inside the stack on all sides, creating distance between the stack's edges and its content.
-   */
   accessor padding: BoxProps['padding'];
-  /**
-   * The vertical padding (top and bottom) in horizontal writing modes.
-   * Use this for flow-relative padding that adapts to text direction.
-   */
   accessor paddingBlock: BoxProps['paddingBlock'];
-  /**
-   * The padding at the top in horizontal writing modes, or at the start edge in vertical writing modes.
-   */
   accessor paddingBlockStart: BoxProps['paddingBlockStart'];
-  /**
-   * The padding at the bottom in horizontal writing modes, or at the end edge in vertical writing modes.
-   */
   accessor paddingBlockEnd: BoxProps['paddingBlockEnd'];
-  /**
-   * The horizontal padding (left and right) in horizontal writing modes.
-   * Use this for flow-relative padding that adapts to text direction.
-   */
   accessor paddingInline: BoxProps['paddingInline'];
-  /**
-   * The padding at the left in left-to-right languages, or at the right in right-to-left languages.
-   */
   accessor paddingInlineStart: BoxProps['paddingInlineStart'];
-  /**
-   * The padding at the right in left-to-right languages, or at the left in right-to-left languages.
-   */
   accessor paddingInlineEnd: BoxProps['paddingInlineEnd'];
-  /**
-   * Applies a border using shorthand syntax to specify width, color, and style in a single property.
-   */
   accessor border: BoxProps['border'];
-  /**
-   * Controls the thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
-   */
   accessor borderWidth: BoxProps['borderWidth'];
-  /**
-   * Controls the visual style of the border on all sides (solid, dashed, auto, or none). When set, this overrides the style value specified in the `border` property.
-   */
   accessor borderStyle: BoxProps['borderStyle'];
-  /**
-   * Controls the color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.
-   */
   accessor borderColor: BoxProps['borderColor'];
-  /**
-   * Controls the roundedness of the element's corners using the design system's radius scale.
-   */
   accessor borderRadius: BoxProps['borderRadius'];
-  /**
-   * A text description of the stack for screen readers, used when the visual context isn't sufficient for understanding.
-   */
   accessor accessibilityLabel: BoxProps['accessibilityLabel'];
-  /**
-   * Controls the visibility of the stack for both visual and assistive technology users. Use `hidden` to hide from screen readers or `exclusive` to hide visually but announce to screen readers.
-   */
   accessor accessibilityVisibility: BoxProps['accessibilityVisibility'];
-  /**
-   * Controls how the stack is displayed in the layout, such as block, inline, or none.
-   */
   accessor display: BoxProps['display'];
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A stack is a layout component that arranges its children in a single direction with controlled spacing and alignment.
+ * Configure the following properties on the stack component.
+ * @publicDocs
  */
 declare class Stack extends BoxElement implements StackProps {
   constructor();
-  /**
-   * The direction in which the stack's children are arranged.
-   */
   accessor direction: StackProps['direction'];
-  /**
-   * Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).
-   */
   accessor justifyContent: StackProps['justifyContent'];
-  /**
-   * Controls the alignment of children along the block axis (vertically in horizontal writing modes).
-   */
   accessor alignItems: StackProps['alignItems'];
-  /**
-   * Controls the distribution of lines along the block axis when content wraps into multiple lines.
-   */
   accessor alignContent: StackProps['alignContent'];
-  /**
-   * The spacing between the stack's children.
-   */
   accessor gap: StackProps['gap'];
-  /**
-   * The spacing between rows in the stack.
-   */
   accessor rowGap: StackProps['rowGap'];
-  /**
-   * The spacing between columns in the stack.
-   */
   accessor columnGap: StackProps['columnGap'];
 }
 declare global {
@@ -659,15 +543,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-stack';
-/**
- * The properties for the stack component when it's used in JSX.
- * @publicDocs
- */
 export interface StackJSXProps
   extends Partial<StackProps>,
     Pick<StackProps$1, 'id' | 'children'> {
   /**
-   * The child elements to render inside the stack.
+   * The child elements displayed within the stack component, which are arranged vertically or horizontally with consistent spacing.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch.d.ts
@@ -1,30 +1,44 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   CheckboxProps,
   SwitchProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event that includes a strongly-typed reference to the element that triggered it.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event handler was attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A function that handles events for a specific element type, or null if no handler is set.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -32,170 +46,93 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/** Used when an element does not have children. * @publicDocs
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
+ * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * CSS styles that will be applied to the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * Configuration for rendering a custom element with Preact and shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's content inside the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * CSS styles that will be applied to the shadow DOM.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * Information about modifier keys and mouse buttons that were active during an interaction.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down during the interaction.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on PC) was held down during the interaction.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down during the interaction.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the interaction.
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * Options for influencing how a programmatic click behaves.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The core properties that all input elements need to function within forms.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/**
- * Base class for input elements that participate in form submission.
- */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
-  /**
-   * Indicates that this element can participate in form submission.
-   */
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's triggered when the input's value changes and the field loses focus.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's triggered when the input's value changes as the user types.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the input is disabled and can't be interacted with.
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * A unique identifier for the input element.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * The name that identifies this input when the form is submitted.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value of the input.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
-/**
- * Properties that are common to checkbox-style components.
- * @publicDocs
- */
 export interface PreactCheckboxProps
   extends Required<
     Pick<
@@ -212,20 +149,15 @@ export interface PreactCheckboxProps
     >
   > {
   /**
-   * The value that's submitted with the form when the checkbox is checked.
+   * The value used in form data when the checkbox is checked.
    */
   value: Required<CheckboxProps>['value'];
 }
-/**
- * Base class for checkbox-style elements that can be toggled on and off.
- */
 declare class PreactCheckboxElement
   extends PreactInputElement
   implements PreactCheckboxProps
 {
-  /**
-   * Whether the checkbox is currently checked.
-   */
+  accessor onblur: CallbackEventListener<'input'>;
   get checked(): boolean;
   set checked(checked: PreactCheckboxProps['checked']);
   /**
@@ -233,29 +165,11 @@ declare class PreactCheckboxElement
    */
   get value(): string;
   set value(value: string);
-  /**
-   * Whether the checkbox should be checked when it's first rendered.
-   */
   accessor defaultChecked: PreactCheckboxProps['defaultChecked'];
-  /**
-   * A label that's only visible to screen readers, used when the visual label isn't descriptive enough.
-   */
   accessor accessibilityLabel: PreactCheckboxProps['accessibilityLabel'];
-  /**
-   * Additional text to provide context or guidance for the checkbox.
-   */
   accessor details: PreactCheckboxProps['details'];
-  /**
-   * An error message that's displayed below the checkbox when validation fails.
-   */
   accessor error: PreactCheckboxProps['error'];
-  /**
-   * The text that describes what the checkbox is for.
-   */
   accessor label: PreactCheckboxProps['label'];
-  /**
-   * Whether the checkbox must be checked before the form can be submitted.
-   */
   accessor required: PreactCheckboxProps['required'];
   /** @private */
   formResetCallback(): void;
@@ -264,21 +178,25 @@ declare class PreactCheckboxElement
 }
 
 /**
- * Properties for rendering a switch that lets users toggle a setting on or off with a sliding control interface.
- * @publicDocs
+ * Configure the following properties on the switch component.
  */
 export interface SwitchProps
   extends PreactCheckboxProps,
     Required<Pick<SwitchProps$1, 'labelAccessibilityVisibility'>> {}
 
-/**
- * A switch that lets users toggle a setting on or off with a sliding control.
- */
-declare class Switch extends PreactCheckboxElement implements SwitchProps {
-  /**
-   * Controls whether the label is visible to all users or only to screen readers.
-   */
+declare abstract class SwitchBase
+  extends PreactCheckboxElement
+  implements Pick<SwitchProps, 'labelAccessibilityVisibility'>
+{
   accessor labelAccessibilityVisibility: SwitchProps['labelAccessibilityVisibility'];
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the switch component.
+ * @publicDocs
+ */
+declare class Switch extends SwitchBase implements SwitchProps {
   constructor();
 }
 declare global {
@@ -295,21 +213,18 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-switch';
-/**
- * Properties for using the switch component in JSX with React-style event handlers.
- * @publicDocs
- */
 export interface SwitchJSXProps
   extends Partial<SwitchProps>,
     Pick<SwitchProps$1, 'id'> {
   /**
-   * A callback that's triggered when the switch's checked state changes and it loses focus.
+   * A callback fired when the switch state changes and the user has finished interacting with it.
    */
   onChange?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's triggered when the switch's checked state changes as the user interacts with it.
+   * A callback fired when the switch state changes, including intermediate states during user interaction.
    */
   onInput?: ((event: CallbackEvent<typeof tagName>) => void) | null;
+  onBlur?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }
 
 export {Switch};

--- a/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -219,6 +214,7 @@ declare class Table extends PolarisCustomElement implements TableProps {
       format: HeaderFormat;
     }[]
   >;
+
   constructor();
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table.d.ts
@@ -1,20 +1,60 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   ComponentChildren,
   TableProps$1,
   TableHeaderProps$1,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+import * as _shopify_admin_web_component_foundations from '@shopify/admin-web-component-foundations';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The properties you can set on a table component.
- * @publicDocs
+ * Configure the following properties on the table component.
  */
 export interface TableProps
   extends Required<
@@ -24,13 +64,23 @@ export interface TableProps
     >
   > {
   /**
-   * The display variant of the table. Use `list` to force a list view, or `auto` to automatically switch between table and list based on the available space.
+   * The layout variant of the table component.
+   *
+   * - `list`: Always displays as a list layout.
+   * - `auto`: Automatically displays as a table on wide screens and as a list on narrow screens.
+   *
+   * @default 'auto'
    */
   variant: Extract<TableProps$1['variant'], 'list' | 'auto'>;
 }
 
 /**
- * The format type for a table header, which determines how the cell content is displayed.
+ * Represents the format options for table headers that control styling and alignment of column content.
+ *
+ * Available values:
+ * - `base`: Standard format for text columns
+ * - `currency`: Right-aligned format for monetary values
+ * - `numeric`: Right-aligned format for numeric values
  * @publicDocs
  */
 export type HeaderFormat = Extract<
@@ -38,203 +88,66 @@ export type HeaderFormat = Extract<
   'base' | 'currency' | 'numeric'
 >;
 /**
- * The properties you can set on a table header component.
- * @publicDocs
+ * The table header component represents a single column header within a table header row. Use table header as a child of table header row to define column headings and optionally enable column sorting.
+ *
+ * Table header provides semantic meaning for screen readers and can include sorting controls when configured. Each header corresponds to a column in the table body.
  */
 export interface TableHeaderProps
   extends Pick<TableHeaderProps$1, 'listSlot' | 'format'> {
   /**
-   * The slot where this header's data appears in list view. The options include `primary` for the main content, `secondary` for supporting text, `labeled` for labeled data, `kicker` for small text above the primary content, or `inline` for inline content.
+   * The content designation for this column when the table displays in list variant on mobile devices.
+   *
+   * @default 'labeled'
    */
   listSlot: Extract<
     TableHeaderProps$1['listSlot'],
     'primary' | 'secondary' | 'labeled' | 'kicker' | 'inline'
   >;
   /**
-   * The format of the header, which affects how the cell content is aligned and displayed. Use `base` for standard text, `currency` for monetary values, or `numeric` for numbers.
+   * The format of the column that controls styling and alignment of cell content.
+   *
+   * @default 'base'
    */
   format: HeaderFormat;
 }
 
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
-};
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
-}
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
-  /** @private */
-  connectedCallback(): void;
-  /** @private */
-  disconnectedCallback(): void;
-  /** @private */
-  adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
-}
-
-/**
- * A context object that provides a default value of a specific type.
- * @publicDocs
- */
-export interface Context<T> {
-  /**
-   * The default value for this context.
-   */
-  readonly defaultValue: T;
-}
-/**
- * An extended context class that provides event-based updates when the context value changes.
- */
-declare class AddedContext<T> extends EventTarget {
-  /**
-   * Creates a new context with the given default value.
-   */
-  constructor(defaultValue: T);
-  /**
-   * The current value of the context.
-   */
-  get value(): T;
-  /**
-   * Sets a new value for the context.
-   */
-  set value(value: T);
-}
-
-/**
- * A callback that a context requester provides, which is called with the value that satisfies the request.
- * Context providers can call this callback multiple times as the requested value changes.
- * @publicDocs
- */
-export type ContextCallback<T> = (value: T) => void;
-/**
- * An event that a context requester fires to signal it wants a named context.
- *
- * A provider should inspect the `context` property of the event to see if it has a value that can satisfy the request, and if so, call the `callback` with the requested value.
- */
-declare class ContextRequestEvent<T> extends Event {
-  /**
-   * The context that's being requested.
-   */
-  readonly context: Context<T>;
-  /**
-   * The callback to call with the requested context value.
-   */
-  readonly callback: ContextCallback<T>;
-  /**
-   * Creates a new context request event with the given context and callback.
-   */
-  constructor(context: Context<T>, callback: ContextCallback<T>);
-}
-declare global {
-  interface HTMLElementEventMap {
-    /**
-     * A 'context-request' event can be emitted by any element which desires
-     * a context value to be injected by an external provider.
-     */
-    'context-request': ContextRequestEvent<unknown>;
-  }
-}
-
-/** @private */
 declare const actualTableVariantSymbol: unique symbol;
-/** @private */
 declare const tableHeadersSharedDataSymbol: unique symbol;
 /**
- * The actual display variant of the table, which is either a traditional table or a list.
+ * Represents the actual rendered variant of a table component.
+ * - `table`: Displays as a traditional table layout.
+ * - `list`: Displays as a list layout.
  * @publicDocs
  */
 export type ActualTableVariant = 'table' | 'list';
+declare const elementInternals: unique symbol;
+
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+}
 
 /**
- * An event that includes a strongly typed `currentTarget` property based on the element tag name.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function that receives a strongly typed callback event, or `null` if no listener is attached.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -243,81 +156,69 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A component that displays data in a structured table format that automatically adapts to the available space.
+ * Configure the following properties on the table component.
+ * @publicDocs
  */
-declare class Table extends PreactCustomElement implements TableProps {
-  /**
-   * The display variant of the table.
-   */
+declare class Table extends PolarisCustomElement implements TableProps {
+  /** @private */
+  [elementInternals]: ElementInternals;
   accessor variant: TableProps['variant'];
   /**
-   * Whether the table is currently in a loading state.
+   * Whether the table is in a loading state, such as during initial page load or when loading the next page in a paginated table. When `true`, the table might be in an inert state that prevents user interaction.
    */
   accessor loading: TableProps['loading'];
-  /**
-   * Whether the pagination controls are displayed.
-   */
   accessor paginate: TableProps['paginate'];
-  /**
-   * Whether there's a previous page of data that the user can navigate to.
-   */
   accessor hasPreviousPage: TableProps['hasPreviousPage'];
-  /**
-   * Whether there's a next page of data that the user can navigate to.
-   */
   accessor hasNextPage: TableProps['hasNextPage'];
-  /**
-   * The event listener that's called when the user navigates to the previous page.
-   */
   accessor onpreviouspage: CallbackEventListener<typeof tagName> | null;
-  /**
-   * The event listener that's called when the user navigates to the next page.
-   */
   accessor onnextpage: CallbackEventListener<typeof tagName> | null;
   /**
    * @private
    * The actual table variant, which is either 'table' or 'list'.
    */
-  [actualTableVariantSymbol]: AddedContext<ActualTableVariant>;
+  [actualTableVariantSymbol]: _shopify_admin_web_component_foundations.AddedContext<ActualTableVariant>;
   /** @private */
-  [tableHeadersSharedDataSymbol]: AddedContext<
+  [tableHeadersSharedDataSymbol]: _shopify_admin_web_component_foundations.AddedContext<
     {
       listSlot: TableHeaderProps['listSlot'];
       textContent: string;
       format: HeaderFormat;
     }[]
   >;
-
-  /**
-   * Creates a new Table instance.
-   */
   constructor();
 }
 declare global {
@@ -334,23 +235,16 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the table component.
- */
 declare const tagName = 's-table';
-/**
- * The JSX properties you can set on a table component.
- * @publicDocs
- */
 export interface TableJSXProps
   extends Partial<TableProps>,
     Pick<TableProps$1, 'id' | 'children' | 'onNextPage' | 'onPreviousPage'> {
   /**
-   * The content to display inside the table, which should include table header row, table body, and table row components.
+   * The table structure displayed within the table component, including table headers, rows, and cells that organize data in a grid format.
    */
   children?: ComponentChildren;
   /**
-   * Additional filters to display in the table. For example, you can use the search field component to filter the table data.
+   * Additional filters to display in the table, such as search fields or other input components that allow users to narrow down the displayed data.
    */
   filters?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableBody.d.ts
@@ -1,146 +1,122 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, TableBodyProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  TableBodyProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
-/**
- * The properties you can set on a table body component.
- * @publicDocs
- */
-export interface TableBodyProps extends TableBodyProps$1 {}
-
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+/**
+ * The table body component represents the main content area of a table, containing the data rows. Use table body as a child of table to structure your table data, with each table row within the body representing a single record or entry.
+ *
+ * Table body must contain table row components, which in turn contain table cell components for the actual data values.
+ */
+export interface TableBodyProps extends TableBodyProps$1 {
+  /**
+   * The rows containing the main data content of the table.
+   * In the `table` variant, this represents the semantic table body. In the `list` variant, this might not have semantic meaning but still contains the data rows.
+   */
+  children?: TableBodyProps$1['children'];
+}
+
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
+declare const elementInternals: unique symbol;
+
 /**
- * A component that wraps the body content of a table, which contains the data rows.
+ * The table body component represents the main content area of a table, containing the data rows. Use table body as a child of table to structure your table data, with each table row within the body representing a single record or entry.
+ *
+ * Table body must contain table row components, which in turn contain table cell components for the actual data values.
+ * @publicDocs
  */
-declare class TableBody extends PreactCustomElement implements TableBodyProps {
-  /**
-   * Creates a new TableBody instance.
-   */
+declare class TableBody extends PolarisCustomElement implements TableBodyProps {
+  /** @private */
+  [elementInternals]: ElementInternals;
   constructor();
 }
 declare global {
@@ -157,19 +133,13 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the table body component.
- */
 declare const tagName = 's-table-body';
-/**
- * The JSX properties you can set on a table body component.
- * @publicDocs
- */
 export interface TableBodyJSXProps
   extends Partial<TableBodyProps>,
     Pick<TableBodyProps$1, 'id' | 'children'> {
   /**
-   * The body content of the table, which should include table row components. This content might not have any semantic meaning when the table uses the `list` variant.
+   * The rows containing the main data content of the table.
+   * In the `table` variant, this represents the semantic table body. In the `list` variant, this might not have semantic meaning but still contains the data rows.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
@@ -1,148 +1,120 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   ComponentChildren,
   TableCellProps$1,
   TableHeaderProps,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
-/**
- * The properties you can set on a table cell component.
- * @publicDocs
- */
-export interface TableCellProps extends TableCellProps$1 {}
-
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+/**
+ * The table cell component represents a single data cell within a table row. Use table cell as a child of table row to display individual data values, with each cell corresponding to a column in the table.
+ *
+ * Table cell automatically inherits styling and alignment from its parent table structure and supports text content or other inline components.
+ */
+export interface TableCellProps extends TableCellProps$1 {
+  /**
+   * The content displayed within the table cell, which represents a single data point in the table's grid structure.
+   */
+  children?: TableCellProps$1['children'];
+}
+
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/** @private */
 declare const headerFormatSymbol: unique symbol;
 
 /**
- * The format type for a table header, which determines how the cell content is displayed.
+ * Represents the format options for table headers that control styling and alignment of column content.
+ *
+ * Available values:
+ * - `base`: Standard format for text columns
+ * - `currency`: Right-aligned format for monetary values
+ * - `numeric`: Right-aligned format for numeric values
  * @publicDocs
  */
 export type HeaderFormat = Extract<
@@ -150,13 +122,17 @@ export type HeaderFormat = Extract<
   'base' | 'currency' | 'numeric'
 >;
 
+declare const elementInternals: unique symbol;
+
 /**
- * A component that represents a single cell in a table row, which displays data in a format that's determined by its column header.
+ * The table cell component represents a single data cell within a table row. Use table cell as a child of table row to display individual data values, with each cell corresponding to a column in the table.
+ *
+ * Table cell automatically inherits styling and alignment from its parent table structure and supports text content or other inline components.
+ * @publicDocs
  */
-declare class TableCell extends PreactCustomElement implements TableCellProps {
-  /**
-   * Creates a new TableCell instance.
-   */
+declare class TableCell extends PolarisCustomElement implements TableCellProps {
+  /** @private */
+  [elementInternals]: ElementInternals;
   constructor();
   /** @private */
   get [headerFormatSymbol](): HeaderFormat;
@@ -177,19 +153,12 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the table cell component.
- */
 declare const tagName = 's-table-cell';
-/**
- * The JSX properties you can set on a table cell component.
- * @publicDocs
- */
 export interface TableCellJSXProps
   extends Partial<TableCellProps>,
     Pick<TableCellProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the table cell.
+   * The content displayed within the table cell, which represents a single data point in the table's grid structure.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableCell.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
@@ -1,15 +1,63 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, TableHeaderProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  TableHeaderProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The format type for a table header, which determines how the cell content is displayed.
+ * Represents the format options for table headers that control styling and alignment of column content.
+ *
+ * Available values:
+ * - `base`: Standard format for text columns
+ * - `currency`: Right-aligned format for monetary values
+ * - `numeric`: Right-aligned format for numeric values
  * @publicDocs
  */
 export type HeaderFormat = Extract<
@@ -17,163 +65,87 @@ export type HeaderFormat = Extract<
   'base' | 'currency' | 'numeric'
 >;
 /**
- * The properties you can set on a table header component.
- * @publicDocs
+ * The table header component represents a single column header within a table header row. Use table header as a child of table header row to define column headings and optionally enable column sorting.
+ *
+ * Table header provides semantic meaning for screen readers and can include sorting controls when configured. Each header corresponds to a column in the table body.
  */
 export interface TableHeaderProps
   extends Pick<TableHeaderProps$1, 'listSlot' | 'format'> {
   /**
-   * The slot where this header's data appears in list view. The options include `primary` for the main content, `secondary` for supporting text, `labeled` for labeled data, `kicker` for small text above the primary content, or `inline` for inline content.
+   * The content designation for this column when the table displays in list variant on mobile devices.
+   *
+   * @default 'labeled'
    */
   listSlot: Extract<
     TableHeaderProps$1['listSlot'],
     'primary' | 'secondary' | 'labeled' | 'kicker' | 'inline'
   >;
   /**
-   * The format of the header, which affects how the cell content is aligned and displayed. Use `base` for standard text, `currency` for monetary values, or `numeric` for numbers.
+   * The format of the column that controls styling and alignment of cell content.
+   *
+   * @default 'base'
    */
   format: HeaderFormat;
 }
 
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
-};
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
-}
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
+declare const elementInternals: unique symbol;
+
 /**
- * A component that defines a column header in a table, which specifies both the header label and how the column's data should be formatted.
+ * The table header component represents a single column header within a table header row. Use table header as a child of table header row to define column headings and optionally enable column sorting.
+ *
+ * Table header provides semantic meaning for screen readers and can include sorting controls when configured. Each header corresponds to a column in the table body.
+ * @publicDocs
  */
 declare class TableHeader
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements TableHeaderProps
 {
-  /**
-   * The slot where this header's data appears when the table is shown in list view.
-   */
+  /** @private */
+  [elementInternals]: ElementInternals;
   accessor listSlot: TableHeaderProps['listSlot'];
-  /**
-   * The format of the header and its corresponding cells.
-   */
   accessor format: TableHeaderProps['format'];
-  /**
-   * Creates a new TableHeader instance.
-   */
   constructor();
 }
 declare global {
@@ -190,19 +162,12 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the table header component.
- */
 declare const tagName = 's-table-header';
-/**
- * The JSX properties you can set on a table header component.
- * @publicDocs
- */
 export interface TableHeaderJSXProps
   extends Partial<TableHeaderProps>,
     Pick<TableHeaderProps$1, 'id' | 'children'> {
   /**
-   * The heading of the column when the table uses the `table` variant, and the label of its data when the table uses the `list` variant.
+   * The heading of the column in the `table` variant, and the label of its data in `list` variant.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeader.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
@@ -1,149 +1,125 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, TableHeaderRowProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  TableHeaderRowProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * The properties you can set on a table header row component.
- * @publicDocs
+ * The table header row component represents the header row of a table, containing column headings. Use table header row as the first child of table (before table body) to define the table structure and provide column labels.
+ *
+ * Table header row must contain table header components for each column. These headers provide context for the data columns and can support sorting functionality.
  */
-export interface TableHeaderRowProps extends TableHeaderRowProps$1 {}
+export interface TableHeaderRowProps extends TableHeaderRowProps$1 {
+  /**
+   * The header cells that define the columns of the table.
+   * Only accepts table header components as children, with each header representing a column and providing its label.
+   */
+  children?: TableHeaderRowProps$1['children'];
+}
 
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
+declare const elementInternals: unique symbol;
+
 /**
- * A component that wraps the header row of a table, which contains the table header components that define the column structure.
+ * The table header row component represents the header row of a table, containing column headings. Use table header row as the first child of table (before table body) to define the table structure and provide column labels.
+ *
+ * Table header row must contain table header components for each column. These headers provide context for the data columns and can support sorting functionality.
+ * @publicDocs
  */
 declare class TableHeaderRow
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements TableHeaderRowProps
 {
-  /**
-   * Creates a new TableHeaderRow instance.
-   */
+  /** @private */
+  [elementInternals]: ElementInternals;
   constructor();
   /** @private */
   connectedCallback(): void;
@@ -164,19 +140,13 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the table header row component.
- */
 declare const tagName = 's-table-header-row';
-/**
- * The JSX properties you can set on a table header row component.
- * @publicDocs
- */
 export interface TableHeaderRowJSXProps
   extends Partial<TableHeaderRowProps>,
     Pick<TableHeaderRowProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the table header row, which should include table header components.
+   * The header cells that define the columns of the table.
+   * Only accepts table header components as children, with each header representing a column and providing its label.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableHeaderRow.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
@@ -1,151 +1,135 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, TableRowProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  TableRowProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The properties you can set on a table row component.
- * @publicDocs
+ * The table row component represents a single row of data within a table body. Use table row as a child of table body to structure individual records or entries in the table.
+ *
+ * Table row must contain table cell components, with each cell representing a data value for the corresponding column. The number of cells should match the number of headers in the table.
  */
 export interface TableRowProps
-  extends Pick<TableRowProps$1, 'children' | 'clickDelegate'> {}
-
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  extends Pick<TableRowProps$1, 'children' | 'clickDelegate'> {
   /**
-   * The function that renders the component's shadow root content.
+   * The data cells displayed within this table row, with each cell containing content for its corresponding column.
+   * Only accepts table cell components as children.
    */
-  ShadowRoot: (element: any) => ComponentChildren;
+  children?: TableRowProps$1['children'];
   /**
-   * The CSS styles to apply to the component.
+   * The ID of an interactive element, such as `s-link`, in the row that will be the target of the click when the row is clicked.
+   * This is the primary action for the row; it should not be used for secondary actions.
+   *
+   * This is a click-only affordance, and does not introduce any keyboard or screen reader affordances.
+   * Which is why the target element must be in the table; so that keyboard and screen reader users can interact with it normally.
+   *
+   * @implementation no focus or keyboard affordances are introduced by this property. No aria attributes need to be added to the table row.
+   * @implementation the row and/or delegate should have some affordance that indicates it is clickable. This may be a background color, a border, or a hover effect
    */
-  styles?: Styles;
-};
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
+  clickDelegate?: TableRowProps$1['clickDelegate'];
 }
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
+declare const elementInternals: unique symbol;
+
 /**
- * A component that represents a single row in a table, which contains the data cells.
+ * The table row component represents a single row of data within a table body. Use table row as a child of table body to structure individual records or entries in the table.
+ *
+ * Table row must contain table cell components, with each cell representing a data value for the corresponding column. The number of cells should match the number of headers in the table.
+ * @publicDocs
  */
-declare class TableRow extends PreactCustomElement implements TableRowProps {
-  /**
-   * Creates a new TableRow instance.
-   */
+declare class TableRow extends PolarisCustomElement implements TableRowProps {
+  /** @private */
+  [elementInternals]: ElementInternals;
   constructor();
-  /**
-   * A CSS selector for a child element that should handle clicks on the entire row. When you set this property, clicking anywhere on the row will trigger a click on the element that matches the selector.
-   */
   accessor clickDelegate: string;
 }
 declare global {
@@ -162,19 +146,13 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the table row component.
- */
 declare const tagName = 's-table-row';
-/**
- * The JSX properties you can set on a table row component.
- * @publicDocs
- */
 export interface TableRowJSXProps
   extends Partial<TableRowProps>,
     Pick<TableRowProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the row, which should include table cell components.
+   * The data cells displayed within this table row, with each cell containing content for its corresponding column.
+   * Only accepts table cell components as children.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TableRow.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
@@ -1,20 +1,79 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, TextProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  TextProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
+declare const typographyFontWeights: readonly [
+  'auto',
+  'base',
+  'medium',
+  'semibold',
+  'bold',
+];
+export type TypographyFontWeight = (typeof typographyFontWeights)[number];
+declare const bodyFontSizes: readonly [
+  'auto',
+  'small-200',
+  'small-100',
+  'small',
+  'base',
+  'large',
+  'large-100',
+];
+export type BodyFontSize = (typeof bodyFontSizes)[number];
+
+export type TextFontSize = BodyFontSize;
+export type TextFontWeight = TypographyFontWeight;
 /**
- * The properties for the text component. These properties define inline or small blocks of text content with various visual styles and semantic meanings.
- * @publicDocs
- */
-/**
- * @publicDocs
- * @publicDocs
+ * Configure the following properties on the text component.
  */
 export interface TextProps
   extends Required<
@@ -29,16 +88,11 @@ export interface TextProps
       | 'interestFor'
     >
   > {
-  /**
-   * The color of the text. Available options:
-   * - `'base'` - The default text color.
-   * - `'subdued'` - A lighter text color for secondary information.
-   */
   color: Extract<TextProps$1['color'], 'base' | 'subdued'>;
   /**
    * The semantic type and styling treatment for the text content.
    *
-   * Other presentation properties on Text override the default styling.
+   * Other presentation properties on text override the default styling.
    *
    * - `strong`: Emphasizes the text with strong importance, typically displayed in bold.
    * - `generic`: Standard text with no special semantic meaning or styling.
@@ -49,7 +103,7 @@ export interface TextProps
    */
   type: Extract<
     TextProps$1['type'],
-    'strong' | 'generic' | 'address' | 'redundant'
+    'address' | 'redundant' | 'strong' | 'generic'
   >;
   /**
    * The semantic tone that's applied to the text, which changes its color to convey meaning.
@@ -66,193 +120,108 @@ export interface TextProps
    */
   tone: Extract<
     TextProps$1['tone'],
-    'info' | 'success' | 'warning' | 'critical' | 'auto' | 'neutral' | 'caution'
+    'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'caution' | 'critical'
   >;
   /**
-   * The numeric font variant for the text. Available options:
-   * - `'auto'` - The font variant is automatically determined.
-   * - `'normal'` - Standard numeric rendering.
-   * - `'tabular-nums'` - Monospaced numbers for better alignment in tables.
+   * @deprecated Use `Number` for inline numeric values instead.
    */
   fontVariantNumeric: Extract<
     TextProps$1['fontVariantNumeric'],
     'auto' | 'normal' | 'tabular-nums'
   >;
-}
-
-/**
- * A string containing CSS styles.
- * @publicDocs
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with a shadow DOM.
- * @publicDocs
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
   /**
-   * The function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * Optional CSS styles to apply to the shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * An object that represents the state of modifier keys and mouse button
- * during an activation event like a click.
- * @publicDocs
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta (Command on Mac, Windows key on PC) key was pressed.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * Options for customizing click behavior on an element.
- * @publicDocs
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
-  /** @private */
-  connectedCallback(): void;
-  /** @private */
-  disconnectedCallback(): void;
-  /** @private */
-  adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
+   * Font size of the text. The named values also apply their matching
+   * line-height and letter-spacing.
    *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
+   * @default 'auto'
    */
-  click({sourceEvent}?: ClickOptions): void;
+  fontSize: TextFontSize;
+  /**
+   * Font weight of the text.
+   *
+   * @default 'auto'
+   */
+  fontWeight: TextFontWeight;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
- * @publicDocs
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/**
- * A custom element for displaying inline or small blocks of text with various visual styles and semantic meanings. Use Text to render short pieces of content with appropriate styling, emphasis, and color treatment.
- */
-declare class Text extends PreactCustomElement implements TextProps {
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+}
+
+declare abstract class TextBase
+  extends PolarisCustomElement
+  implements
+    Pick<
+      TextProps,
+      | 'fontVariantNumeric'
+      | 'fontSize'
+      | 'fontWeight'
+      | 'color'
+      | 'type'
+      | 'dir'
+      | 'accessibilityVisibility'
+      | 'interestFor'
+    >
+{
+  accessor fontSize: TextProps['fontSize'];
+  accessor fontWeight: TextProps['fontWeight'];
   /**
-   * The numeric font variant for the text.
+   * @deprecated Use `Number` for inline numeric values instead.
    */
   accessor fontVariantNumeric: TextProps['fontVariantNumeric'];
-  /**
-   * The color of the text.
-   */
   accessor color: TextProps['color'];
-  /**
-   * The semantic tone that's applied to the text, which changes its color to convey meaning.
-   *
-   * - `info`: Informational content or helpful tips (blue).
-   * - `success`: Positive outcomes or successful states (green).
-   * - `warning`: Important warnings about potential issues (orange).
-   * - `critical`: Urgent problems or destructive actions (red).
-   * - `auto`: Automatically determined based on context.
-   * - `neutral`: General information without specific intent (gray).
-   * - `caution`: Advisory notices that need attention (yellow).
-   */
-  accessor tone: TextProps['tone'];
-  /**
-   * The semantic type and styling treatment for the text content.
-   *
-   * - `strong`: Emphasizes the text with strong importance, typically displayed in bold.
-   * - `generic`: Standard text with no special semantic meaning or styling.
-   * - `address`: Marks the text as contact information, such as a physical or email address.
-   * - `redundant`: Indicates the text is redundant or duplicated information for screen reader context.
-   */
   accessor type: TextProps['type'];
-  /**
-   * The text direction (left-to-right or right-to-left).
-   */
   accessor dir: TextProps['dir'];
-  /**
-   * The visibility of the element to assistive technologies.
-   */
   accessor accessibilityVisibility: TextProps['accessibilityVisibility'];
-  /**
-   * The ID of an element this text provides contextual information for.
-   */
   accessor interestFor: string;
+  abstract tone: string;
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the text component.
+ * @publicDocs
+ */
+declare class Text extends TextBase implements TextProps {
+  accessor tone: TextProps['tone'];
   constructor();
 }
 declare global {
@@ -269,16 +238,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-text';
-/**
- * The JSX properties for the text component. These properties define how text is rendered in Preact or JSX.
- * @publicDocs
- * @publicDocs
- */
 export interface TextJSXProps
   extends Partial<TextProps>,
     Pick<TextProps$1, 'id' | 'children'> {
   /**
-   * The content of the text.
+   * The text content displayed within the text component, which applies semantic meaning and styling appropriate to the specified text type.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
@@ -1,29 +1,43 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   TextAreaProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event with a strongly-typed currentTarget property for a specific HTML element.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * A callback function that receives a strongly-typed event for a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -31,189 +45,133 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * The React-style event callback props for form field components.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's invoked when the user makes any changes in the field. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
+};
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles for the component's shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a Preact component in a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's Preact elements into the shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * The properties from an event that indicate how the user activated an element.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was held down when the event occurred.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on macOS) was held down when the event occurred.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was held down when the event occurred.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed when the event occurred. A value of 0 indicates the primary button (usually left), 1 indicates the middle button, and 2 indicates the secondary button (usually right).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for influencing a programmatic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The base properties for an input element that participates in form submission.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/** @private */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the user makes any changes in the field.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the field is disabled, disallowing any interaction.
-   *
-   * @default false
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * An identifier for the field.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * An identifier for the field that's unique within the nearest containing form.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value for the field.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The base properties for form field elements that support labels, validation, and autocomplete.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -235,10 +193,10 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        * A hint as to the intended content of the field.
        *
        * When set to `on` (the default), this property indicates that the field should support
-       * autofill, but you don't have any more semantic information on the intended
+       * autofill, but you do not have any more semantic information on the intended
        * contents.
        *
-       * When set to `off`, you're indicating that this field contains sensitive
+       * When set to `off`, you are indicating that this field contains sensitive
        * information, or contents that are never saved, like one-time codes.
        *
        * Alternatively, you can provide value which describes the
@@ -253,58 +211,20 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/** @private */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * A callback that's invoked when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint as to the intended content of the field for autocomplete purposes.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value for the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * Additional descriptive text to display below the field that provides supplementary information.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * An error message to display below the field, indicating validation failure or other issues.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label to display for the field, describing what the user should enter.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * Controls the visibility of the label for accessibility purposes.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The placeholder text that's displayed inside the field when it's empty, providing a hint about expected input.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only, preventing edits while still allowing focus and selection.
-   *
-   * @default false
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before form submission.
-   *
-   * @default false
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
@@ -334,7 +254,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the text area component. These properties configure a multi-line text input field that allows merchants to enter and edit longer text content.
+ * Represents the props for textarea components. Extends `PreactFieldProps` for multi-line text input functionality.
  * @publicDocs
  */
 export type TextAreaProps = PreactFieldProps<
@@ -342,30 +262,21 @@ export type TextAreaProps = PreactFieldProps<
 > &
   Required<Pick<TextAreaProps$1, 'maxLength' | 'minLength' | 'rows'>>;
 
-/**
- * The text area custom element class that renders a multi-line text input field in the Shopify admin interface. This component allows merchants to enter and edit longer text content with support for labels, validation, and length constraints.
- */
-declare class TextArea
+declare abstract class TextAreaBase
   extends PreactFieldElement<TextAreaProps['autocomplete']>
-  implements TextAreaProps
+  implements Pick<TextAreaProps, 'maxLength' | 'minLength' | 'rows'>
 {
-  /**
-   * The maximum number of characters the user can enter in the field.
-   */
   accessor maxLength: TextAreaProps['maxLength'];
-  /**
-   * The minimum number of characters required in the field for validation.
-   */
   accessor minLength: TextAreaProps['minLength'];
-  /**
-   * The number of visible text lines for the field, controlling its initial height.
-   */
   accessor rows: TextAreaProps['rows'];
-  /**
-   * The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.
-   */
-  get value(): string;
-  set value(value: string);
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the text area component.
+ * @publicDocs
+ */
+declare class TextArea extends TextAreaBase implements TextAreaProps {
   constructor();
 }
 declare global {
@@ -376,20 +287,19 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: TextAreaJSXProps & PreactBaseElementProps<TextArea>;
+      [tagName]: Omit<TextAreaJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<TextArea>;
     }
   }
 }
 
 declare const tagName = 's-text-area';
-/**
- * The JSX props for the text area component. These properties extend `TextAreaProps` with JSX-specific event callbacks for React-style event handling.
- * @publicDocs
- */
 export interface TextAreaJSXProps
-  extends Partial<TextAreaProps>,
+  extends Partial<Omit<TextAreaProps, 'error' | 'details'>>,
     Pick<TextAreaProps$1, 'id'>,
-    FieldReactProps<typeof tagName> {}
+    FieldReactProps<typeof tagName>,
+    FieldSlotInternalReactProps {}
 
 export {TextArea};
 export type {TextAreaJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -45,7 +40,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -62,7 +57,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -70,19 +65,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -1,25 +1,43 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, TextFieldProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  TextFieldProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * A callback event with a strongly-typed `currentTarget` property that corresponds to a specific HTML element. This provides better type safety when handling events from custom elements.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that the event listener is attached to, strongly typed based on the element's tag name.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function type for callback events with a strongly-typed `currentTarget`. This ensures the event handler receives the correct element type.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -27,200 +45,144 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * The JSX-style event callback props for form field components. These properties provide React-like event handling for input, change, focus, and blur events.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's invoked when the user makes any changes in the field. This fires on every keystroke or modification. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field or press Enter. This fires less frequently than `onInput`. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field receives focus, typically when the user clicks into it or tabs to it. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's invoked when the field loses focus, typically when the user clicks away or tabs out of it. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
+};
 /**
- * The base properties for Preact elements without children. Provides `key`, `ref`, and `slot` properties for element identification, DOM access, and slot-based positioning.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for the element when used in lists. Preact uses keys for efficient rendering and reconciliation when lists change.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element. Typically created with `useRef()` to access the element directly for imperative operations like focusing or measuring.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements with children. Extends `PreactBaseElementProps` with the ability to render child elements.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
   /**
-   * The child elements to render within this component.
+   * The child elements to be rendered within this component.
    */
   children?: preact.ComponentChildren;
 }
 
-/**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The base properties for an input element that participates in form submission. Defines the core properties needed for form integration including identifier, name, value, and disabled state.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps$1, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/** @private */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * A callback that's invoked when the user has finished editing the field, such as when they blur the field.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the user makes any changes in the field.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the field is disabled, disallowing any interaction.
-   *
-   * @default false
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * An identifier for the field.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * An identifier for the field that's unique within the nearest containing form.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value for the field.
-   */
   get value(): PreactInputProps['value'];
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The base properties for form field elements that support labels, validation, and autocomplete. Extends `PreactInputProps` with additional form field features like labels, placeholders, error messages, and autocomplete hints.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -239,9 +201,19 @@ export type PreactFieldProps<Autocomplete extends string = string> =
       >
     > & {
       /**
-       * A hint about the intended content of the field for browser autocomplete functionality. When set to `'on'` (the default), this indicates that the field should support autofill, but you don't have specific semantic information about the contents. When set to `'off'`, you're indicating that this field contains sensitive information or contents that are never saved, like one-time codes. Alternatively, you can provide a specific autocomplete value that describes the data you'd like to be entered during autofill, such as `'email'`, `'name'`, or `'street-address'`.
+       * A hint as to the intended content of the field.
        *
-       * @see Learn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.
+       * When set to `on` (the default), this property indicates that the field should support
+       * autofill, but you do not have any more semantic information on the intended
+       * contents.
+       *
+       * When set to `off`, you are indicating that this field contains sensitive
+       * information, or contents that are never saved, like one-time codes.
+       *
+       * Alternatively, you can provide value which describes the
+       * specific data you would like to be entered into this field during autofill.
+       *
+       * @see Learn more about the set of {@link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens|autocomplete values} supported in browsers.
        *
        * @default 'tel' for PhoneField
        * @default 'email' for EmailField
@@ -250,58 +222,20 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/** @private */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * A callback that's invoked when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * A callback that's invoked when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint as to the intended content of the field for autocomplete purposes.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value for the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * Additional descriptive text to display below the field that provides supplementary information.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * An error message to display below the field, indicating validation failure or other issues.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label to display for the field, describing what the user should enter.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * Controls the visibility of the label for accessibility purposes.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The placeholder text that's displayed inside the field when it's empty, providing a hint about expected input.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only, preventing edits while still allowing focus and selection.
-   *
-   * @default false
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before form submission.
-   *
-   * @default false
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
@@ -331,7 +265,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the text field component. Extends `PreactFieldProps` with text-specific features like icons, length constraints, and prefix/suffix content.
+ * Represents the props for text input field components. Extends `PreactFieldProps` with autocomplete support for text-related fields.
  * @publicDocs
  */
 export type TextFieldProps = PreactFieldProps<
@@ -345,38 +279,27 @@ export type TextFieldProps = PreactFieldProps<
     >
   >;
 
-/**
- * The text field custom element class that renders a single-line text input field in the Shopify admin interface. This component allows merchants to enter and edit text with support for labels, validation, icons, and prefix/suffix content.
- */
-declare class TextField
+declare abstract class TextFieldBase
   extends PreactFieldElement<TextFieldProps['autocomplete']>
-  implements TextFieldProps
+  implements
+    Pick<
+      TextFieldProps,
+      'icon' | 'maxLength' | 'minLength' | 'prefix' | 'suffix'
+    >
 {
-  /**
-   * An icon to display at the start of the text field, providing visual context for the input. Accepts any valid icon type from the admin icon set, or an empty string to display no icon.
-   */
   accessor icon: TextFieldProps['icon'];
-  /**
-   * The maximum number of characters the merchant can enter in the field. When this limit is reached, the field prevents further input.
-   */
   accessor maxLength: TextFieldProps['maxLength'];
-  /**
-   * The minimum number of characters required in the field for validation. The field will be considered invalid if the merchant enters fewer characters than this value.
-   */
   accessor minLength: TextFieldProps['minLength'];
-  /**
-   * Text or content to display before the merchant's input, such as a currency symbol (`$`) or protocol (`https://`).
-   */
   accessor prefix: TextFieldProps['prefix'];
-  /**
-   * Text or content to display after the merchant's input, such as a unit of measurement (`kg`, `%`) or domain (`.myshopify.com`).
-   */
   accessor suffix: TextFieldProps['suffix'];
-  /**
-   * The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.
-   */
-  get value(): string;
-  set value(value: string);
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the text field component.
+ * @publicDocs
+ */
+declare class TextField extends TextFieldBase implements TextFieldProps {
   constructor();
 }
 declare global {
@@ -387,23 +310,21 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: Omit<TextFieldJSXProps, 'accessory'> &
+      [tagName]: Omit<TextFieldJSXProps, 'accessory' | 'error' | 'details'> &
+        FieldSlotPreactProps &
         PreactBaseElementPropsWithChildren<TextField>;
     }
   }
 }
 
 declare const tagName = 's-text-field';
-/**
- * The JSX props for the text field component. These properties extend `TextFieldProps` with JSX-specific event callbacks and an accessory slot for rendering additional content at the end of the field.
- * @publicDocs
- */
 export interface TextFieldJSXProps
-  extends Partial<Omit<TextFieldProps, 'accessory'>>,
+  extends Partial<Omit<TextFieldProps, 'accessory' | 'error' | 'details'>>,
     Pick<TextFieldProps$1, 'id'>,
-    FieldReactProps<typeof tagName> {
+    FieldReactProps<typeof tagName>,
+    FieldSlotInternalReactProps {
   /**
-   * An accessory element to display at the end of the text field, such as a button, icon, or other interactive component. This appears inside the field's visual boundary, typically for actions like clearing the field or showing additional options.
+   * Additional content displayed alongside the text field, typically an icon or button that provides related functionality like opening a help tooltip or triggering a modal.
    */
   accessory?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -45,7 +40,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -62,7 +57,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -70,19 +65,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
@@ -1,25 +1,42 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ThumbnailProps$1, ComponentChildren} from './shared.d.ts';
+import type {
+  ThumbnailProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * A callback event that's typed to a specific HTML element.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The element that currently has the event listener attached.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener for callback events, typed to a specific HTML element.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
@@ -28,42 +45,73 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
     })
   | null;
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
+
 /**
- * The properties for the thumbnail component. A thumbnail displays a small preview image with configurable sizing. Properties include `src` for the image URL, `alt` for accessibility text, and `size` for controlling the thumbnail dimensions.
- * @publicDocs
+ * Configure the following properties on the thumbnail component.
  */
 export interface ThumbnailProps
   extends Required<Pick<ThumbnailProps$1, 'src' | 'alt' | 'size'>> {
   /**
-   * The URL of the image to display in the thumbnail. You can provide an absolute or relative URL pointing to the image file.
-   */
-  src: ThumbnailProps$1['src'];
-  /**
-   * Alternative text that describes the image for screen readers. This text should convey the meaning or content of the image to users who can't see it.
-   */
-  alt: ThumbnailProps$1['alt'];
-  /**
-   * The size of the thumbnail. Choose from `'small-200'`, `'small-100'`, `'small'`, `'base'`, `'large'`, or `'large-100'` to control the thumbnail dimensions.
+   * The size of the product thumbnail image.
    *
-   * @default 'base'
+   * - `small-200`: Smallest thumbnail size, ideal for compact product lists or tables.
+   * - `small-100`: Very small thumbnail, suitable for dense layouts.
+   * - `small`: Small thumbnail for space-constrained contexts.
+   * - `base`: Default size that balances visibility and space efficiency.
+   * - `large`: Larger thumbnail for featured products or detailed views.
+   * - `large-100`: Extra large thumbnail for prominent product display.
    */
   size: Extract<
     ThumbnailProps$1['size'],
@@ -71,126 +119,37 @@ export interface ThumbnailProps
   >;
 }
 
-/**
- * A string containing CSS styles for a custom element.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with Preact.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to apply to the shadow root.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event, such as a click or keypress. These properties capture which modifier keys were pressed and which mouse button was used during the event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * The options for triggering a synthetic click event.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * The base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of `HTMLElement` to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-/**
- * An abstract base class for creating custom elements that render with Preact.
- */
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queues a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to `@property` values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in a background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * A thumbnail displays a small preview image with configurable sizing.
+ * Configure the following properties on the thumbnail component.
+ * @publicDocs
  */
-declare class Thumbnail extends PreactCustomElement implements ThumbnailProps {
+declare class Thumbnail extends PolarisCustomElement implements ThumbnailProps {
   /**
-   * The URL of the image to display in the thumbnail.
+   * The image source (either a remote URL or a local file resource).
+   *
+   * When the image is loading or no `src` is provided, a placeholder is rendered.
    */
   accessor src: ThumbnailProps['src'];
   /**
-   * Alternative text that describes the image for screen readers.
+   * Alternative text that describes the image for accessibility.
+   *
+   * Provides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.
+   *
+   * When a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.
+   *
+   * Learn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).
    */
   accessor alt: ThumbnailProps['alt'];
-  /**
-   * The size of the thumbnail.
-   */
   accessor size: ThumbnailProps['size'];
-  /**
-   * A callback that's fired when the image has loaded successfully.
-   */
   accessor onload: CallbackEventListener<typeof tagName> | null;
-  /**
-   * A callback that's fired when the image fails to load.
-   */
   accessor onerror: OnErrorEventHandler;
   constructor();
 }
@@ -208,19 +167,15 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-thumbnail';
-/**
- * The properties for the thumbnail component when it's used in JSX.
- * @publicDocs
- */
 export interface ThumbnailJSXProps
   extends Partial<ThumbnailProps>,
     Pick<ThumbnailProps$1, 'id'> {
   /**
-   * A callback that's fired when the image has loaded successfully.
+   * A callback fired when the thumbnail image loads successfully.
    */
   onLoad?: ((event: CallbackEvent<typeof tagName>) => void) | null;
   /**
-   * A callback that's fired when the image fails to load.
+   * A callback fired when the thumbnail image fails to load.
    */
   onError?: ((event: CallbackEvent<typeof tagName>) => void) | null;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip.d.ts
@@ -1,159 +1,113 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   ComponentChildren,
   TooltipProps$1,
+  PreactCustomElement,
+  RenderImpl,
   InteractionProps,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The properties you can set on a tooltip component.
- * @publicDocs
+ * Configure the following properties on the tooltip component.
  */
 export interface TooltipProps extends Required<Pick<TooltipProps$1, 'id'>> {}
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
-/**
- * A string that contains CSS styles to apply to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a Preact custom element with a shadow root.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow root content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
-};
-/**
- * An object that resembles an activation event, containing information about which modifier keys were pressed and which mouse button was used.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed. A value of `0` means the primary button (usually left), `1` means the middle button, and `2` means the secondary button (usually right).
-   */
-  button: number;
-}
-/**
- * The options for customizing how a synthetic click is performed.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
-/**
- * The properties for controlling overlay elements like popovers, tooltips, and menus through command interactions.
- * @publicDocs
- */
 export interface PreactOverlayControlProps
   extends Pick<InteractionProps, 'commandFor' | 'interestFor'> {
   /**
-   * The action that the [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
+   * The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.
    *
-   * See the documentation of specific components for the actions they support.
-   *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
+   * - `--auto`: A default action for the target component.
+   * - `--show`: Shows the target component.
+   * - `--hide`: Hides the target component.
+   * - `--toggle`: Toggles the visibility of the target component.
    *
    * @default '--auto'
    */
@@ -162,11 +116,11 @@ export interface PreactOverlayControlProps
     '--show' | '--hide' | '--toggle' | '--auto'
   >;
   /**
-   * The element that the [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
+   * The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.
    */
   commandFor: Extract<InteractionProps['commandFor'], string>;
   /**
-   * The element that the [interestFor](https://open-ui.org/components/interest-invokers.explainer/#the-pitch-in-code) should act on when this component is activated.
+   * The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.
    */
   interestFor: Extract<InteractionProps['interestFor'], string>;
 }
@@ -174,43 +128,37 @@ export interface PreactOverlayControlProps
 /**
  * Shared symbols for overlay control functionality.
  * These symbols are used by components that implement overlay behavior
- * (such as Popover, Tooltip, and Modal) to communicate with the overlay control system.
+ * (like Popover, Tooltip, Modal, etc.) to communicate with the overlay control system.
  */
-/** @private */
+/**
+ * Symbol used to track the open or closed state of the overlay.
+ */
 declare const overlayHidden: unique symbol;
-/** @private */
+/**
+ * Symbol used to track the element that opened the overlay. In some cases, like tooltips and popovers, the overlay is positioned against this element. In all cases, focus should be restored to this element when the overlay is closed.
+ */
 declare const overlayActivator: unique symbol;
-/** @private */
 declare const overlayHideFrameId: unique symbol;
 /**
- * The initialization object for creating a polyfill command event.
+ * Represents the initialization object for creating a polyfill command event. Used for overlay control commands in environments that require polyfills.
  * @publicDocs
  */
 export type PolyfillCommandEventInit = EventInit & {
-  /**
-   * The element that triggered the command.
-   */
   source: HTMLElement | null | undefined;
-  /**
-   * The command action that should be performed.
-   */
   command: PreactOverlayControlProps['command'];
+  rootActivator?: HTMLElement | null;
 };
 /**
- * A polyfill event for the command interaction pattern, which is used to control overlay elements.
+ * Represents a polyfill command event for overlay controls. Used in environments where native command events are not available.
  * @publicDocs
  */
 export type PolyfillCommandEvent = Event & {
-  /**
-   * The element that triggered the command.
-   */
   source: PolyfillCommandEventInit['source'];
-  /**
-   * The command action that should be performed.
-   */
   command: PolyfillCommandEventInit['command'];
-  /** You have to use `_s_shadowSource` because `source` is retargeted to the shadow host by browsers. */
+  /** Have to use `_s_shadowSource` because `source` is retargeted to the shadow host by browsers */
   _s_shadowSource: PolyfillCommandEventInit['source'];
+  /** Root activator for nested overlays (e.g., menu button when modal opened from menu item) */
+  _s_rootActivator?: HTMLElement | null;
 };
 declare global {
   interface GlobalEventHandlersEventMap {
@@ -218,14 +166,10 @@ declare global {
   }
 }
 
-/**
- * The base class for overlay elements that can be shown and hidden through command interactions.
- */
-declare class PreactOverlayElement extends PreactCustomElement {
-  /**
-   * Creates a new overlay element with the given render implementation.
-   */
+declare class PreactOverlayElement extends PolarisCustomElement {
   constructor(renderImpl: RenderImpl);
+  /** @private */
+  disconnectedCallback(): void;
   /** @private */
   [overlayHidden]: boolean;
   /** @private */
@@ -235,12 +179,10 @@ declare class PreactOverlayElement extends PreactCustomElement {
 }
 
 /**
- * A component that displays a small popup with explanatory text when the user hovers over or focuses on an element.
+ * Configure the following properties on the tooltip component.
+ * @publicDocs
  */
 declare class Tooltip extends PreactOverlayElement implements TooltipProps {
-  /**
-   * Creates a new Tooltip instance.
-   */
   constructor();
 }
 declare global {
@@ -256,19 +198,14 @@ declare module 'preact' {
   }
 }
 
-/**
- * The custom element tag name for the tooltip component.
- */
 declare const tagName = 's-tooltip';
-/**
- * The JSX properties you can set on a tooltip component.
- * @publicDocs
- */
 export interface TooltipJSXProps
   extends Partial<TooltipProps>,
     Pick<TooltipProps$1, 'id' | 'children'> {
   /**
-   * The content to display inside the tooltip, which should include text or paragraph components, or raw text content.
+   * The informational text or elements displayed within the tooltip overlay, providing helpful context or explanations when users interact with the associated element.
+   *
+   * Only accepts text, paragraph components, and raw `textContent`.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
@@ -1,226 +1,177 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
   TextFieldProps,
   URLFieldProps$1,
-  ComponentChildren,
+  PreactCustomElement,
+  RenderImpl,
 } from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
 
 /**
- * An event object with a strongly-typed currentTarget property that references the specific HTML element type.
+ * An event object with a strongly-typed `currentTarget` property that references the specific HTML element that triggered the event.
+ *
+ * This type extends the standard DOM `Event` interface and ensures type safety when accessing the element that fired the event.
  * @publicDocs
  */
 export type CallbackEvent<T extends keyof HTMLElementTagNameMap> = Event & {
-  /**
-   * The DOM element that the event listener is attached to.
-   */
   currentTarget: HTMLElementTagNameMap[T];
 };
 /**
- * An event listener function or null that receives a typed callback event.
+ * A function that handles events from UI components.
+ *
+ * This type represents an event listener callback that receives a `CallbackEvent` with a strongly-typed `currentTarget`. Use this for component event handlers like `click`, `focus`, `blur`, and other DOM events.
+ *
+ * @example
+ * const handleClick: CallbackEventListener<'button'> = (event) => {
+ *   console.log('Button clicked:', event.currentTarget);
+ * };
  * @publicDocs
  */
 export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
   | (EventListener & {
-      /**
-       * The callback function that's invoked when the event fires.
-       */
       (event: CallbackEvent<T>): void;
     })
   | null;
-/**
- * The React-style event handler props for form field components.
- * @publicDocs
- */
-export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
+export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
   /**
-   * A callback that's triggered when the field's value changes as the user types.
+   * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
   onInput?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field's value changes and the field loses focus.
+   * A callback fired when the user has finished editing the field, such as when they blur the field.
    */
   onChange?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field receives focus.
+   * A callback fired when the field receives focus.
    */
   onFocus?: ((event: CallbackEvent<T>) => void) | null;
   /**
-   * A callback that's triggered when the field loses focus.
+   * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-}
+};
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
+ * Props for field slot content (label, error, details) that accept
+ * either a string or JSX content in the React wrapper.
+ *
+ * Internal use only — not exported publicly. External consumers receive
+ * string-only types via FieldSlotPreactProps.
+ */
+export type FieldSlotInternalReactProps = {
+  error?: preact.ComponentChildren;
+  details?: preact.ComponentChildren;
+};
+/**
+ * Preact JSX string-only versions of field slot props.
+ * Used in Preact module declarations after Omit-ing the ComponentChildren
+ * versions (required by force-omit-react-slots lint rule).
+ */
+export type FieldSlotPreactProps = {
+  error?: string;
+  details?: string;
+};
+/**
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 
-/**
- * A string containing CSS styles to be applied to the component.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation details for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * A function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The CSS styles to apply to the component.
-   */
-  styles?: Styles;
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
 };
-/**
- * An object containing information about keyboard and mouse button states during an activation event.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta (Command on Mac, Windows key on PC) key was pressed during the event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the event.
-   */
-  button: number;
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
 }
-/**
- * The options for programmatically triggering a click event on an element.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
 
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 declare const internals: unique symbol;
 /**
- * The required props for input elements that all form controls must implement.
+ * Represents the essential input props required for Preact-based input elements. Includes properties like `disabled`, `id`, `name`, and `value`.
  * @publicDocs
  */
 export type PreactInputProps = Required<
   Pick<TextFieldProps, 'disabled' | 'id' | 'name' | 'value'>
 >;
-/**
- * The base class for form input elements that participate in form submission.
- */
 declare class PreactInputElement
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements PreactInputProps
 {
-  /** @private */
   static formAssociated: boolean;
   /** @private */
   [internals]: ElementInternals;
-  /**
-   * The callback that's triggered when the input value changes and the field loses focus.
-   */
   accessor onchange: CallbackEventListener<'input'>;
-  /**
-   * The callback that's triggered when the input value changes as the user types.
-   */
   accessor oninput: CallbackEventListener<'input'>;
-  /**
-   * Whether the input is disabled and can't be interacted with.
-   */
   accessor disabled: PreactInputProps['disabled'];
-  /**
-   * The unique identifier for the input element.
-   */
   accessor id: PreactInputProps['id'];
-  /**
-   * The name of the input, used when submitting form data.
-   */
   accessor name: PreactInputProps['name'];
-  /**
-   * The current value of the input.
-   */
   get value(): PreactInputProps['value'];
-  /**
-   * The current value of the input.
-   */
   set value(value: PreactInputProps['value']);
   constructor(renderImpl: RenderImpl);
 }
 
 /**
- * The common props shared by all form field components in the admin UI.
+ * Represents the props for Preact-based form field components with autocomplete support. The generic type parameter allows specifying the valid autocomplete values for the field.
  * @publicDocs
  */
 export type PreactFieldProps<Autocomplete extends string = string> =
@@ -239,17 +190,17 @@ export type PreactFieldProps<Autocomplete extends string = string> =
       >
     > & {
       /**
-       * A hint about the intended content of the field for browser autofill.
+       * A hint as to the intended content of the field.
        *
        * When set to `on` (the default), this property indicates that the field should support
-       * autofill, but you don't have any more semantic information on the intended
+       * autofill, but you do not have any more semantic information on the intended
        * contents.
        *
-       * When set to `off`, you're indicating that this field contains sensitive
+       * When set to `off`, you are indicating that this field contains sensitive
        * information, or contents that are never saved, like one-time codes.
        *
-       * Alternatively, you can provide a value which describes the
-       * specific data you'd like to be entered into this field during autofill.
+       * Alternatively, you can provide value which describes the
+       * specific data you would like to be entered into this field during autofill.
        *
        * @see Learn more about the set of {@link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens|autocomplete values} supported in browsers.
        *
@@ -260,63 +211,27 @@ export type PreactFieldProps<Autocomplete extends string = string> =
        */
       autocomplete: Autocomplete;
     };
-/**
- * The base class for form field elements that includes label, error, and validation support.
- */
 declare class PreactFieldElement<Autocomplete extends string = string>
   extends PreactInputElement
   implements PreactFieldProps<Autocomplete>
 {
-  /**
-   * The callback that's triggered when the field loses focus.
-   */
   accessor onblur: CallbackEventListener<'input'>;
-  /**
-   * The callback that's triggered when the field receives focus.
-   */
   accessor onfocus: CallbackEventListener<'input'>;
-  /**
-   * A hint about the intended content of the field for browser autofill.
-   */
   accessor autocomplete: PreactFieldProps<Autocomplete>['autocomplete'];
-  /**
-   * The initial value of the field when it's first rendered.
-   */
   accessor defaultValue: PreactFieldProps['defaultValue'];
-  /**
-   * The additional text displayed below the field to provide helpful context.
-   */
   accessor details: PreactFieldProps['details'];
-  /**
-   * The error message displayed when the field validation fails.
-   */
   accessor error: PreactFieldProps['error'];
-  /**
-   * The text label displayed above the field.
-   */
   accessor label: PreactFieldProps['label'];
-  /**
-   * The visibility of the label for accessibility purposes. Available values: `hidden`, `visible`.
-   */
   accessor labelAccessibilityVisibility: PreactFieldProps['labelAccessibilityVisibility'];
-  /**
-   * The hint text displayed inside the field when it's empty.
-   */
   accessor placeholder: PreactFieldProps['placeholder'];
-  /**
-   * Whether the field is read-only and can't be edited by the user.
-   */
   accessor readOnly: PreactFieldProps['readOnly'];
-  /**
-   * Whether the field must be filled out before the form can be submitted.
-   */
   accessor required: PreactFieldProps['required'];
   /**
    * Global keyboard event handlers for things like key bindings typically
    * ignore keystrokes originating from within input elements. Unfortunately,
-   * these never account for a custom element being the input element.
+   * these never account for a Custom Element being the input element.
    *
-   * To fix this, we spoof getAttribute and hasAttribute to make a PreactFieldElement
+   * To fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement
    * appear as a contentEditable "input" when it contains a focused input element.
    * @private technically not private, but we don't want to expose this as public API
    */
@@ -326,8 +241,8 @@ declare class PreactFieldElement<Autocomplete extends string = string>
    */
   hasAttribute(qualifiedName: string): boolean;
   /**
-   * Checks if the shadow tree contains a focused input (input, textarea, select, contentEditable element).
-   * Note: this doesn't return true for focused non-field form elements like buttons.
+   * Checks if the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).
+   * Note: this does _not_ return true for focussed non-field form elements like buttons.
    * @private
    */
   get isContentEditable(): boolean;
@@ -339,7 +254,7 @@ declare class PreactFieldElement<Autocomplete extends string = string>
 }
 
 /**
- * The properties for the URL field component. These properties configure an input field that allows merchants to enter and validate web addresses (URLs) with built-in validation.
+ * Represents the props for URL input field components. Extends `PreactFieldProps` with autocomplete support for URL-related fields.
  * @publicDocs
  */
 export type URLFieldProps = PreactFieldProps<
@@ -347,32 +262,21 @@ export type URLFieldProps = PreactFieldProps<
 > &
   Required<Pick<URLFieldProps$1, 'maxLength' | 'minLength'>>;
 
-/**
- * The URL field custom element class that renders a URL input field in the Shopify admin interface. This component allows merchants to enter web addresses with automatic URL validation and appropriate mobile keyboard layouts.
- */
-declare class URLField
+declare abstract class URLFieldBase
   extends PreactFieldElement<URLFieldProps['autocomplete']>
-  implements URLFieldProps
+  implements Pick<URLFieldProps, 'autocomplete' | 'maxLength' | 'minLength'>
 {
-  /**
-   * A hint about the intended content of the field for browser autofill.
-   *
-   * @default 'url'
-   */
   accessor autocomplete: URLFieldProps['autocomplete'];
-  /**
-   * The maximum number of characters allowed in the URL.
-   */
   accessor maxLength: URLFieldProps['maxLength'];
-  /**
-   * The minimum number of characters required in the URL.
-   */
   accessor minLength: URLFieldProps['minLength'];
-  /**
-   * The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing.
-   */
-  get value(): string;
-  set value(value: string);
+  constructor(renderImpl: RenderImpl);
+}
+
+/**
+ * Configure the following properties on the URL field component.
+ * @publicDocs
+ */
+declare class URLField extends URLFieldBase implements URLFieldProps {
   constructor();
 }
 declare global {
@@ -383,20 +287,19 @@ declare global {
 declare module 'preact' {
   namespace createElement.JSX {
     interface IntrinsicElements {
-      [tagName]: URLFieldJSXProps & PreactBaseElementProps<URLField>;
+      [tagName]: Omit<URLFieldJSXProps, 'error' | 'details'> &
+        FieldSlotPreactProps &
+        PreactBaseElementProps<URLField>;
     }
   }
 }
 
 declare const tagName = 's-url-field';
-/**
- * The JSX props for the URL field component. These properties extend `URLFieldProps` with JSX-specific event callbacks for React-style event handling when used in Preact.
- * @publicDocs
- */
 export interface URLFieldJSXProps
-  extends Partial<Omit<URLFieldProps, 'accessory'>>,
+  extends Partial<Omit<URLFieldProps, 'accessory' | 'error' | 'details'>>,
     Pick<URLFieldProps$1, 'id'>,
-    FieldReactProps<typeof tagName> {}
+    FieldReactProps<typeof tagName>,
+    FieldSlotInternalReactProps {}
 
 export {URLField};
 export type {URLFieldJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField.d.ts
@@ -1,14 +1,9 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {
@@ -45,7 +40,7 @@ export type CallbackEventListener<T extends keyof HTMLElementTagNameMap> =
       (event: CallbackEvent<T>): void;
     })
   | null;
-export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
+export interface FieldReactProps<T extends keyof HTMLElementTagNameMap> {
   /**
    * A callback fired when the user makes changes to the field value. This fires before `onChange`.
    */
@@ -62,7 +57,7 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
    * A callback fired when the field loses focus.
    */
   onBlur?: ((event: CallbackEvent<T>) => void) | null;
-};
+}
 /**
  * Props for field slot content (label, error, details) that accept
  * either a string or JSX content in the React wrapper.
@@ -70,19 +65,19 @@ export type FieldReactProps<T extends keyof HTMLElementTagNameMap> = {
  * Internal use only — not exported publicly. External consumers receive
  * string-only types via FieldSlotPreactProps.
  */
-export type FieldSlotInternalReactProps = {
+export interface FieldSlotInternalReactProps {
   error?: preact.ComponentChildren;
   details?: preact.ComponentChildren;
-};
+}
 /**
  * Preact JSX string-only versions of field slot props.
  * Used in Preact module declarations after Omit-ing the ComponentChildren
  * versions (required by force-omit-react-slots lint rule).
  */
-export type FieldSlotPreactProps = {
+export interface FieldSlotPreactProps {
   error?: string;
   details?: string;
-};
+}
 /**
  * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
@@ -1,14 +1,8 @@
 /** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-/* eslint-disable @typescript-eslint/ban-types */
+
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/member-ordering */
-/* eslint-disable line-comment-position */
-/* eslint-disable @typescript-eslint/unified-signatures */
-/* eslint-disable no-var */
-/* eslint-disable import/no-deprecated */
-/* eslint-disable import/namespace */
-/* eslint-disable import/no-deprecated */
+
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
 import type {

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList.d.ts
@@ -1,150 +1,109 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 /* eslint-disable import/extensions */
-
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-namespace */
-
+/* eslint-disable @typescript-eslint/member-ordering */
+/* eslint-disable line-comment-position */
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-var */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable import/namespace */
+/* eslint-disable import/no-deprecated */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren, UnorderedListProps$1} from './shared.d.ts';
+import type {
+  ComponentChildren,
+  UnorderedListProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
+import * as preact$1 from 'preact';
+import {ReactNode, RefAttributes} from 'react';
+
+export type ReactIntrinsicElementChildren<PreactProps extends object> =
+  'children' extends keyof PreactProps
+    ? {
+        children?: ReactNode;
+      }
+    : Record<never, never>;
+export type ReactIntrinsicElementProps<
+  PreactProps extends object,
+  ElementType,
+> = Omit<PreactProps, 'children' | 'key' | 'ref' | 'slot'> &
+  ReactIntrinsicElementChildren<PreactProps> &
+  RefAttributes<ElementType> & {
+    slot?: Lowercase<string>;
+  };
+export type ReactIntrinsicElements = {
+  [Tag in Exclude<
+    Extract<keyof preact$1.createElement.JSX.IntrinsicElements, `s-${string}`>,
+    `s-test-${string}`
+  >]: ReactIntrinsicElementProps<
+    preact$1.createElement.JSX.IntrinsicElements[Tag],
+    Tag extends keyof HTMLElementTagNameMap
+      ? HTMLElementTagNameMap[Tag]
+      : HTMLElement
+  >;
+};
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ReactIntrinsicElements {}
+  }
+}
 
 /**
- * The properties for the unordered list component. These properties define a bulleted list of items where the order doesn't matter.
- * @publicDocs
- * @publicDocs
+ * Configure the following properties on the unordered list component.
  */
 export interface UnorderedListProps extends UnorderedListProps$1 {}
 
-/**
- * A string containing CSS styles.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The configuration for rendering a custom element with a shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The function that renders the component's shadow DOM content.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * Optional CSS styles to apply to the shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * An object that represents the state of modifier keys and mouse button
- * during an activation event like a click.
- * @publicDocs
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the shift key was pressed during the event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the meta (Command on Mac, Windows key on PC) key was pressed.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the control key was pressed during the event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed (0 for left, 1 for middle, 2 for right).
-   */
-  button: number;
-}
-/**
- * Options for customizing click behavior on an element.
- * @publicDocs
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The original user event (such as a click or keyboard event) that triggered this programmatic click. When provided, the component preserves important event properties like modifier keys (Ctrl, Shift, Alt, Meta) and mouse button states, enabling behaviors such as opening links in a new tab when middle-clicked or Ctrl+clicked.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
   /** @private */
   connectedCallback(): void;
   /** @private */
-  disconnectedCallback(): void;
-  /** @private */
   adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
 }
 
 /**
- * The base properties for Preact elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
+ * Base props for Preact custom elements without children support. Includes common properties like key, ref, and slot for elements that don't accept child content.
  * @publicDocs
  */
 export interface PreactBaseElementProps<TClass extends HTMLElement> {
   /**
-   * A unique identifier for this element within its parent. Preact uses keys to optimize rendering performance when lists change by tracking which items have been added, removed, or reordered.
+   * A unique identifier for this element, used by the virtual DOM to efficiently track and update elements in lists.
+   * Essential for maintaining component state and optimizing re-renders when lists change.
    */
   key?: preact.Key;
   /**
-   * A reference to the underlying DOM element, typically created using `useRef()`. This allows you to access and manipulate the DOM element directly in your component logic.
+   * A reference to access the underlying DOM element directly.
+   * Typically created using `useRef()` to interact with the element imperatively or measure its properties.
    */
   ref?: preact.Ref<TClass>;
   /**
-   * Assigns this element to a named slot in a parent component that uses shadow DOM or slot-based composition patterns.
+   * The named slot to which this element is assigned in the parent component's shadow DOM.
+   *
+   * Used for advanced component composition with web components.
    */
   slot?: Lowercase<string>;
 }
 /**
- * The base properties for Preact elements that have children, extending the base element properties to include child content.
- * @publicDocs
+ * Base props for Preact custom elements with children support. Extends PreactBaseElementProps with the ability to render child elements.
  * @publicDocs
  */
 export interface PreactBaseElementPropsWithChildren<TClass extends HTMLElement>
   extends PreactBaseElementProps<TClass> {
+  /**
+   * The child elements to be rendered within this component.
+   */
   children?: preact.ComponentChildren;
 }
 
 /**
- * A custom element for displaying a bulleted list of items where the order doesn't matter. Use unordered list when you have a collection of related items without a specific sequence, such as features, options, or bullet points.
+ * Configure the following properties on the unordered list component.
+ * @publicDocs
  */
 declare class UnorderedList
-  extends PreactCustomElement
+  extends PolarisCustomElement
   implements UnorderedListProps
 {
   constructor();
@@ -164,16 +123,11 @@ declare module 'preact' {
 }
 
 declare const tagName = 's-unordered-list';
-/**
- * The JSX properties for the unordered list component. These properties define how an unordered list is rendered in Preact or JSX.
- * @publicDocs
- * @publicDocs
- */
 export interface UnorderedListJSXProps
   extends Partial<UnorderedListProps>,
     Pick<UnorderedListProps$1, 'id'> {
   /**
-   * The items in the unordered list. Only list item components are accepted.
+   * The list entries displayed within the unordered list, where each item is marked with a bullet point. Only accepts list item components as children. Each list item represents a single bulleted entry in the list.
    */
   children?: ComponentChildren;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
@@ -1,25 +1,22 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 2.23.0 **/
 
 /* eslint-disable @typescript-eslint/ban-types */
 
 /* eslint-disable @typescript-eslint/member-ordering */
 
 /**
- * TODO: Update `any` type here after this is resolved
- * https://github.com/Shopify/ui-api-design/issues/139
+ * Represents any valid children that can be rendered within a component, including elements, strings, numbers, or arrays of these types. This is an alias for Preact's `ComponentChildren` type.
  * @publicDocs
  */
 export type ComponentChildren = preact.ComponentChildren;
 /**
+ * Represents string-only children for components that specifically require text content.
  * @publicDocs
  */
 export type StringChildren = string;
-/**
- * @publicDocs
- */
 export interface GlobalProps {
   /**
-   * A unique identifier for the element.
+   * A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.
    */
   id?: string;
 }
@@ -28,27 +25,28 @@ export interface GlobalProps {
  */
 export interface ActionProps {
   /**
-   * The text to use as the Action modal’s title. If not provided, the name of the extension will be used.
+   * The text to use as the action modal's title. If not provided, the name of the extension will be used.
    */
   heading?: string;
 }
 /**
+ * The action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
  * @publicDocs
  */
 export interface ActionSlots {
   /**
-   * The primary action element, typically a button or link component representing the main call-to-action.
+   * The primary action button or link, representing the main or most important action available in this context. Typically displayed with higher visual prominence than secondary actions to establish clear hierarchy.
    */
   primaryAction?: ComponentChildren;
   /**
-   * The secondary action elements, typically button or link components representing alternative or supporting actions.
+   * Additional action buttons or links that provide alternative or supporting actions. Visually de-emphasized compared to the primary action.
    */
   secondaryActions?: ComponentChildren;
 }
 interface AdminActionProps$1 extends GlobalProps, ActionProps, ActionSlots {
   /**
-   * Whether the action is in a loading state, such as during initial page load or when the action is being opened.
-   * When `true`, the action might be in an inert state that prevents user interaction.
+   * Whether the action is in a loading state, such as initial page load or action opening.
+   * When true, the action could be in an inert state, which prevents user interaction.
    *
    * @default false
    */
@@ -56,21 +54,30 @@ interface AdminActionProps$1 extends GlobalProps, ActionProps, ActionSlots {
 }
 interface AdminBlockProps$1 extends GlobalProps {
   /**
-   * The text displayed as the block's title in the header. If not provided, the extension name will be used.
+   * The text to use as the Block title in the block header. If not provided, the name of the
+   * extension will be used.
    */
   heading?: string;
   /**
-   * The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated.
+   * The summary to display when the app block is collapsed.
+   * Summary longer than 30 characters will be truncated.
    */
   collapsedSummary?: string;
 }
 interface AdminPrintActionProps$1 extends GlobalProps {
   /**
-   * The source URL of the preview and the document to print.
+   * Sets the src URL of the preview and the document to print.
    * If not provided, the preview will show an empty state and the print button will be disabled.
-   * HTML, PDFs, and images are supported.
+   * HTML, PDFs and images are supported.
    */
   src?: string;
+  /**
+   * Programmatically controls the loading state of the component.
+   * When true, displays a loading indicator. The component also shows loading automatically when fetching the preview.
+   *
+   * @default false
+   */
+  loading?: boolean;
 }
 interface AppNavProps$1 extends GlobalProps {
   /**
@@ -104,12 +111,9 @@ export interface BaseOverlayProps {
   onAfterHide?: (event: Event) => void;
 }
 /**
- * Shared interfaces for web component methods.
+ * Shared interface for web component methods that control overlay visibility.
  *
- * Methods are required (not optional) because:
- * - Components implementing this interface must provide all methods
- * - Unlike props/attributes, methods are not rendered in HTML but are JavaScript APIs
- * - Consumers expect these methods to be consistently available on all instances
+ * All methods are required (not optional) because components implementing this interface must provide consistent JavaScript APIs. Unlike props/attributes, methods are not rendered in HTML and consumers expect them to be available on all component instances.
  * @publicDocs
  */
 export interface BaseOverlayMethods {
@@ -137,11 +141,15 @@ export interface BaseOverlayMethods {
  */
 export interface FocusEventProps {
   /**
-   * A callback fired when the element loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+   * A callback fired when the component loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event
    */
   onBlur?: (event: FocusEvent) => void;
   /**
-   * A callback fired when the element receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   * A callback fired when the component receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event
    */
   onFocus?: (event: FocusEvent) => void;
 }
@@ -152,27 +160,34 @@ export interface ToggleEventProps {
   /**
    * A callback fired when the element state changes, after any toggle animations have finished.
    *
-   * - If the element transitioned from hidden to showing, the `oldState` property will be set to `closed` and the
-   *   `newState` property will be set to `open`.
-   * - If the element transitioned from showing to hidden, the `oldState` property will be set to `open` and the
-   *   `newState` will be `closed`.
+   * - If the element transitioned from hidden to showing, the `oldState` property will be set to `closed` and the   `newState` property will be set to `open`.
+   * - If the element transitioned from showing to hidden, the `oldState` property will be set to `open` and the   `newState` will be `closed`.
    *
    * Learn more about [ToggleEvent.newState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState) and [ToggleEvent.oldState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState
    */
   onAfterToggle?: (event: ToggleEvent$1) => void;
   /**
    * A callback fired immediately when the element state changes, before any animations.
    *
-   * - If the element is transitioning from hidden to showing, the `oldState` property will be set to `closed` and the
-   *   `newState` property will be set to `open`.
-   * - If the element is transitioning from showing to hidden, then `oldState` property will be set to `open` and the
-   *   `newState` will be `closed`.
+   * - If the element is transitioning from hidden to showing, the `oldState` property will be set to `closed` and the   `newState` property will be set to `open`.
+   * - If the element is transitioning from showing to hidden, then `oldState` property will be set to `open` and the   `newState` will be `closed`.
    *
    * Learn more about the [toggle event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event), [ToggleEvent.newState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState), and [ToggleEvent.oldState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState
    */
   onToggle?: (event: ToggleEvent$1) => void;
 }
 /**
+ * Represents the visibility state of a toggleable element.
+ *
+ * - `open`: The element is visible or expanded.
+ * - `closed`: The element is hidden or collapsed.
  * @publicDocs
  */
 export type ToggleState = 'open' | 'closed';
@@ -185,28 +200,32 @@ interface ToggleEvent$1 extends Event {
  */
 export interface ExtendableEvent extends Event {
   /**
-   * A method that accepts a promise signaling the duration and eventual success or failure of actions relating to the event.
+   * A method that accepts a promise signaling the duration and eventual success or failure of event-related actions.
    *
-   * This might be called multiple times to add promises to the event.
-   *
-   * However, this might only be called synchronously during the dispatch of the event.
-   * As in, you cannot call it after a `setTimeout` or microtask.
+   * Can be called multiple times to add promises to the event, but must be called synchronously during event dispatch. Cannot be called after a `setTimeout` or within a microtask.
    */
   waitUntil?: (promise: Promise<void>) => void;
 }
-/**
- * @publicDocs
- */
-export interface AggregateError<T extends Error> extends Error {
+interface AggregateError$1<T extends Error> extends Error {
   errors: T[];
 }
 /**
  * @publicDocs
  */
 export interface AggregateErrorEvent<T extends Error> extends ErrorEvent {
-  error: AggregateError<T>;
+  /**
+   * The aggregated error object containing multiple individual errors. Access the `errors` property to retrieve the array of individual error instances.
+   */
+  error: AggregateError$1<T>;
 }
 /**
+ * Defines component sizes using a consistent scale from extra small to extra large.
+ *
+ * - `small-500` through `small-100`: Extra small to small sizes, progressively increasing.
+ * - `small`: Standard small size.
+ * - `base`: Default medium size that works well in most contexts.
+ * - `large`: Standard large size.
+ * - `large-100` through `large-500`: Large to extra large sizes, progressively increasing.
  * @publicDocs
  */
 export type SizeKeyword =
@@ -229,46 +248,41 @@ export type SizeKeyword =
  * - `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.
  * - `base`: Primary color for body text, standard UI elements, and general content with good readability.
  * - `strong`: Emphasized color for headings, key labels, and interactive elements that need prominence.
- *
  * @publicDocs
  */
 export type ColorKeyword = 'subdued' | 'base' | 'strong';
 interface AvatarProps$1 extends GlobalProps {
   /**
-   * The initials to display in the avatar when no image is provided or fails to load. Typically one or two characters representing a person's first and last name initials (e.g., "JD" for John Doe).
+   * Initials to display in the avatar.
    */
   initials?: string;
   /**
-   * The URL or path to the avatar image. When provided, the image takes priority over `initials`. If the image is not provided, fails to load, or loads slowly, `initials` will be rendered as a fallback.
+   * The URL or path to the image.
+   *
+   * Initials will be rendered as a fallback if `src` is not provided, fails to load or does not load quickly
    */
   src?: string;
   /**
-   * A callback fired when the avatar image loads successfully. Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload).
+   * Invoked when load of provided image completes successfully.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
    */
   onLoad?: (event: Event) => void;
   /**
-   * A callback fired when the avatar image fails to load. Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror).
+   * Invoked on load error of provided image.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
    */
   onError?: (event: Event) => void;
   /**
-   * The size of the avatar. Available sizes range from `small-500` (smallest) to `large-500` (largest), with `base` providing the default medium size that works well in most contexts.
+   * Size of the avatar.
    *
    * @default 'base'
    */
   size?: SizeKeyword;
   /**
-   * Alternative text that describes the avatar for accessibility.
-   *
-   * Provides a text description of the avatar for users with assistive technology
-   * and serves as a fallback when the avatar fails to load. A well-written description
-   * enables people with visual impairments to understand non-text content.
-   *
-   * When a screen reader encounters an avatar, it reads this description aloud.
-   * When an avatar fails to load, this text displays on screen, helping all users
-   * understand what content was intended.
-   *
-   * Learn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4)
-   * and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).
+   * An alternative text that describes the avatar for the reader
+   * to understand what it is about or identify the user the avatar belongs to.
    */
   alt?: string;
 }
@@ -277,16 +291,12 @@ interface AvatarProps$1 extends GlobalProps {
  *
  * - `transparent`: No background, allowing the underlying surface to show through.
  * - `ColorKeyword`: Applies color intensity levels (subdued, base, strong) to create spatial emphasis and containment.
- *
  * @publicDocs
  */
 export type BackgroundColorKeyword = 'transparent' | ColorKeyword;
-/**
- * @publicDocs
- */
 export interface BackgroundProps {
   /**
-   * The background color of the element. Use `transparent` for no background, or choose from `subdued`, `base`, or `strong` to apply varying levels of color intensity based on the component's `tone`.
+   * The background color of the element. Use `transparent` for no background, `subdued` for a subtle background, `base` for standard background, or `strong` for a prominent background.
    *
    * - `transparent`: No background, allowing the underlying surface to show through.
    * - `ColorKeyword`: Applies color intensity levels (subdued, base, strong) to create spatial emphasis and containment.
@@ -296,12 +306,19 @@ export interface BackgroundProps {
   background?: BackgroundColorKeyword;
 }
 /**
- * Tone is a property for defining the color treatment of a component.
+ * Defines the semantic color treatment of a component to convey specific intent or status.
  *
- * A tone can apply a grouping of colors to a component. For example,
- * critical might have a specific text color and background color.
+ * Tones apply coordinated color schemes (text, background, icons) across the component. Some components, like banner, also use tone to determine accessibility attributes and screen reader announcements.
  *
- * In some cases, like for Banner, the tone might also affect the semantic and accessibility treatment of the component.
+ * - `auto`: Automatically determined based on context.
+ * - `neutral`: General-purpose information without specific sentiment.
+ * - `info`: Informational content that provides helpful details or guidance.
+ * - `success`: Positive outcomes, successful operations, or confirmations.
+ * - `caution`: Warnings about potential issues that require attention but aren't critical.
+ * - `warning`: Similar to caution, indicates something that needs user awareness.
+ * - `critical`: Errors, failures, or urgent issues that require immediate attention.
+ * - `accent`: Highlighted or emphasized content that doesn't fit other semantic tones.
+ * - `custom`: Custom color treatment defined by your theme or implementation.
  *
  * @default 'auto'
  * @publicDocs
@@ -316,578 +333,582 @@ export type ToneKeyword =
   | 'critical'
   | 'accent'
   | 'custom';
-declare const privateIconArray: readonly [
-  'adjust',
-  'affiliate',
-  'airplane',
-  'alert-bubble',
-  'alert-circle',
-  'alert-diamond',
-  'alert-location',
-  'alert-octagon',
-  'alert-octagon-filled',
-  'alert-triangle',
-  'alert-triangle-filled',
-  'app-extension',
-  'apps',
-  'archive',
-  'arrow-down',
-  'arrow-down-circle',
-  'arrow-down-right',
-  'arrow-left',
-  'arrow-left-circle',
-  'arrow-right',
-  'arrow-right-circle',
-  'arrow-up',
-  'arrow-up-circle',
-  'arrow-up-right',
-  'arrows-in-horizontal',
-  'arrows-out-horizontal',
-  'asterisk',
-  'attachment',
-  'automation',
-  'backspace',
-  'bag',
-  'bank',
-  'barcode',
-  'battery-low',
-  'bill',
-  'blank',
-  'blog',
-  'bolt',
-  'bolt-filled',
-  'book',
-  'book-open',
-  'bug',
-  'bullet',
-  'business-entity',
-  'button',
-  'button-press',
-  'calculator',
-  'calendar',
-  'calendar-check',
-  'calendar-compare',
-  'calendar-list',
-  'calendar-time',
-  'camera',
-  'camera-flip',
-  'caret-down',
-  'caret-left',
-  'caret-right',
-  'caret-up',
-  'cart',
-  'cart-abandoned',
-  'cart-discount',
-  'cart-down',
-  'cart-filled',
-  'cart-sale',
-  'cart-send',
-  'cart-up',
-  'cash-dollar',
-  'cash-euro',
-  'cash-pound',
-  'cash-rupee',
-  'cash-yen',
-  'catalog-product',
-  'categories',
-  'channels',
-  'chart-cohort',
-  'chart-donut',
-  'chart-funnel',
-  'chart-histogram-first',
-  'chart-histogram-first-last',
-  'chart-histogram-flat',
-  'chart-histogram-full',
-  'chart-histogram-growth',
-  'chart-histogram-last',
-  'chart-histogram-second-last',
-  'chart-horizontal',
-  'chart-line',
-  'chart-popular',
-  'chart-stacked',
-  'chart-vertical',
-  'chat',
-  'chat-new',
-  'chat-referral',
-  'check',
-  'check-circle',
-  'check-circle-filled',
-  'checkbox',
-  'chevron-down',
-  'chevron-down-circle',
-  'chevron-left',
-  'chevron-left-circle',
-  'chevron-right',
-  'chevron-right-circle',
-  'chevron-up',
-  'chevron-up-circle',
-  'circle',
-  'circle-dashed',
-  'clipboard',
-  'clipboard-check',
-  'clipboard-checklist',
-  'clock',
-  'clock-list',
-  'clock-revert',
-  'code',
-  'code-add',
-  'collection',
-  'collection-featured',
-  'collection-list',
-  'collection-reference',
-  'color',
-  'color-none',
-  'compass',
-  'complete',
-  'compose',
-  'confetti',
-  'connect',
-  'content',
-  'contract',
-  'corner-pill',
-  'corner-round',
-  'corner-square',
-  'credit-card',
-  'credit-card-cancel',
-  'credit-card-percent',
-  'credit-card-reader',
-  'credit-card-reader-chip',
-  'credit-card-reader-tap',
-  'credit-card-secure',
-  'credit-card-tap-chip',
-  'crop',
-  'currency-convert',
-  'cursor',
-  'cursor-banner',
-  'cursor-option',
-  'data-presentation',
-  'data-table',
-  'database',
-  'database-add',
-  'database-connect',
-  'delete',
-  'delivered',
-  'delivery',
-  'desktop',
-  'disabled',
-  'disabled-filled',
-  'discount',
-  'discount-add',
-  'discount-automatic',
-  'discount-code',
-  'discount-remove',
-  'dns-settings',
-  'dock-floating',
-  'dock-side',
-  'domain',
-  'domain-landing-page',
-  'domain-new',
-  'domain-redirect',
-  'download',
-  'drag-drop',
-  'drag-handle',
-  'drawer',
-  'duplicate',
-  'edit',
-  'email',
-  'email-follow-up',
-  'email-newsletter',
-  'empty',
-  'enabled',
-  'enter',
-  'envelope',
-  'envelope-soft-pack',
-  'eraser',
-  'exchange',
-  'exit',
-  'export',
-  'external',
-  'eye-check-mark',
-  'eye-dropper',
-  'eye-dropper-list',
-  'eye-first',
-  'eyeglasses',
-  'fav',
-  'favicon',
-  'file',
-  'file-list',
-  'filter',
-  'filter-active',
-  'flag',
-  'flip-horizontal',
-  'flip-vertical',
-  'flower',
-  'folder',
-  'folder-add',
-  'folder-down',
-  'folder-remove',
-  'folder-up',
-  'food',
-  'foreground',
-  'forklift',
-  'forms',
-  'games',
-  'gauge',
-  'geolocation',
-  'gift',
-  'gift-card',
-  'git-branch',
-  'git-commit',
-  'git-repository',
-  'globe',
-  'globe-asia',
-  'globe-europe',
-  'globe-lines',
-  'globe-list',
-  'graduation-hat',
-  'grid',
-  'hashtag',
-  'hashtag-decimal',
-  'hashtag-list',
-  'heart',
-  'hide',
-  'hide-filled',
-  'home',
-  'home-filled',
-  'icons',
-  'identity-card',
-  'image',
-  'image-add',
-  'image-alt',
-  'image-explore',
-  'image-magic',
-  'image-none',
-  'image-with-text-overlay',
-  'images',
-  'import',
-  'in-progress',
-  'incentive',
-  'incoming',
-  'incomplete',
-  'info',
-  'info-filled',
-  'inheritance',
-  'inventory',
-  'inventory-edit',
-  'inventory-list',
-  'inventory-transfer',
-  'inventory-updated',
-  'iq',
-  'key',
-  'keyboard',
-  'keyboard-filled',
-  'keyboard-hide',
-  'keypad',
-  'label-printer',
-  'language',
-  'language-translate',
-  'layout-block',
-  'layout-buy-button',
-  'layout-buy-button-horizontal',
-  'layout-buy-button-vertical',
-  'layout-column-1',
-  'layout-columns-2',
-  'layout-columns-3',
-  'layout-footer',
-  'layout-header',
-  'layout-logo-block',
-  'layout-popup',
-  'layout-rows-2',
-  'layout-section',
-  'layout-sidebar-left',
-  'layout-sidebar-right',
-  'lightbulb',
-  'link',
-  'link-list',
-  'list-bulleted',
-  'list-bulleted-filled',
-  'list-numbered',
-  'live',
-  'live-critical',
-  'live-none',
-  'location',
-  'location-none',
-  'lock',
-  'map',
-  'markets',
-  'markets-euro',
-  'markets-rupee',
-  'markets-yen',
-  'maximize',
-  'measurement-size',
-  'measurement-size-list',
-  'measurement-volume',
-  'measurement-volume-list',
-  'measurement-weight',
-  'measurement-weight-list',
-  'media-receiver',
-  'megaphone',
-  'mention',
-  'menu',
-  'menu-filled',
-  'menu-horizontal',
-  'menu-vertical',
-  'merge',
-  'metafields',
-  'metaobject',
-  'metaobject-list',
-  'metaobject-reference',
-  'microphone',
-  'microphone-muted',
-  'minimize',
-  'minus',
-  'minus-circle',
-  'mobile',
-  'money',
-  'money-none',
-  'money-split',
-  'moon',
-  'nature',
-  'note',
-  'note-add',
-  'notification',
-  'number-one',
-  'order',
-  'order-batches',
-  'order-draft',
-  'order-filled',
-  'order-first',
-  'order-fulfilled',
-  'order-repeat',
-  'order-unfulfilled',
-  'orders-status',
-  'organization',
-  'outdent',
-  'outgoing',
-  'package',
-  'package-cancel',
-  'package-fulfilled',
-  'package-on-hold',
-  'package-reassign',
-  'package-returned',
-  'page',
-  'page-add',
-  'page-attachment',
-  'page-clock',
-  'page-down',
-  'page-heart',
-  'page-list',
-  'page-reference',
-  'page-remove',
-  'page-report',
-  'page-up',
-  'pagination-end',
-  'pagination-start',
-  'paint-brush-flat',
-  'paint-brush-round',
-  'paper-check',
-  'partially-complete',
-  'passkey',
-  'paste',
-  'pause-circle',
-  'payment',
-  'payment-capture',
-  'payout',
-  'payout-dollar',
-  'payout-euro',
-  'payout-pound',
-  'payout-rupee',
-  'payout-yen',
-  'person',
-  'person-add',
-  'person-exit',
-  'person-filled',
-  'person-list',
-  'person-lock',
-  'person-remove',
-  'person-segment',
-  'personalized-text',
-  'phablet',
-  'phone',
-  'phone-down',
-  'phone-down-filled',
-  'phone-in',
-  'phone-out',
-  'pin',
-  'pin-remove',
-  'plan',
-  'play',
-  'play-circle',
-  'plus',
-  'plus-circle',
-  'plus-circle-down',
-  'plus-circle-filled',
-  'plus-circle-up',
-  'point-of-sale',
-  'point-of-sale-register',
-  'price-list',
-  'print',
-  'product',
-  'product-add',
-  'product-cost',
-  'product-filled',
-  'product-list',
-  'product-reference',
-  'product-remove',
-  'product-return',
-  'product-unavailable',
-  'profile',
-  'profile-filled',
-  'question-circle',
-  'question-circle-filled',
-  'radio-control',
-  'receipt',
-  'receipt-dollar',
-  'receipt-euro',
-  'receipt-folded',
-  'receipt-paid',
-  'receipt-pound',
-  'receipt-refund',
-  'receipt-rupee',
-  'receipt-yen',
-  'receivables',
-  'redo',
-  'referral-code',
-  'refresh',
-  'remove-background',
-  'reorder',
-  'replace',
-  'replay',
-  'reset',
-  'return',
-  'reward',
-  'rocket',
-  'rotate-left',
-  'rotate-right',
-  'sandbox',
-  'save',
-  'savings',
-  'scan-qr-code',
-  'search',
-  'search-add',
-  'search-list',
-  'search-recent',
-  'search-resource',
-  'select',
-  'send',
-  'settings',
-  'share',
-  'shield-check-mark',
-  'shield-none',
-  'shield-pending',
-  'shield-person',
-  'shipping-label',
-  'shipping-label-cancel',
-  'shopcodes',
-  'slideshow',
-  'smiley-happy',
-  'smiley-joy',
-  'smiley-neutral',
-  'smiley-sad',
-  'social-ad',
-  'social-post',
-  'sort',
-  'sort-ascending',
-  'sort-descending',
-  'sound',
-  'split',
-  'sports',
-  'star',
-  'star-circle',
-  'star-filled',
-  'star-half',
-  'star-list',
-  'status',
-  'status-active',
-  'stop-circle',
-  'store',
-  'store-import',
-  'store-managed',
-  'store-online',
-  'sun',
-  'table',
-  'table-masonry',
-  'tablet',
-  'target',
-  'tax',
-  'team',
-  'text',
-  'text-align-center',
-  'text-align-left',
-  'text-align-right',
-  'text-block',
-  'text-bold',
-  'text-color',
-  'text-font',
-  'text-font-list',
-  'text-grammar',
-  'text-in-columns',
-  'text-in-rows',
-  'text-indent',
-  'text-indent-remove',
-  'text-italic',
-  'text-quote',
-  'text-title',
-  'text-underline',
-  'text-with-image',
-  'theme',
-  'theme-edit',
-  'theme-store',
-  'theme-template',
-  'three-d-environment',
-  'thumbs-down',
-  'thumbs-up',
-  'tip-jar',
-  'toggle-off',
-  'toggle-on',
-  'transaction',
-  'transaction-fee-add',
-  'transaction-fee-dollar',
-  'transaction-fee-euro',
-  'transaction-fee-pound',
-  'transaction-fee-rupee',
-  'transaction-fee-yen',
-  'transfer',
-  'transfer-in',
-  'transfer-internal',
-  'transfer-out',
-  'truck',
-  'undo',
-  'unknown-device',
-  'unlock',
-  'upload',
-  'variant',
-  'variant-list',
-  'video',
-  'video-list',
-  'view',
-  'viewport-narrow',
-  'viewport-short',
-  'viewport-tall',
-  'viewport-wide',
-  'wallet',
-  'wand',
-  'watch',
-  'wifi',
-  'work',
-  'work-list',
-  'wrench',
-  'x',
-  'x-circle',
-  'x-circle-filled',
-];
 /**
+ * Represents the available icon names that can be used in icon components. This is derived from the complete list of supported icons in the design system.
  * @publicDocs
  */
-export type IconType = (typeof privateIconArray)[number];
+export type IconType =
+  | 'adjust'
+  | 'affiliate'
+  | 'airplane'
+  | 'alert-bubble'
+  | 'alert-circle'
+  | 'alert-diamond'
+  | 'alert-location'
+  | 'alert-octagon'
+  | 'alert-octagon-filled'
+  | 'alert-triangle'
+  | 'alert-triangle-filled'
+  | 'align-horizontal-centers'
+  | 'app-extension'
+  | 'apps'
+  | 'archive'
+  | 'arrow-down'
+  | 'arrow-down-circle'
+  | 'arrow-down-right'
+  | 'arrow-left'
+  | 'arrow-left-circle'
+  | 'arrow-right'
+  | 'arrow-right-circle'
+  | 'arrow-up'
+  | 'arrow-up-circle'
+  | 'arrow-up-right'
+  | 'arrows-in-horizontal'
+  | 'arrows-out-horizontal'
+  | 'asterisk'
+  | 'attachment'
+  | 'automation'
+  | 'backspace'
+  | 'bag'
+  | 'bank'
+  | 'barcode'
+  | 'battery-low'
+  | 'bill'
+  | 'blank'
+  | 'blog'
+  | 'bolt'
+  | 'bolt-filled'
+  | 'book'
+  | 'book-open'
+  | 'brain'
+  | 'broom'
+  | 'bug'
+  | 'bullet'
+  | 'business-entity'
+  | 'button'
+  | 'button-press'
+  | 'calculator'
+  | 'calendar'
+  | 'calendar-check'
+  | 'calendar-compare'
+  | 'calendar-list'
+  | 'calendar-time'
+  | 'camera'
+  | 'camera-flip'
+  | 'caret-down'
+  | 'caret-left'
+  | 'caret-right'
+  | 'caret-up'
+  | 'cart'
+  | 'cart-abandoned'
+  | 'cart-discount'
+  | 'cart-down'
+  | 'cart-filled'
+  | 'cart-sale'
+  | 'cart-send'
+  | 'cart-up'
+  | 'cash-dollar'
+  | 'cash-euro'
+  | 'cash-pound'
+  | 'cash-rupee'
+  | 'cash-yen'
+  | 'catalog-product'
+  | 'categories'
+  | 'channels'
+  | 'channels-filled'
+  | 'chart-cohort'
+  | 'chart-donut'
+  | 'chart-funnel'
+  | 'chart-histogram-first'
+  | 'chart-histogram-first-last'
+  | 'chart-histogram-flat'
+  | 'chart-histogram-full'
+  | 'chart-histogram-growth'
+  | 'chart-histogram-last'
+  | 'chart-histogram-second-last'
+  | 'chart-horizontal'
+  | 'chart-line'
+  | 'chart-popular'
+  | 'chart-stacked'
+  | 'chart-vertical'
+  | 'chat'
+  | 'chat-new'
+  | 'chat-referral'
+  | 'check'
+  | 'check-circle'
+  | 'check-circle-filled'
+  | 'checkbox'
+  | 'chevron-down'
+  | 'chevron-down-circle'
+  | 'chevron-left'
+  | 'chevron-left-circle'
+  | 'chevron-right'
+  | 'chevron-right-circle'
+  | 'chevron-up'
+  | 'chevron-up-circle'
+  | 'circle'
+  | 'circle-dashed'
+  | 'clipboard'
+  | 'clipboard-check'
+  | 'clipboard-checklist'
+  | 'clock'
+  | 'clock-list'
+  | 'clock-revert'
+  | 'code'
+  | 'code-add'
+  | 'collection'
+  | 'collection-featured'
+  | 'collection-list'
+  | 'collection-reference'
+  | 'color'
+  | 'color-none'
+  | 'compass'
+  | 'complete'
+  | 'compose'
+  | 'confetti'
+  | 'connect'
+  | 'content'
+  | 'contract'
+  | 'corner-pill'
+  | 'corner-round'
+  | 'corner-square'
+  | 'credit-card'
+  | 'credit-card-cancel'
+  | 'credit-card-percent'
+  | 'credit-card-reader'
+  | 'credit-card-reader-chip'
+  | 'credit-card-reader-tap'
+  | 'credit-card-secure'
+  | 'credit-card-tap-chip'
+  | 'crop'
+  | 'currency-convert'
+  | 'cursor'
+  | 'cursor-banner'
+  | 'cursor-option'
+  | 'data-presentation'
+  | 'data-table'
+  | 'database'
+  | 'database-add'
+  | 'database-connect'
+  | 'delete'
+  | 'delivered'
+  | 'delivery'
+  | 'desktop'
+  | 'disabled'
+  | 'disabled-filled'
+  | 'discount'
+  | 'discount-add'
+  | 'discount-automatic'
+  | 'discount-code'
+  | 'discount-remove'
+  | 'dns-settings'
+  | 'dock-floating'
+  | 'dock-side'
+  | 'domain'
+  | 'domain-landing-page'
+  | 'domain-new'
+  | 'domain-redirect'
+  | 'download'
+  | 'drag-drop'
+  | 'drag-handle'
+  | 'drawer'
+  | 'duplicate'
+  | 'edit'
+  | 'email'
+  | 'email-follow-up'
+  | 'email-newsletter'
+  | 'empty'
+  | 'enabled'
+  | 'enter'
+  | 'envelope'
+  | 'envelope-soft-pack'
+  | 'eraser'
+  | 'exchange'
+  | 'exit'
+  | 'export'
+  | 'external'
+  | 'eye-check-mark'
+  | 'eye-dropper'
+  | 'eye-dropper-list'
+  | 'eye-first'
+  | 'eyeglasses'
+  | 'fav'
+  | 'favicon'
+  | 'file'
+  | 'file-list'
+  | 'filter'
+  | 'filter-active'
+  | 'flag'
+  | 'flip-horizontal'
+  | 'flip-vertical'
+  | 'flower'
+  | 'folder'
+  | 'folder-add'
+  | 'folder-down'
+  | 'folder-remove'
+  | 'folder-up'
+  | 'food'
+  | 'foreground'
+  | 'forklift'
+  | 'forms'
+  | 'games'
+  | 'gauge'
+  | 'geolocation'
+  | 'gift'
+  | 'gift-card'
+  | 'git-branch'
+  | 'git-commit'
+  | 'git-repository'
+  | 'globe'
+  | 'globe-asia'
+  | 'globe-europe'
+  | 'globe-lines'
+  | 'globe-list'
+  | 'graduation-hat'
+  | 'grid'
+  | 'hashtag'
+  | 'hashtag-decimal'
+  | 'hashtag-list'
+  | 'heart'
+  | 'hide'
+  | 'hide-filled'
+  | 'home'
+  | 'home-filled'
+  | 'icons'
+  | 'identity-card'
+  | 'image'
+  | 'image-add'
+  | 'image-alt'
+  | 'image-explore'
+  | 'image-magic'
+  | 'image-none'
+  | 'image-with-text-overlay'
+  | 'images'
+  | 'import'
+  | 'in-progress'
+  | 'incentive'
+  | 'incoming'
+  | 'incomplete'
+  | 'info'
+  | 'info-filled'
+  | 'inheritance'
+  | 'inventory'
+  | 'inventory-edit'
+  | 'inventory-list'
+  | 'inventory-transfer'
+  | 'inventory-updated'
+  | 'iq'
+  | 'key'
+  | 'keyboard'
+  | 'keyboard-filled'
+  | 'keyboard-hide'
+  | 'keypad'
+  | 'label-printer'
+  | 'language'
+  | 'language-translate'
+  | 'layout-block'
+  | 'layout-buy-button'
+  | 'layout-buy-button-horizontal'
+  | 'layout-buy-button-vertical'
+  | 'layout-column-1'
+  | 'layout-columns-2'
+  | 'layout-columns-3'
+  | 'layout-footer'
+  | 'layout-header'
+  | 'layout-logo-block'
+  | 'layout-popup'
+  | 'layout-rows-2'
+  | 'layout-section'
+  | 'layout-sidebar-left'
+  | 'layout-sidebar-right'
+  | 'layer'
+  | 'lightbulb'
+  | 'link'
+  | 'link-list'
+  | 'list-bulleted'
+  | 'list-bulleted-filled'
+  | 'list-numbered'
+  | 'live'
+  | 'live-critical'
+  | 'live-none'
+  | 'location'
+  | 'location-none'
+  | 'lock'
+  | 'map'
+  | 'markets'
+  | 'markets-euro'
+  | 'markets-rupee'
+  | 'markets-yen'
+  | 'maximize'
+  | 'measurement-size'
+  | 'measurement-size-list'
+  | 'measurement-volume'
+  | 'measurement-volume-list'
+  | 'measurement-weight'
+  | 'measurement-weight-list'
+  | 'media-receiver'
+  | 'megaphone'
+  | 'mention'
+  | 'menu'
+  | 'menu-filled'
+  | 'menu-horizontal'
+  | 'menu-vertical'
+  | 'merge'
+  | 'metafields'
+  | 'metaobject'
+  | 'metaobject-list'
+  | 'metaobject-reference'
+  | 'microphone'
+  | 'microphone-muted'
+  | 'minimize'
+  | 'minus'
+  | 'minus-circle'
+  | 'mobile'
+  | 'money'
+  | 'money-none'
+  | 'money-split'
+  | 'moon'
+  | 'nature'
+  | 'note'
+  | 'note-add'
+  | 'notification'
+  | 'number-one'
+  | 'order'
+  | 'order-batches'
+  | 'order-draft'
+  | 'order-filled'
+  | 'order-first'
+  | 'order-fulfilled'
+  | 'order-repeat'
+  | 'order-unfulfilled'
+  | 'orders-status'
+  | 'organization'
+  | 'outdent'
+  | 'outgoing'
+  | 'package'
+  | 'package-cancel'
+  | 'package-fulfilled'
+  | 'package-on-hold'
+  | 'package-reassign'
+  | 'package-returned'
+  | 'page'
+  | 'page-add'
+  | 'page-attachment'
+  | 'page-clock'
+  | 'page-down'
+  | 'page-heart'
+  | 'page-list'
+  | 'page-reference'
+  | 'page-remove'
+  | 'page-report'
+  | 'page-up'
+  | 'pagination-end'
+  | 'pagination-start'
+  | 'paint-brush-flat'
+  | 'paint-brush-round'
+  | 'paper-check'
+  | 'partially-complete'
+  | 'passkey'
+  | 'paste'
+  | 'pause-circle'
+  | 'payment'
+  | 'payment-capture'
+  | 'payout'
+  | 'payout-dollar'
+  | 'payout-euro'
+  | 'payout-pound'
+  | 'payout-rupee'
+  | 'payout-yen'
+  | 'person'
+  | 'person-add'
+  | 'person-exit'
+  | 'person-filled'
+  | 'person-list'
+  | 'person-lock'
+  | 'person-remove'
+  | 'person-segment'
+  | 'personalized-text'
+  | 'phablet'
+  | 'phone'
+  | 'phone-down'
+  | 'phone-down-filled'
+  | 'phone-in'
+  | 'phone-out'
+  | 'pin'
+  | 'pin-remove'
+  | 'plan'
+  | 'play'
+  | 'play-circle'
+  | 'plus'
+  | 'plus-circle'
+  | 'plus-circle-down'
+  | 'plus-circle-filled'
+  | 'plus-circle-up'
+  | 'point-of-sale'
+  | 'point-of-sale-register'
+  | 'price-list'
+  | 'print'
+  | 'product'
+  | 'product-add'
+  | 'product-cost'
+  | 'product-filled'
+  | 'product-list'
+  | 'product-reference'
+  | 'product-remove'
+  | 'product-return'
+  | 'product-unavailable'
+  | 'profile'
+  | 'profile-filled'
+  | 'question-circle'
+  | 'question-circle-filled'
+  | 'radio-control'
+  | 'receipt'
+  | 'receipt-dollar'
+  | 'receipt-euro'
+  | 'receipt-folded'
+  | 'receipt-paid'
+  | 'receipt-pound'
+  | 'receipt-refund'
+  | 'receipt-rupee'
+  | 'receipt-yen'
+  | 'receivables'
+  | 'redo'
+  | 'referral-code'
+  | 'refresh'
+  | 'remove-background'
+  | 'reorder'
+  | 'replace'
+  | 'replay'
+  | 'reset'
+  | 'return'
+  | 'reward'
+  | 'rocket'
+  | 'rotate-left'
+  | 'rotate-right'
+  | 'sandbox'
+  | 'save'
+  | 'savings'
+  | 'scan-qr-code'
+  | 'search'
+  | 'search-add'
+  | 'search-list'
+  | 'search-recent'
+  | 'search-resource'
+  | 'select'
+  | 'send'
+  | 'settings'
+  | 'share'
+  | 'shield-check-mark'
+  | 'shield-none'
+  | 'shield-pending'
+  | 'shield-person'
+  | 'shipping-label'
+  | 'shipping-label-cancel'
+  | 'shopcodes'
+  | 'slideshow'
+  | 'smiley-happy'
+  | 'smiley-joy'
+  | 'smiley-neutral'
+  | 'smiley-sad'
+  | 'social-ad'
+  | 'social-post'
+  | 'sort'
+  | 'sort-ascending'
+  | 'sort-descending'
+  | 'sound'
+  | 'split'
+  | 'sports'
+  | 'star'
+  | 'star-circle'
+  | 'star-filled'
+  | 'star-half'
+  | 'star-list'
+  | 'status'
+  | 'status-active'
+  | 'stop-circle'
+  | 'store'
+  | 'store-import'
+  | 'store-managed'
+  | 'store-online'
+  | 'sun'
+  | 'table'
+  | 'table-masonry'
+  | 'tablet'
+  | 'target'
+  | 'tax'
+  | 'team'
+  | 'text'
+  | 'text-align-center'
+  | 'text-align-left'
+  | 'text-align-right'
+  | 'text-block'
+  | 'text-bold'
+  | 'text-color'
+  | 'text-font'
+  | 'text-font-list'
+  | 'text-grammar'
+  | 'text-in-columns'
+  | 'text-in-rows'
+  | 'text-indent'
+  | 'text-indent-remove'
+  | 'text-italic'
+  | 'text-quote'
+  | 'text-title'
+  | 'text-underline'
+  | 'text-with-image'
+  | 'theme'
+  | 'theme-cart'
+  | 'theme-edit'
+  | 'theme-store'
+  | 'theme-template'
+  | 'three-d-environment'
+  | 'thumbs-down'
+  | 'thumbs-up'
+  | 'tip-jar'
+  | 'toggle-off'
+  | 'toggle-on'
+  | 'transaction'
+  | 'transaction-fee-add'
+  | 'transaction-fee-dollar'
+  | 'transaction-fee-euro'
+  | 'transaction-fee-pound'
+  | 'transaction-fee-rupee'
+  | 'transaction-fee-yen'
+  | 'transfer'
+  | 'transfer-in'
+  | 'transfer-internal'
+  | 'transfer-out'
+  | 'truck'
+  | 'undo'
+  | 'unknown-device'
+  | 'unlock'
+  | 'upload'
+  | 'variant'
+  | 'variant-list'
+  | 'video'
+  | 'video-list'
+  | 'view'
+  | 'viewport-narrow'
+  | 'viewport-short'
+  | 'viewport-tall'
+  | 'viewport-wide'
+  | 'wallet'
+  | 'wand'
+  | 'watch'
+  | 'wifi'
+  | 'work'
+  | 'work-list'
+  | 'wrench'
+  | 'x'
+  | 'x-circle'
+  | 'x-circle-filled';
 /**
- * Like `Extract`, but ensures that the extracted type is a strict subtype of the input type.
+ * A type-safe version of TypeScript's `Extract` utility that constrains the second type parameter to be assignable to the first. This provides compile-time validation that you're only extracting types that actually exist within the union, catching potential errors earlier in development.
  * @publicDocs
  */
 export type ExtractStrict<T, U extends T> = Extract<T, U>;
 /**
- * Represents CSS shorthand properties that accept one to four values.
- * Supports specifying values for all four sides: top, right, bottom, and left.
+ * Represents CSS shorthand properties that accept one to four values. Supports specifying values for all four sides: top, right, bottom, and left.
  *
  * - `T`: Single value that applies to all four sides.
  * - `${T} ${T}`: Two values for block axis (top/bottom) and inline axis (left/right).
@@ -901,8 +922,7 @@ export type MaybeAllValuesShorthandProperty<T extends string> =
   | `${T} ${T} ${T}`
   | `${T} ${T} ${T} ${T}`;
 /**
- * Represents CSS shorthand properties that accept one or two values.
- * Supports specifying the same value for both dimensions or different values.
+ * Represents CSS shorthand properties that accept one or two values. Supports specifying the same value for both dimensions or different values.
  *
  * - `T`: Single value that applies to both dimensions.
  * - `${T} ${T}`: Two values for block axis (vertical) and inline axis (horizontal).
@@ -910,8 +930,7 @@ export type MaybeAllValuesShorthandProperty<T extends string> =
  */
 export type MaybeTwoValuesShorthandProperty<T extends string> = T | `${T} ${T}`;
 /**
- * Makes a property responsive by allowing it to be set conditionally based on container query conditions.
- * The value can be either a base value or a container query string.
+ * Makes a property responsive by allowing it to be set conditionally based on container query conditions. The value can be either a base value or a container query string.
  *
  * - `T`: Base value that applies in all conditions.
  * - `@container${string}`: Container query string for conditional responsive styling based on container size.
@@ -919,7 +938,8 @@ export type MaybeTwoValuesShorthandProperty<T extends string> = T | `${T} ${T}`;
  */
 export type MaybeResponsive<T> = T | `@container${string}`;
 /**
- * Prevents widening string literal types in a union to `string`.
+ * A utility type that enables autocomplete for specific string literals while still accepting any string value. By intersecting `string` with an empty object type, this prevents TypeScript from widening literal types, preserving IDE suggestions for known values while maintaining flexibility for custom strings.
+ *
  * @example
  * type PropName = 'foo' | 'bar' | string
  * //   ^? string
@@ -929,54 +949,606 @@ export type MaybeResponsive<T> = T | `@container${string}`;
  */
 export type AnyString = string & {};
 /**
- * This is purely to give the ability
- * to have a space or not in the string literal types.
- *
- * For example in the `aspectRatio` property, `16/9` and `16 / 9` are both valid.
+ * A utility type representing an optional space character for use in string literal type composition. Allows flexible formatting of compound values where spacing is a matter of preference rather than semantic difference.
  * @publicDocs
  */
 export type optionalSpace = '' | ' ';
 interface BadgeProps$1 extends GlobalProps {
   /**
-   * The text or elements displayed inside the badge component.
+   * The content of the Badge.
    */
   children?: ComponentChildren;
   /**
-   * The semantic meaning and color treatment of the component.
-   *
-   * - `auto`: Automatically determined based on context.
-   * - `neutral`: General information without specific intent.
-   * - `info`: Informational content or helpful tips.
-   * - `success`: Positive outcomes or successful states.
-   * - `caution`: Advisory notices that need attention.
-   * - `warning`: Important warnings about potential issues.
-   * - `critical`: Urgent problems or destructive actions.
+   * Sets the tone of the Badge, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Controls the visual weight and emphasis of the badge.
-   *
-   * - `base`: Standard weight with moderate emphasis, suitable for most use cases.
-   * - `strong`: Increased visual weight for higher emphasis and prominence.
+   * Modify the color to be more or less intense.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning.
-   * Accepts any icon name from the icon library or a custom string identifier.
+   * The type of icon to be displayed in the badge.
    *
    * @default ''
    */
-  icon?: IconType | AnyString;
+  icon?:
+    | (
+        | 'adjust'
+        | 'affiliate'
+        | 'airplane'
+        | 'alert-bubble'
+        | 'alert-circle'
+        | 'alert-diamond'
+        | 'alert-location'
+        | 'alert-octagon'
+        | 'alert-octagon-filled'
+        | 'alert-triangle'
+        | 'alert-triangle-filled'
+        | 'align-horizontal-centers'
+        | 'app-extension'
+        | 'apps'
+        | 'archive'
+        | 'arrow-down'
+        | 'arrow-down-circle'
+        | 'arrow-down-right'
+        | 'arrow-left'
+        | 'arrow-left-circle'
+        | 'arrow-right'
+        | 'arrow-right-circle'
+        | 'arrow-up'
+        | 'arrow-up-circle'
+        | 'arrow-up-right'
+        | 'arrows-in-horizontal'
+        | 'arrows-out-horizontal'
+        | 'asterisk'
+        | 'attachment'
+        | 'automation'
+        | 'backspace'
+        | 'bag'
+        | 'bank'
+        | 'barcode'
+        | 'battery-low'
+        | 'bill'
+        | 'blank'
+        | 'blog'
+        | 'bolt'
+        | 'bolt-filled'
+        | 'book'
+        | 'book-open'
+        | 'brain'
+        | 'broom'
+        | 'bug'
+        | 'bullet'
+        | 'business-entity'
+        | 'button'
+        | 'button-press'
+        | 'calculator'
+        | 'calendar'
+        | 'calendar-check'
+        | 'calendar-compare'
+        | 'calendar-list'
+        | 'calendar-time'
+        | 'camera'
+        | 'camera-flip'
+        | 'caret-down'
+        | 'caret-left'
+        | 'caret-right'
+        | 'caret-up'
+        | 'cart'
+        | 'cart-abandoned'
+        | 'cart-discount'
+        | 'cart-down'
+        | 'cart-filled'
+        | 'cart-sale'
+        | 'cart-send'
+        | 'cart-up'
+        | 'cash-dollar'
+        | 'cash-euro'
+        | 'cash-pound'
+        | 'cash-rupee'
+        | 'cash-yen'
+        | 'catalog-product'
+        | 'categories'
+        | 'channels'
+        | 'channels-filled'
+        | 'chart-cohort'
+        | 'chart-donut'
+        | 'chart-funnel'
+        | 'chart-histogram-first'
+        | 'chart-histogram-first-last'
+        | 'chart-histogram-flat'
+        | 'chart-histogram-full'
+        | 'chart-histogram-growth'
+        | 'chart-histogram-last'
+        | 'chart-histogram-second-last'
+        | 'chart-horizontal'
+        | 'chart-line'
+        | 'chart-popular'
+        | 'chart-stacked'
+        | 'chart-vertical'
+        | 'chat'
+        | 'chat-new'
+        | 'chat-referral'
+        | 'check'
+        | 'check-circle'
+        | 'check-circle-filled'
+        | 'checkbox'
+        | 'chevron-down'
+        | 'chevron-down-circle'
+        | 'chevron-left'
+        | 'chevron-left-circle'
+        | 'chevron-right'
+        | 'chevron-right-circle'
+        | 'chevron-up'
+        | 'chevron-up-circle'
+        | 'circle'
+        | 'circle-dashed'
+        | 'clipboard'
+        | 'clipboard-check'
+        | 'clipboard-checklist'
+        | 'clock'
+        | 'clock-list'
+        | 'clock-revert'
+        | 'code'
+        | 'code-add'
+        | 'collection'
+        | 'collection-featured'
+        | 'collection-list'
+        | 'collection-reference'
+        | 'color'
+        | 'color-none'
+        | 'compass'
+        | 'complete'
+        | 'compose'
+        | 'confetti'
+        | 'connect'
+        | 'content'
+        | 'contract'
+        | 'corner-pill'
+        | 'corner-round'
+        | 'corner-square'
+        | 'credit-card'
+        | 'credit-card-cancel'
+        | 'credit-card-percent'
+        | 'credit-card-reader'
+        | 'credit-card-reader-chip'
+        | 'credit-card-reader-tap'
+        | 'credit-card-secure'
+        | 'credit-card-tap-chip'
+        | 'crop'
+        | 'currency-convert'
+        | 'cursor'
+        | 'cursor-banner'
+        | 'cursor-option'
+        | 'data-presentation'
+        | 'data-table'
+        | 'database'
+        | 'database-add'
+        | 'database-connect'
+        | 'delete'
+        | 'delivered'
+        | 'delivery'
+        | 'desktop'
+        | 'disabled'
+        | 'disabled-filled'
+        | 'discount'
+        | 'discount-add'
+        | 'discount-automatic'
+        | 'discount-code'
+        | 'discount-remove'
+        | 'dns-settings'
+        | 'dock-floating'
+        | 'dock-side'
+        | 'domain'
+        | 'domain-landing-page'
+        | 'domain-new'
+        | 'domain-redirect'
+        | 'download'
+        | 'drag-drop'
+        | 'drag-handle'
+        | 'drawer'
+        | 'duplicate'
+        | 'edit'
+        | 'email'
+        | 'email-follow-up'
+        | 'email-newsletter'
+        | 'empty'
+        | 'enabled'
+        | 'enter'
+        | 'envelope'
+        | 'envelope-soft-pack'
+        | 'eraser'
+        | 'exchange'
+        | 'exit'
+        | 'export'
+        | 'external'
+        | 'eye-check-mark'
+        | 'eye-dropper'
+        | 'eye-dropper-list'
+        | 'eye-first'
+        | 'eyeglasses'
+        | 'fav'
+        | 'favicon'
+        | 'file'
+        | 'file-list'
+        | 'filter'
+        | 'filter-active'
+        | 'flag'
+        | 'flip-horizontal'
+        | 'flip-vertical'
+        | 'flower'
+        | 'folder'
+        | 'folder-add'
+        | 'folder-down'
+        | 'folder-remove'
+        | 'folder-up'
+        | 'food'
+        | 'foreground'
+        | 'forklift'
+        | 'forms'
+        | 'games'
+        | 'gauge'
+        | 'geolocation'
+        | 'gift'
+        | 'gift-card'
+        | 'git-branch'
+        | 'git-commit'
+        | 'git-repository'
+        | 'globe'
+        | 'globe-asia'
+        | 'globe-europe'
+        | 'globe-lines'
+        | 'globe-list'
+        | 'graduation-hat'
+        | 'grid'
+        | 'hashtag'
+        | 'hashtag-decimal'
+        | 'hashtag-list'
+        | 'heart'
+        | 'hide'
+        | 'hide-filled'
+        | 'home'
+        | 'home-filled'
+        | 'icons'
+        | 'identity-card'
+        | 'image'
+        | 'image-add'
+        | 'image-alt'
+        | 'image-explore'
+        | 'image-magic'
+        | 'image-none'
+        | 'image-with-text-overlay'
+        | 'images'
+        | 'import'
+        | 'in-progress'
+        | 'incentive'
+        | 'incoming'
+        | 'incomplete'
+        | 'info'
+        | 'info-filled'
+        | 'inheritance'
+        | 'inventory'
+        | 'inventory-edit'
+        | 'inventory-list'
+        | 'inventory-transfer'
+        | 'inventory-updated'
+        | 'iq'
+        | 'key'
+        | 'keyboard'
+        | 'keyboard-filled'
+        | 'keyboard-hide'
+        | 'keypad'
+        | 'label-printer'
+        | 'language'
+        | 'language-translate'
+        | 'layout-block'
+        | 'layout-buy-button'
+        | 'layout-buy-button-horizontal'
+        | 'layout-buy-button-vertical'
+        | 'layout-column-1'
+        | 'layout-columns-2'
+        | 'layout-columns-3'
+        | 'layout-footer'
+        | 'layout-header'
+        | 'layout-logo-block'
+        | 'layout-popup'
+        | 'layout-rows-2'
+        | 'layout-section'
+        | 'layout-sidebar-left'
+        | 'layout-sidebar-right'
+        | 'layer'
+        | 'lightbulb'
+        | 'link'
+        | 'link-list'
+        | 'list-bulleted'
+        | 'list-bulleted-filled'
+        | 'list-numbered'
+        | 'live'
+        | 'live-critical'
+        | 'live-none'
+        | 'location'
+        | 'location-none'
+        | 'lock'
+        | 'map'
+        | 'markets'
+        | 'markets-euro'
+        | 'markets-rupee'
+        | 'markets-yen'
+        | 'maximize'
+        | 'measurement-size'
+        | 'measurement-size-list'
+        | 'measurement-volume'
+        | 'measurement-volume-list'
+        | 'measurement-weight'
+        | 'measurement-weight-list'
+        | 'media-receiver'
+        | 'megaphone'
+        | 'mention'
+        | 'menu'
+        | 'menu-filled'
+        | 'menu-horizontal'
+        | 'menu-vertical'
+        | 'merge'
+        | 'metafields'
+        | 'metaobject'
+        | 'metaobject-list'
+        | 'metaobject-reference'
+        | 'microphone'
+        | 'microphone-muted'
+        | 'minimize'
+        | 'minus'
+        | 'minus-circle'
+        | 'mobile'
+        | 'money'
+        | 'money-none'
+        | 'money-split'
+        | 'moon'
+        | 'nature'
+        | 'note'
+        | 'note-add'
+        | 'notification'
+        | 'number-one'
+        | 'order'
+        | 'order-batches'
+        | 'order-draft'
+        | 'order-filled'
+        | 'order-first'
+        | 'order-fulfilled'
+        | 'order-repeat'
+        | 'order-unfulfilled'
+        | 'orders-status'
+        | 'organization'
+        | 'outdent'
+        | 'outgoing'
+        | 'package'
+        | 'package-cancel'
+        | 'package-fulfilled'
+        | 'package-on-hold'
+        | 'package-reassign'
+        | 'package-returned'
+        | 'page'
+        | 'page-add'
+        | 'page-attachment'
+        | 'page-clock'
+        | 'page-down'
+        | 'page-heart'
+        | 'page-list'
+        | 'page-reference'
+        | 'page-remove'
+        | 'page-report'
+        | 'page-up'
+        | 'pagination-end'
+        | 'pagination-start'
+        | 'paint-brush-flat'
+        | 'paint-brush-round'
+        | 'paper-check'
+        | 'partially-complete'
+        | 'passkey'
+        | 'paste'
+        | 'pause-circle'
+        | 'payment'
+        | 'payment-capture'
+        | 'payout'
+        | 'payout-dollar'
+        | 'payout-euro'
+        | 'payout-pound'
+        | 'payout-rupee'
+        | 'payout-yen'
+        | 'person'
+        | 'person-add'
+        | 'person-exit'
+        | 'person-filled'
+        | 'person-list'
+        | 'person-lock'
+        | 'person-remove'
+        | 'person-segment'
+        | 'personalized-text'
+        | 'phablet'
+        | 'phone'
+        | 'phone-down'
+        | 'phone-down-filled'
+        | 'phone-in'
+        | 'phone-out'
+        | 'pin'
+        | 'pin-remove'
+        | 'plan'
+        | 'play'
+        | 'play-circle'
+        | 'plus'
+        | 'plus-circle'
+        | 'plus-circle-down'
+        | 'plus-circle-filled'
+        | 'plus-circle-up'
+        | 'point-of-sale'
+        | 'point-of-sale-register'
+        | 'price-list'
+        | 'print'
+        | 'product'
+        | 'product-add'
+        | 'product-cost'
+        | 'product-filled'
+        | 'product-list'
+        | 'product-reference'
+        | 'product-remove'
+        | 'product-return'
+        | 'product-unavailable'
+        | 'profile'
+        | 'profile-filled'
+        | 'question-circle'
+        | 'question-circle-filled'
+        | 'radio-control'
+        | 'receipt'
+        | 'receipt-dollar'
+        | 'receipt-euro'
+        | 'receipt-folded'
+        | 'receipt-paid'
+        | 'receipt-pound'
+        | 'receipt-refund'
+        | 'receipt-rupee'
+        | 'receipt-yen'
+        | 'receivables'
+        | 'redo'
+        | 'referral-code'
+        | 'refresh'
+        | 'remove-background'
+        | 'reorder'
+        | 'replace'
+        | 'replay'
+        | 'reset'
+        | 'return'
+        | 'reward'
+        | 'rocket'
+        | 'rotate-left'
+        | 'rotate-right'
+        | 'sandbox'
+        | 'save'
+        | 'savings'
+        | 'scan-qr-code'
+        | 'search'
+        | 'search-add'
+        | 'search-list'
+        | 'search-recent'
+        | 'search-resource'
+        | 'select'
+        | 'send'
+        | 'settings'
+        | 'share'
+        | 'shield-check-mark'
+        | 'shield-none'
+        | 'shield-pending'
+        | 'shield-person'
+        | 'shipping-label'
+        | 'shipping-label-cancel'
+        | 'shopcodes'
+        | 'slideshow'
+        | 'smiley-happy'
+        | 'smiley-joy'
+        | 'smiley-neutral'
+        | 'smiley-sad'
+        | 'social-ad'
+        | 'social-post'
+        | 'sort'
+        | 'sort-ascending'
+        | 'sort-descending'
+        | 'sound'
+        | 'split'
+        | 'sports'
+        | 'star'
+        | 'star-circle'
+        | 'star-filled'
+        | 'star-half'
+        | 'star-list'
+        | 'status'
+        | 'status-active'
+        | 'stop-circle'
+        | 'store'
+        | 'store-import'
+        | 'store-managed'
+        | 'store-online'
+        | 'sun'
+        | 'table'
+        | 'table-masonry'
+        | 'tablet'
+        | 'target'
+        | 'tax'
+        | 'team'
+        | 'text'
+        | 'text-align-center'
+        | 'text-align-left'
+        | 'text-align-right'
+        | 'text-block'
+        | 'text-bold'
+        | 'text-color'
+        | 'text-font'
+        | 'text-font-list'
+        | 'text-grammar'
+        | 'text-in-columns'
+        | 'text-in-rows'
+        | 'text-indent'
+        | 'text-indent-remove'
+        | 'text-italic'
+        | 'text-quote'
+        | 'text-title'
+        | 'text-underline'
+        | 'text-with-image'
+        | 'theme'
+        | 'theme-cart'
+        | 'theme-edit'
+        | 'theme-store'
+        | 'theme-template'
+        | 'three-d-environment'
+        | 'thumbs-down'
+        | 'thumbs-up'
+        | 'tip-jar'
+        | 'toggle-off'
+        | 'toggle-on'
+        | 'transaction'
+        | 'transaction-fee-add'
+        | 'transaction-fee-dollar'
+        | 'transaction-fee-euro'
+        | 'transaction-fee-pound'
+        | 'transaction-fee-rupee'
+        | 'transaction-fee-yen'
+        | 'transfer'
+        | 'transfer-in'
+        | 'transfer-internal'
+        | 'transfer-out'
+        | 'truck'
+        | 'undo'
+        | 'unknown-device'
+        | 'unlock'
+        | 'upload'
+        | 'variant'
+        | 'variant-list'
+        | 'video'
+        | 'video-list'
+        | 'view'
+        | 'viewport-narrow'
+        | 'viewport-short'
+        | 'viewport-tall'
+        | 'viewport-wide'
+        | 'wallet'
+        | 'wand'
+        | 'watch'
+        | 'wifi'
+        | 'work'
+        | 'work-list'
+        | 'wrench'
+        | 'x'
+        | 'x-circle'
+        | 'x-circle-filled'
+      )
+    | AnyString;
   /**
-   * The position of the icon relative to the badge text. Use `start` to place the icon before the text, or `end` to place it after.
+   * The position of the icon in relation to the text.
    */
   iconPosition?: 'start' | 'end';
   /**
-   * The size of the badge. Available sizes range from `small-500` (smallest) to `large-500` (largest), with `base` providing the default size.
+   * Adjusts the size.
    *
    * @default 'base'
    */
@@ -984,42 +1556,42 @@ interface BadgeProps$1 extends GlobalProps {
 }
 interface BannerProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The heading text displayed at the top of the banner to summarize the message or alert.
+   * The title of the banner.
    *
    * @default ''
    */
   heading?: string;
   /**
-   * The main content displayed within the banner component, typically descriptive text or other elements providing details about the message or alert.
+   * The content of the Banner.
    */
   children?: ComponentChildren;
   /**
-   * The semantic meaning and color treatment of the component. The banner is a live region and the type of status is dictated by the tone selected.
+   * Sets the tone of the Banner, based on the intention of the information being conveyed.
    *
-   * - `auto`: Automatically determined based on context.
-   * - `neutral`: General status information without emphasis.
-   * - `info`: Informational content or helpful tips.
-   * - `success`: Positive outcomes or successful states.
-   * - `caution`: Situations that need attention but aren't urgent.
-   * - `warning`: Important warnings about potential issues.
-   * - `critical`: Urgent problems or destructive actions.
+   * The banner is a live region and the type of status will be dictated by the Tone selected.
    *
-   * The `critical` tone creates an [assertive live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role) that is announced by screen readers immediately. The `neutral`, `info`, `success`, `warning`, and `caution` tones create an [informative live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role) that is announced by screen readers after the current message.
+   * - `critical` creates an [assertive live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) that is announced by screen readers immediately.
+   * - `neutral`, `info`, `success`, `warning` and `caution` creates an [informative live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) that is announced by screen readers after the current message.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
+   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
+   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * Whether the banner content can be collapsed and expanded by the user. A collapsible banner conceals child elements initially, allowing the user to expand the banner to reveal them.
+   * Makes the content collapsible.
+   * A collapsible banner will conceal child elements initially, but allow the user to expand the banner to see them.
    *
    * @default false
    */
   collapsible?: boolean;
   /**
-   * Whether the banner displays a close button that allows users to dismiss it.
+   * Determines whether the close button of the banner is present.
    *
    * When the close button is pressed, the `dismiss` event will fire,
-   * then `hidden` will be set to `true`,
+   * then `hidden` will be true,
    * any animation will complete,
    * and the `afterhide` event will fire.
    *
@@ -1027,17 +1599,17 @@ interface BannerProps$1 extends GlobalProps, ActionSlots {
    */
   dismissible?: boolean;
   /**
-   * A callback that fires when the banner is dismissed by the user clicking the close button.
+   * Event handler when the banner is dismissed by the user.
    *
-   * This doesn't fire when setting `hidden` manually.
+   * This does not fire when setting `hidden` manually.
    *
-   * The `hidden` property is `false` when this event fires.
+   * The `hidden` property will be `false` when this event fires.
    */
   onDismiss?: (event: Event) => void;
   /**
-   * A callback that fires when the banner has fully hidden, including after any hide animations have completed.
+   * Event handler when the banner has fully hidden.
    *
-   * The `hidden` property is `true` when this event fires.
+   * The `hidden` property will be `true` when this event fires.
    *
    * @implementation If implementations animate the hiding of the banner,
    * this event must fire after the banner has fully hidden.
@@ -1045,12 +1617,13 @@ interface BannerProps$1 extends GlobalProps, ActionSlots {
    */
   onAfterHide?: (event: Event) => void;
   /**
-   * Controls whether the banner is visible or hidden.
+   * Determines whether the banner is hidden.
    *
-   * When using a controlled component pattern and the banner is `dismissible`,
-   * update this property to `true` when the `dismiss` event fires.
+   * If this property is being set on each framework render (as in 'controlled' usage),
+   * and the banner is `dismissible`,
+   * ensure you update app state for this property when the `dismiss` event fires.
    *
-   * You can hide the banner programmatically by setting this to `true` even if it's not `dismissible`.
+   * If the banner is not `dismissible`, it can still be hidden by setting this property.
    *
    * @default false
    */
@@ -1061,13 +1634,14 @@ interface BannerProps$1 extends GlobalProps, ActionSlots {
  */
 export interface DisplayProps {
   /**
-   * Sets the outer display type of the component. The outer type sets a component’s participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
+   * The outer display type of the component. The outer type sets a component’s participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).
    *
    * - `auto`: the component’s initial value. The actual value depends on the component and context.
    * - `none`: hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
    *
    * Learn more about the [display property](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
    * @default 'auto'
    */
   display?: MaybeResponsive<'auto' | 'none'>;
@@ -1077,9 +1651,7 @@ export interface DisplayProps {
  */
 export interface AccessibilityRoleProps {
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help users
-   * navigate the page.
+   * The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.
    *
    * @implementation Although, in HTML hosts, this property changes the element used,
    * changing this property must not impact the visual styling of inside or outside of the box.
@@ -1091,8 +1663,7 @@ export interface AccessibilityRoleProps {
 /**
  * Defines the semantic role of a component for assistive technologies like screen readers.
  *
- * Accessibility roles help users with disabilities understand the purpose and structure of content.
- * These roles map to HTML elements and ARIA roles, providing semantic meaning beyond visual presentation.
+ * Accessibility roles help users with disabilities understand the purpose and structure of content. These roles map to HTML elements and ARIA roles, providing semantic meaning beyond visual presentation.
  *
  * Use these roles to:
  * - Improve navigation for screen reader users
@@ -1143,13 +1714,21 @@ export type AccessibilityRole =
   | 'footer'
   /**
    * Used to indicate a generic section.
-   * Sections should always have a heading or an accessible name provided in the `accessibilityLabel` property.
+   * Sections should always have a `Heading` or an accessible name provided in the `accessibilityLabel` property.
    *
    * In an HTML host `section` will render a `<section>` element.
    * Learn more about the [`<section>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) in the MDN web docs.
    *
    */
   | 'section'
+  /**
+   * Used to identify a perceivable section containing content that is relevant to a specific, author-specified purpose and sufficiently important that users will likely want to be able to navigate to the section easily.
+   *
+   * In an HTML host `region` will render as `<div role="region">`.
+   * A region **must** have an accessible name provided via the `accessibilityLabel` property.
+   * Learn more about the [`region` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) in the MDN web docs.
+   */
+  | 'region'
   /**
    * Used to designate a supporting section that relates to the main content.
    *
@@ -1234,12 +1813,9 @@ export type AccessibilityRole =
    * Learn more about the [`none` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/none_role) in the MDN web docs.
    */
   | 'none';
-/**
- * @publicDocs
- */
 export interface AccessibilityVisibilityProps {
   /**
-   * Controls the visibility of the element for both visual and assistive technology users.
+   * The visibility mode of the element for both visual and assistive technology users.
    *
    * - `visible`: The element is visible to all users (both sighted users and screen readers).
    * - `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.
@@ -1259,8 +1835,7 @@ export interface LabelAccessibilityVisibilityProps {
    * - `visible`: The label is shown to everyone (default).
    * - `exclusive`: The label is visually hidden but still announced by screen readers.
    *
-   * Use `exclusive` when the surrounding context makes the label redundant visually,
-   * but screen reader users still need it for clarity.
+   * Use `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.
    *
    * @default 'visible'
    */
@@ -1277,9 +1852,6 @@ export interface LabelAccessibilityVisibilityProps {
  * @publicDocs
  */
 export type PaddingKeyword = SizeKeyword | 'none';
-/**
- * @publicDocs
- */
 export interface PaddingProps {
   /**
    * The padding applied to all edges of the component.
@@ -1383,54 +1955,94 @@ export type SizeUnitsOrAuto = SizeUnits | 'auto';
  * @publicDocs
  */
 export type SizeUnitsOrNone = SizeUnits | 'none';
-/**
- * @publicDocs
- */
 export interface SizingProps {
   /**
-   * The block size of the element (height in horizontal writing modes). Learn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
+   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).
+   *
+   * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.
+   *
+   * Learn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
    *
    * - `SizeUnits`: Specific size values in pixels, percentages, or zero for precise control.
    * - `auto`: Automatically sizes based on content and layout constraints.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/block-size
    *
    * @default 'auto'
    */
   blockSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * The minimum block size of the element (minimum height in horizontal writing modes). Learn more about the [min-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
+   * The minimum vertical size of the element in standard layouts (min-height in left-to-right or right-to-left writing modes).
+   *
+   * Prevents the element from becoming smaller than this size along the block axis.
+   *
+   * Learn more about the [min-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size
    *
    * @default '0'
    */
   minBlockSize?: MaybeResponsive<SizeUnits>;
   /**
-   * The maximum block size of the element (maximum height in horizontal writing modes). Learn more about the [max-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
+   * The maximum vertical size of the element in standard layouts (max-height in left-to-right or right-to-left writing modes).
+   *
+   * Prevents the element from becoming larger than this size along the block axis.
+   *
+   * Learn more about the [max-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size
    *
    * @default 'none'
    */
   maxBlockSize?: MaybeResponsive<SizeUnitsOrNone>;
   /**
-   * The inline size of the element (width in horizontal writing modes). Learn more about the [inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
+   * The horizontal size of the element in standard layouts (width in left-to-right or right-to-left writing modes).
+   *
+   * Inline size adjusts based on the writing direction: in horizontal layouts, it controls the width; in vertical layouts, it controls the height. This ensures consistent behavior across different text directions.
+   *
+   * Learn more about the [inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).
    *
    * - `SizeUnits`: Specific size values in pixels, percentages, or zero for precise control.
    * - `auto`: Automatically sizes based on content and layout constraints.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size
    *
    * @default 'auto'
    */
   inlineSize?: MaybeResponsive<SizeUnitsOrAuto>;
   /**
-   * The minimum inline size of the element (minimum width in horizontal writing modes). Learn more about the [min-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
+   * The minimum horizontal size of the element in standard layouts (min-width in left-to-right or right-to-left writing modes).
+   *
+   * Prevents the element from becoming smaller than this size along the inline axis.
+   *
+   * Learn more about the [min-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size
    *
    * @default '0'
    */
   minInlineSize?: MaybeResponsive<SizeUnits>;
   /**
-   * The maximum inline size of the element (maximum width in horizontal writing modes). Learn more about the [max-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
+   * The maximum horizontal size of the element in standard layouts (max-width in left-to-right or right-to-left writing modes).
+   *
+   * Prevents the element from becoming larger than this size along the inline axis.
+   *
+   * Learn more about the [max-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size
    *
    * @default 'none'
    */
   maxInlineSize?: MaybeResponsive<SizeUnitsOrNone>;
 }
 /**
+ * Defines the visual style of borders.
+ *
+ * - `none`: No border is displayed.
+ * - `solid`: A single solid line.
+ * - `dashed`: A series of short dashes.
+ * - `dotted`: A series of dots.
+ * - `auto`: Automatically determined based on context.
  * @publicDocs
  */
 export type BorderStyleKeyword =
@@ -1448,6 +2060,7 @@ export type BorderStyleKeyword =
  */
 export type BorderSizeKeyword = SizeKeyword | 'none';
 /**
+ * Defines the radius of rounded corners, using the standard size scale, `max` for fully rounded, or `none` for sharp corners.
  * @publicDocs
  */
 export type BorderRadiusKeyword = SizeKeyword | 'max' | 'none';
@@ -1459,15 +2072,11 @@ export type BorderShorthand =
   | BorderSizeKeyword
   | `${BorderSizeKeyword} ${ColorKeyword}`
   | `${BorderSizeKeyword} ${ColorKeyword} ${BorderStyleKeyword}`;
-/**
- * @publicDocs
- */
 export interface BorderProps {
   /**
-   * Applies a border using shorthand syntax to specify width, color, and style in a single property.
+   * A border applied using shorthand syntax to specify width, color, and style in a single property.
    *
-   * Accepts a size value, optionally followed by a color, optionally followed by a style.
-   * Omitted values use defaults: color defaults to `base`, style defaults to `auto`.
+   * Accepts a size value, optionally followed by a color, optionally followed by a style. Omitted values use defaults: color defaults to `base`, style defaults to `auto`.
    *
    * Individual properties (`borderWidth`, `borderStyle`, `borderColor`) can override values set here.
    *
@@ -1480,7 +2089,7 @@ export interface BorderProps {
    */
   border?: BorderShorthand;
   /**
-   * Controls the thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
+   * The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.
    *
    * - `small`: Thin border for subtle definition.
    * - `small-100`: Extra thin border for minimal emphasis.
@@ -1499,7 +2108,7 @@ export interface BorderProps {
    */
   borderWidth?: MaybeAllValuesShorthandProperty<BorderSizeKeyword> | '';
   /**
-   * Controls the visual style of the border on all sides, such as solid, dashed, or dotted.
+   * The visual style of the border on all sides, such as solid, dashed, or dotted.
    *
    * When set, this overrides the style value specified in the `border` property.
    *
@@ -1513,16 +2122,15 @@ export interface BorderProps {
    */
   borderStyle?: MaybeAllValuesShorthandProperty<BorderStyleKeyword> | '';
   /**
-   * Controls the color of the border using the design system's color scale.
+   * The color of the border using the design system's color scale.
    *
-   * When set, this overrides the color value specified in the `border` property.
-   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.
+   * When set, this overrides the color value specified in the `border` property. Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.
    *
    * @default '' - meaning no override
    */
   borderColor?: ColorKeyword | '';
   /**
-   * Controls the roundedness of the element's corners using the design system's radius scale.
+   * The roundedness of the element's corners using the design system's radius scale.
    *
    * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:
    * - One value: applies to all corners
@@ -1545,12 +2153,10 @@ export interface BorderProps {
  */
 export interface OverflowProps {
   /**
-   * Sets the overflow behavior of the element.
+   * The overflow behavior of the element.
    *
    * - `visible`: the content that extends beyond the element’s container is visible.
-   * - `hidden`: clips the content when it is larger than the element’s container.
-   * The element will not be scrollable and the users will not be able
-   * to access the clipped content by dragging or using a scroll wheel on a mouse.
+   * - `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.
    *
    * @default 'visible'
    */
@@ -1568,7 +2174,7 @@ export interface BaseBoxProps
     BorderProps,
     OverflowProps {
   /**
-   * The content of the box.
+   * The content displayed within the box component, which serves as a flexible container for organizing and styling other components.
    */
   children?: ComponentChildren;
   /**
@@ -1588,19 +2194,21 @@ interface BoxProps$1 extends BaseBoxPropsWithRole, GlobalProps {}
  */
 export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
   /**
-   * The behavioral type of the button component, which determines what action it performs when activated.
+   * The behavior of the button component.
    *
-   * - `submit`: Submits the nearest containing form.
-   * - `button`: Performs no default action, relying on the `onClick` handler for behavior.
-   * - `reset`: Resets all fields in the nearest containing form to their default values.
+   * - `button`: Used to indicate the component acts as a button, meaning it has no default action.
+   * - `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).
+   * - `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.
    *
-   * This property is ignored if `href` or `commandFor`/`command` is set.
+   * This property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.
    *
    * @default 'button'
    */
   type?: 'submit' | 'button' | 'reset';
   /**
    * A callback fired when the button is activated, before performing the action indicated by `type`. Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
    */
   onClick?: (event: Event) => void;
   /**
@@ -1610,7 +2218,9 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
    */
   disabled?: boolean;
   /**
-   * Whether the button is in a loading state, which replaces the button content with a loading indicator and disables interactions.
+   * Whether to replace the button content with a loading indicator while a background action is being performed.
+   *
+   * This also disables the button component.
    *
    * @default false
    */
@@ -1625,15 +2235,17 @@ export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
    */
   href?: string;
   /**
-   * Specifies where to display the linked URL.
-   *
-   * Learn more about the [target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).
+   * The browsing context where the linked URL should be displayed.
    *
    * - `auto`: The target is automatically determined based on the origin of the URL.
    * - `_blank`: Opens the URL in a new window or tab.
    * - `_self`: Opens the URL in the same browsing context as the current one.
    * - `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.
    * - `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
+   *
+   * 'auto': The target is automatically determined based on the origin of the URL.
    *
    * @implementation Surfaces can set specific rules on how they handle each URL.
    * @implementation It’s expected that the behavior of `auto` is as `_self` except in specific cases.
@@ -1643,11 +2255,19 @@ export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
    */
   target?: 'auto' | '_blank' | '_self' | '_parent' | '_top' | AnyString;
   /**
-   * A filename that causes the browser to treat the linked URL as a download. Downloads only work for same-origin URLs or the `blob:` and `data:` schemes. Learn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).
+   * Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.
+   *
+   * The filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.
+   *
+   * Learn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download
    */
   download?: string;
   /**
    * A callback fired when the link is activated, before navigating to the location specified by `href`. Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
    */
   onClick?: (event: Event) => void;
 }
@@ -1657,20 +2277,24 @@ export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
 export interface InteractionProps {
   /**
    * The ID of the component to control when this component is activated. Pair with the `command` property to specify what action to perform on the target component. Learn more about the [commandfor attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor
    */
   commandFor?: string;
   /**
-   * The action that the `commandFor` target should take when this component is activated. The supported actions vary by target component type.
+   * The action that `commandFor` should take when this component is activated.
    *
-   * - `--auto`: Performs the default action appropriate for the target component.
-   * - `--show`: Displays the target component if it's currently hidden.
-   * - `--hide`: Conceals the target component from view.
-   * - `--toggle`: Alternates the target component between visible and hidden states.
-   * - `--copy`: Copies the content of the target `ClipboardItem` to the system clipboard.
+   * - `--auto`: A default action for the target component.
+   * - `--show`: Shows the target component.
+   * - `--hide`: Hides the target component.
+   * - `--toggle`: Toggles the visibility of the target component.
+   * - `--copy`: Copies the target `ClipboardItem`.
    *
    * Learn more about the [command attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
    *
    * @default '--auto'
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command
    */
   command?: '--auto' | '--show' | '--hide' | '--toggle' | '--copy';
   /**
@@ -1686,65 +2310,630 @@ export interface BaseClickableProps
     LinkBehaviorProps {}
 interface ButtonProps$1 extends GlobalProps, BaseClickableProps {
   /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   * A label that describes the purpose or contents of the Button. It will be read to users using assistive technologies such as screen readers.
+   *
+   * Use this when using only an icon or the Button text is not enough context
+   * for users using assistive technologies.
    */
   accessibilityLabel?: string;
   /**
-   * The content displayed within the button component.
+   * The content of the Button.
    */
   children?: ComponentChildren;
   /**
-   * An icon displayed inside the button, typically positioned before the button text.
-   * Use icons to help users quickly identify the button's action or to improve scannability.
-   * Accepts any icon name from the icon library or a custom string identifier.
+   * The type of icon to be displayed in the Button.
    *
    * @default ''
    */
-  icon?: IconType | AnyString;
+  icon?:
+    | (
+        | 'adjust'
+        | 'affiliate'
+        | 'airplane'
+        | 'alert-bubble'
+        | 'alert-circle'
+        | 'alert-diamond'
+        | 'alert-location'
+        | 'alert-octagon'
+        | 'alert-octagon-filled'
+        | 'alert-triangle'
+        | 'alert-triangle-filled'
+        | 'align-horizontal-centers'
+        | 'app-extension'
+        | 'apps'
+        | 'archive'
+        | 'arrow-down'
+        | 'arrow-down-circle'
+        | 'arrow-down-right'
+        | 'arrow-left'
+        | 'arrow-left-circle'
+        | 'arrow-right'
+        | 'arrow-right-circle'
+        | 'arrow-up'
+        | 'arrow-up-circle'
+        | 'arrow-up-right'
+        | 'arrows-in-horizontal'
+        | 'arrows-out-horizontal'
+        | 'asterisk'
+        | 'attachment'
+        | 'automation'
+        | 'backspace'
+        | 'bag'
+        | 'bank'
+        | 'barcode'
+        | 'battery-low'
+        | 'bill'
+        | 'blank'
+        | 'blog'
+        | 'bolt'
+        | 'bolt-filled'
+        | 'book'
+        | 'book-open'
+        | 'brain'
+        | 'broom'
+        | 'bug'
+        | 'bullet'
+        | 'business-entity'
+        | 'button'
+        | 'button-press'
+        | 'calculator'
+        | 'calendar'
+        | 'calendar-check'
+        | 'calendar-compare'
+        | 'calendar-list'
+        | 'calendar-time'
+        | 'camera'
+        | 'camera-flip'
+        | 'caret-down'
+        | 'caret-left'
+        | 'caret-right'
+        | 'caret-up'
+        | 'cart'
+        | 'cart-abandoned'
+        | 'cart-discount'
+        | 'cart-down'
+        | 'cart-filled'
+        | 'cart-sale'
+        | 'cart-send'
+        | 'cart-up'
+        | 'cash-dollar'
+        | 'cash-euro'
+        | 'cash-pound'
+        | 'cash-rupee'
+        | 'cash-yen'
+        | 'catalog-product'
+        | 'categories'
+        | 'channels'
+        | 'channels-filled'
+        | 'chart-cohort'
+        | 'chart-donut'
+        | 'chart-funnel'
+        | 'chart-histogram-first'
+        | 'chart-histogram-first-last'
+        | 'chart-histogram-flat'
+        | 'chart-histogram-full'
+        | 'chart-histogram-growth'
+        | 'chart-histogram-last'
+        | 'chart-histogram-second-last'
+        | 'chart-horizontal'
+        | 'chart-line'
+        | 'chart-popular'
+        | 'chart-stacked'
+        | 'chart-vertical'
+        | 'chat'
+        | 'chat-new'
+        | 'chat-referral'
+        | 'check'
+        | 'check-circle'
+        | 'check-circle-filled'
+        | 'checkbox'
+        | 'chevron-down'
+        | 'chevron-down-circle'
+        | 'chevron-left'
+        | 'chevron-left-circle'
+        | 'chevron-right'
+        | 'chevron-right-circle'
+        | 'chevron-up'
+        | 'chevron-up-circle'
+        | 'circle'
+        | 'circle-dashed'
+        | 'clipboard'
+        | 'clipboard-check'
+        | 'clipboard-checklist'
+        | 'clock'
+        | 'clock-list'
+        | 'clock-revert'
+        | 'code'
+        | 'code-add'
+        | 'collection'
+        | 'collection-featured'
+        | 'collection-list'
+        | 'collection-reference'
+        | 'color'
+        | 'color-none'
+        | 'compass'
+        | 'complete'
+        | 'compose'
+        | 'confetti'
+        | 'connect'
+        | 'content'
+        | 'contract'
+        | 'corner-pill'
+        | 'corner-round'
+        | 'corner-square'
+        | 'credit-card'
+        | 'credit-card-cancel'
+        | 'credit-card-percent'
+        | 'credit-card-reader'
+        | 'credit-card-reader-chip'
+        | 'credit-card-reader-tap'
+        | 'credit-card-secure'
+        | 'credit-card-tap-chip'
+        | 'crop'
+        | 'currency-convert'
+        | 'cursor'
+        | 'cursor-banner'
+        | 'cursor-option'
+        | 'data-presentation'
+        | 'data-table'
+        | 'database'
+        | 'database-add'
+        | 'database-connect'
+        | 'delete'
+        | 'delivered'
+        | 'delivery'
+        | 'desktop'
+        | 'disabled'
+        | 'disabled-filled'
+        | 'discount'
+        | 'discount-add'
+        | 'discount-automatic'
+        | 'discount-code'
+        | 'discount-remove'
+        | 'dns-settings'
+        | 'dock-floating'
+        | 'dock-side'
+        | 'domain'
+        | 'domain-landing-page'
+        | 'domain-new'
+        | 'domain-redirect'
+        | 'download'
+        | 'drag-drop'
+        | 'drag-handle'
+        | 'drawer'
+        | 'duplicate'
+        | 'edit'
+        | 'email'
+        | 'email-follow-up'
+        | 'email-newsletter'
+        | 'empty'
+        | 'enabled'
+        | 'enter'
+        | 'envelope'
+        | 'envelope-soft-pack'
+        | 'eraser'
+        | 'exchange'
+        | 'exit'
+        | 'export'
+        | 'external'
+        | 'eye-check-mark'
+        | 'eye-dropper'
+        | 'eye-dropper-list'
+        | 'eye-first'
+        | 'eyeglasses'
+        | 'fav'
+        | 'favicon'
+        | 'file'
+        | 'file-list'
+        | 'filter'
+        | 'filter-active'
+        | 'flag'
+        | 'flip-horizontal'
+        | 'flip-vertical'
+        | 'flower'
+        | 'folder'
+        | 'folder-add'
+        | 'folder-down'
+        | 'folder-remove'
+        | 'folder-up'
+        | 'food'
+        | 'foreground'
+        | 'forklift'
+        | 'forms'
+        | 'games'
+        | 'gauge'
+        | 'geolocation'
+        | 'gift'
+        | 'gift-card'
+        | 'git-branch'
+        | 'git-commit'
+        | 'git-repository'
+        | 'globe'
+        | 'globe-asia'
+        | 'globe-europe'
+        | 'globe-lines'
+        | 'globe-list'
+        | 'graduation-hat'
+        | 'grid'
+        | 'hashtag'
+        | 'hashtag-decimal'
+        | 'hashtag-list'
+        | 'heart'
+        | 'hide'
+        | 'hide-filled'
+        | 'home'
+        | 'home-filled'
+        | 'icons'
+        | 'identity-card'
+        | 'image'
+        | 'image-add'
+        | 'image-alt'
+        | 'image-explore'
+        | 'image-magic'
+        | 'image-none'
+        | 'image-with-text-overlay'
+        | 'images'
+        | 'import'
+        | 'in-progress'
+        | 'incentive'
+        | 'incoming'
+        | 'incomplete'
+        | 'info'
+        | 'info-filled'
+        | 'inheritance'
+        | 'inventory'
+        | 'inventory-edit'
+        | 'inventory-list'
+        | 'inventory-transfer'
+        | 'inventory-updated'
+        | 'iq'
+        | 'key'
+        | 'keyboard'
+        | 'keyboard-filled'
+        | 'keyboard-hide'
+        | 'keypad'
+        | 'label-printer'
+        | 'language'
+        | 'language-translate'
+        | 'layout-block'
+        | 'layout-buy-button'
+        | 'layout-buy-button-horizontal'
+        | 'layout-buy-button-vertical'
+        | 'layout-column-1'
+        | 'layout-columns-2'
+        | 'layout-columns-3'
+        | 'layout-footer'
+        | 'layout-header'
+        | 'layout-logo-block'
+        | 'layout-popup'
+        | 'layout-rows-2'
+        | 'layout-section'
+        | 'layout-sidebar-left'
+        | 'layout-sidebar-right'
+        | 'layer'
+        | 'lightbulb'
+        | 'link'
+        | 'link-list'
+        | 'list-bulleted'
+        | 'list-bulleted-filled'
+        | 'list-numbered'
+        | 'live'
+        | 'live-critical'
+        | 'live-none'
+        | 'location'
+        | 'location-none'
+        | 'lock'
+        | 'map'
+        | 'markets'
+        | 'markets-euro'
+        | 'markets-rupee'
+        | 'markets-yen'
+        | 'maximize'
+        | 'measurement-size'
+        | 'measurement-size-list'
+        | 'measurement-volume'
+        | 'measurement-volume-list'
+        | 'measurement-weight'
+        | 'measurement-weight-list'
+        | 'media-receiver'
+        | 'megaphone'
+        | 'mention'
+        | 'menu'
+        | 'menu-filled'
+        | 'menu-horizontal'
+        | 'menu-vertical'
+        | 'merge'
+        | 'metafields'
+        | 'metaobject'
+        | 'metaobject-list'
+        | 'metaobject-reference'
+        | 'microphone'
+        | 'microphone-muted'
+        | 'minimize'
+        | 'minus'
+        | 'minus-circle'
+        | 'mobile'
+        | 'money'
+        | 'money-none'
+        | 'money-split'
+        | 'moon'
+        | 'nature'
+        | 'note'
+        | 'note-add'
+        | 'notification'
+        | 'number-one'
+        | 'order'
+        | 'order-batches'
+        | 'order-draft'
+        | 'order-filled'
+        | 'order-first'
+        | 'order-fulfilled'
+        | 'order-repeat'
+        | 'order-unfulfilled'
+        | 'orders-status'
+        | 'organization'
+        | 'outdent'
+        | 'outgoing'
+        | 'package'
+        | 'package-cancel'
+        | 'package-fulfilled'
+        | 'package-on-hold'
+        | 'package-reassign'
+        | 'package-returned'
+        | 'page'
+        | 'page-add'
+        | 'page-attachment'
+        | 'page-clock'
+        | 'page-down'
+        | 'page-heart'
+        | 'page-list'
+        | 'page-reference'
+        | 'page-remove'
+        | 'page-report'
+        | 'page-up'
+        | 'pagination-end'
+        | 'pagination-start'
+        | 'paint-brush-flat'
+        | 'paint-brush-round'
+        | 'paper-check'
+        | 'partially-complete'
+        | 'passkey'
+        | 'paste'
+        | 'pause-circle'
+        | 'payment'
+        | 'payment-capture'
+        | 'payout'
+        | 'payout-dollar'
+        | 'payout-euro'
+        | 'payout-pound'
+        | 'payout-rupee'
+        | 'payout-yen'
+        | 'person'
+        | 'person-add'
+        | 'person-exit'
+        | 'person-filled'
+        | 'person-list'
+        | 'person-lock'
+        | 'person-remove'
+        | 'person-segment'
+        | 'personalized-text'
+        | 'phablet'
+        | 'phone'
+        | 'phone-down'
+        | 'phone-down-filled'
+        | 'phone-in'
+        | 'phone-out'
+        | 'pin'
+        | 'pin-remove'
+        | 'plan'
+        | 'play'
+        | 'play-circle'
+        | 'plus'
+        | 'plus-circle'
+        | 'plus-circle-down'
+        | 'plus-circle-filled'
+        | 'plus-circle-up'
+        | 'point-of-sale'
+        | 'point-of-sale-register'
+        | 'price-list'
+        | 'print'
+        | 'product'
+        | 'product-add'
+        | 'product-cost'
+        | 'product-filled'
+        | 'product-list'
+        | 'product-reference'
+        | 'product-remove'
+        | 'product-return'
+        | 'product-unavailable'
+        | 'profile'
+        | 'profile-filled'
+        | 'question-circle'
+        | 'question-circle-filled'
+        | 'radio-control'
+        | 'receipt'
+        | 'receipt-dollar'
+        | 'receipt-euro'
+        | 'receipt-folded'
+        | 'receipt-paid'
+        | 'receipt-pound'
+        | 'receipt-refund'
+        | 'receipt-rupee'
+        | 'receipt-yen'
+        | 'receivables'
+        | 'redo'
+        | 'referral-code'
+        | 'refresh'
+        | 'remove-background'
+        | 'reorder'
+        | 'replace'
+        | 'replay'
+        | 'reset'
+        | 'return'
+        | 'reward'
+        | 'rocket'
+        | 'rotate-left'
+        | 'rotate-right'
+        | 'sandbox'
+        | 'save'
+        | 'savings'
+        | 'scan-qr-code'
+        | 'search'
+        | 'search-add'
+        | 'search-list'
+        | 'search-recent'
+        | 'search-resource'
+        | 'select'
+        | 'send'
+        | 'settings'
+        | 'share'
+        | 'shield-check-mark'
+        | 'shield-none'
+        | 'shield-pending'
+        | 'shield-person'
+        | 'shipping-label'
+        | 'shipping-label-cancel'
+        | 'shopcodes'
+        | 'slideshow'
+        | 'smiley-happy'
+        | 'smiley-joy'
+        | 'smiley-neutral'
+        | 'smiley-sad'
+        | 'social-ad'
+        | 'social-post'
+        | 'sort'
+        | 'sort-ascending'
+        | 'sort-descending'
+        | 'sound'
+        | 'split'
+        | 'sports'
+        | 'star'
+        | 'star-circle'
+        | 'star-filled'
+        | 'star-half'
+        | 'star-list'
+        | 'status'
+        | 'status-active'
+        | 'stop-circle'
+        | 'store'
+        | 'store-import'
+        | 'store-managed'
+        | 'store-online'
+        | 'sun'
+        | 'table'
+        | 'table-masonry'
+        | 'tablet'
+        | 'target'
+        | 'tax'
+        | 'team'
+        | 'text'
+        | 'text-align-center'
+        | 'text-align-left'
+        | 'text-align-right'
+        | 'text-block'
+        | 'text-bold'
+        | 'text-color'
+        | 'text-font'
+        | 'text-font-list'
+        | 'text-grammar'
+        | 'text-in-columns'
+        | 'text-in-rows'
+        | 'text-indent'
+        | 'text-indent-remove'
+        | 'text-italic'
+        | 'text-quote'
+        | 'text-title'
+        | 'text-underline'
+        | 'text-with-image'
+        | 'theme'
+        | 'theme-cart'
+        | 'theme-edit'
+        | 'theme-store'
+        | 'theme-template'
+        | 'three-d-environment'
+        | 'thumbs-down'
+        | 'thumbs-up'
+        | 'tip-jar'
+        | 'toggle-off'
+        | 'toggle-on'
+        | 'transaction'
+        | 'transaction-fee-add'
+        | 'transaction-fee-dollar'
+        | 'transaction-fee-euro'
+        | 'transaction-fee-pound'
+        | 'transaction-fee-rupee'
+        | 'transaction-fee-yen'
+        | 'transfer'
+        | 'transfer-in'
+        | 'transfer-internal'
+        | 'transfer-out'
+        | 'truck'
+        | 'undo'
+        | 'unknown-device'
+        | 'unlock'
+        | 'upload'
+        | 'variant'
+        | 'variant-list'
+        | 'video'
+        | 'video-list'
+        | 'view'
+        | 'viewport-narrow'
+        | 'viewport-short'
+        | 'viewport-tall'
+        | 'viewport-wide'
+        | 'wallet'
+        | 'wand'
+        | 'watch'
+        | 'wifi'
+        | 'work'
+        | 'work-list'
+        | 'wrench'
+        | 'x'
+        | 'x-circle'
+        | 'x-circle-filled'
+      )
+    | AnyString;
   /**
-   * The inline width (horizontal size) of the button component.
+   * The displayed inline width of the Button.
    *
-   * - `auto`: The button size depends on the surface and context.
-   * - `fill`: The button takes up 100% of the available inline space.
-   * - `fit-content`: The button takes up only the space needed to fit its content.
+   * - `auto`: the size of the button depends on the surface and context.
+   * - `fill`: the button will takes up 100% of the available inline size.
+   * - `fit-content`: the button will take up the minimum inline-size required to fit its content.
    *
    * @default 'auto'
    */
   inlineSize?: 'auto' | 'fill' | 'fit-content';
   /**
-   * The visual style variant of the button component, which controls its prominence and emphasis in the interface.
+   * Changes the visual appearance of the Button.
    *
-   * @default 'auto' - the variant is automatically determined by the button's context
+   * @default 'auto' - the variant is automatically determined by the Button's context
    */
   variant?: 'auto' | 'primary' | 'secondary' | 'tertiary';
   /**
-   * The semantic meaning and color treatment of the component.
-   *
-   * - `critical`: Urgent problems or destructive actions.
-   * - `auto`: Automatically determined based on context.
-   * - `neutral`: General information without specific intent.
+   * Sets the tone of the Button based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * The language of the button's text content. Use this when the button text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. See the [reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label).
+   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
+   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
+   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
    */
   lang?: string;
 }
 interface ButtonGroupProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The content of the button group, typically a collection of button or link components.
+   * The content of the ButtonGroup.
    */
   children?: ComponentChildren;
   /**
-   * The spacing between button elements within the group.
-   *
+   * The gap between elements.
    * @default 'base'
    */
   gap?: 'base' | 'none';
   /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   * Label for the button group that describes the content of the group for screen reader users to understand what's included.
    *
    * @implementation Used as a hidden heading or an aria-label on the wrapping element.
    */
@@ -1771,18 +2960,22 @@ export interface BaseInputProps {
 export interface InputProps extends BaseInputProps {
   /**
    * A callback fired when the user has finished editing the field, such as when they blur the field or press Enter. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
    */
   onChange?: (event: Event) => void;
   /**
    * A callback fired when the user makes any changes in the field, such as typing a character. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
    */
   onInput?: (event: Event) => void;
   /**
-   * The current value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.
+   * The current value for the field. If omitted, the field will be empty.
    */
   value?: string;
   /**
-   * The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. After the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value, use `value` instead.
+   * The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.
    *
    * @implementation `defaultValue` reflects to the `value` attribute.
    */
@@ -1794,16 +2987,18 @@ export interface InputProps extends BaseInputProps {
 export interface MultipleInputProps extends BaseInputProps {
   /**
    * A callback fired when the user has selected one or more options. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
    */
   onChange?: (event: Event) => void;
   /**
    * A callback fired when the user selects or deselects options. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
    */
   onInput?: (event: Event) => void;
   /**
-   * An array of `value` attributes for the currently selected options.
-   *
-   * When provided, this property automatically sets the `selected` state on child Option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.
+   * An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.
    */
   values?: string[];
 }
@@ -1820,9 +3015,11 @@ export interface FileInputProps extends BaseInputProps {
    */
   onInput?: (event: Event) => void;
   /**
-   * A string that represents the path to the selected file(s). If no file is selected yet, the value is an empty string ("").
-   * When the user selected multiple files, the value represents the first file in the list of files they selected.
-   * The value is always the file's name prefixed with "C:\fakepath\", which isn't the real path of the file. Learn more about the [file input value](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file#value).
+   * A string that represents the path to the selected file(s). If no file is selected yet, the value is an empty string (""). When the user selected multiple files, the value represents the first file in the list of files they selected. The value is always the file's name prefixed with "C:\fakepath\", which isn't the real path of the file.
+   *
+   * Learn more about the [file input value](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file#value).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file#value
    *
    * @default ''
    */
@@ -1842,9 +3039,15 @@ export interface FileInputProps extends BaseInputProps {
  */
 export interface FieldErrorProps {
   /**
-   * An error message to display to the user. When set, the field will be styled with error indicators to communicate problems that need to be resolved immediately.
+   * An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.
+   *
+   * @implementation (string) The error is a simple string that will be displayed to the user.
+   *
+   * @implementation (ComponentChildren) Behaves as a slot: any elements passed
+   * are rendered as the error content (subject to surface constraints); there
+   * is no coercion to a string.
    */
-  error?: string;
+  error?: string | ComponentChildren;
 }
 /**
  * @publicDocs
@@ -1859,18 +3062,30 @@ export interface BasicFieldProps
    */
   required?: boolean;
   /**
-   * The text label displayed above or alongside the field to describe its purpose.
+   * The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.
+   *
+   * @implementation (string) The label is a simple string that will be displayed to the user.
+   *
+   * @implementation (ComponentChildren) Behaves as a slot: any elements passed
+   * are rendered as the label content (subject to surface constraints); there
+   * is no coercion to a string.
    */
-  label?: string;
+  label?: string | ComponentChildren;
 }
 /**
  * @publicDocs
  */
 export interface FieldDetailsProps {
   /**
-   * Additional helpful text displayed alongside the field to provide context, guidance, or instructions to the user. This content is accessible to both visual and screen reader users.
+   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.
+   *
+   * @implementation (string) The details is a simple string that will be displayed to the user.
+   *
+   * @implementation (ComponentChildren) Behaves as a slot: any elements passed
+   * are rendered as the details content (subject to surface constraints); there
+   * is no coercion to a string.
    */
-  details?: string;
+  details?: string | ComponentChildren;
 }
 /**
  * @publicDocs
@@ -1881,7 +3096,7 @@ export interface FieldProps
     FocusEventProps,
     FieldDetailsProps {
   /**
-   * The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value. Unlike `defaultValue`, this is a temporary value that disappears after the user starts typing.
+   * The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.
    */
   placeholder?: string;
 }
@@ -1917,15 +3132,581 @@ export interface FieldDecorationProps {
    */
   prefix?: string;
   /**
-   * The type of icon to be displayed in the field.
+   * An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier.
    *
    * @default ''
    */
-  icon?: IconType | AnyString;
+  icon?:
+    | (
+        | 'adjust'
+        | 'affiliate'
+        | 'airplane'
+        | 'alert-bubble'
+        | 'alert-circle'
+        | 'alert-diamond'
+        | 'alert-location'
+        | 'alert-octagon'
+        | 'alert-octagon-filled'
+        | 'alert-triangle'
+        | 'alert-triangle-filled'
+        | 'align-horizontal-centers'
+        | 'app-extension'
+        | 'apps'
+        | 'archive'
+        | 'arrow-down'
+        | 'arrow-down-circle'
+        | 'arrow-down-right'
+        | 'arrow-left'
+        | 'arrow-left-circle'
+        | 'arrow-right'
+        | 'arrow-right-circle'
+        | 'arrow-up'
+        | 'arrow-up-circle'
+        | 'arrow-up-right'
+        | 'arrows-in-horizontal'
+        | 'arrows-out-horizontal'
+        | 'asterisk'
+        | 'attachment'
+        | 'automation'
+        | 'backspace'
+        | 'bag'
+        | 'bank'
+        | 'barcode'
+        | 'battery-low'
+        | 'bill'
+        | 'blank'
+        | 'blog'
+        | 'bolt'
+        | 'bolt-filled'
+        | 'book'
+        | 'book-open'
+        | 'brain'
+        | 'broom'
+        | 'bug'
+        | 'bullet'
+        | 'business-entity'
+        | 'button'
+        | 'button-press'
+        | 'calculator'
+        | 'calendar'
+        | 'calendar-check'
+        | 'calendar-compare'
+        | 'calendar-list'
+        | 'calendar-time'
+        | 'camera'
+        | 'camera-flip'
+        | 'caret-down'
+        | 'caret-left'
+        | 'caret-right'
+        | 'caret-up'
+        | 'cart'
+        | 'cart-abandoned'
+        | 'cart-discount'
+        | 'cart-down'
+        | 'cart-filled'
+        | 'cart-sale'
+        | 'cart-send'
+        | 'cart-up'
+        | 'cash-dollar'
+        | 'cash-euro'
+        | 'cash-pound'
+        | 'cash-rupee'
+        | 'cash-yen'
+        | 'catalog-product'
+        | 'categories'
+        | 'channels'
+        | 'channels-filled'
+        | 'chart-cohort'
+        | 'chart-donut'
+        | 'chart-funnel'
+        | 'chart-histogram-first'
+        | 'chart-histogram-first-last'
+        | 'chart-histogram-flat'
+        | 'chart-histogram-full'
+        | 'chart-histogram-growth'
+        | 'chart-histogram-last'
+        | 'chart-histogram-second-last'
+        | 'chart-horizontal'
+        | 'chart-line'
+        | 'chart-popular'
+        | 'chart-stacked'
+        | 'chart-vertical'
+        | 'chat'
+        | 'chat-new'
+        | 'chat-referral'
+        | 'check'
+        | 'check-circle'
+        | 'check-circle-filled'
+        | 'checkbox'
+        | 'chevron-down'
+        | 'chevron-down-circle'
+        | 'chevron-left'
+        | 'chevron-left-circle'
+        | 'chevron-right'
+        | 'chevron-right-circle'
+        | 'chevron-up'
+        | 'chevron-up-circle'
+        | 'circle'
+        | 'circle-dashed'
+        | 'clipboard'
+        | 'clipboard-check'
+        | 'clipboard-checklist'
+        | 'clock'
+        | 'clock-list'
+        | 'clock-revert'
+        | 'code'
+        | 'code-add'
+        | 'collection'
+        | 'collection-featured'
+        | 'collection-list'
+        | 'collection-reference'
+        | 'color'
+        | 'color-none'
+        | 'compass'
+        | 'complete'
+        | 'compose'
+        | 'confetti'
+        | 'connect'
+        | 'content'
+        | 'contract'
+        | 'corner-pill'
+        | 'corner-round'
+        | 'corner-square'
+        | 'credit-card'
+        | 'credit-card-cancel'
+        | 'credit-card-percent'
+        | 'credit-card-reader'
+        | 'credit-card-reader-chip'
+        | 'credit-card-reader-tap'
+        | 'credit-card-secure'
+        | 'credit-card-tap-chip'
+        | 'crop'
+        | 'currency-convert'
+        | 'cursor'
+        | 'cursor-banner'
+        | 'cursor-option'
+        | 'data-presentation'
+        | 'data-table'
+        | 'database'
+        | 'database-add'
+        | 'database-connect'
+        | 'delete'
+        | 'delivered'
+        | 'delivery'
+        | 'desktop'
+        | 'disabled'
+        | 'disabled-filled'
+        | 'discount'
+        | 'discount-add'
+        | 'discount-automatic'
+        | 'discount-code'
+        | 'discount-remove'
+        | 'dns-settings'
+        | 'dock-floating'
+        | 'dock-side'
+        | 'domain'
+        | 'domain-landing-page'
+        | 'domain-new'
+        | 'domain-redirect'
+        | 'download'
+        | 'drag-drop'
+        | 'drag-handle'
+        | 'drawer'
+        | 'duplicate'
+        | 'edit'
+        | 'email'
+        | 'email-follow-up'
+        | 'email-newsletter'
+        | 'empty'
+        | 'enabled'
+        | 'enter'
+        | 'envelope'
+        | 'envelope-soft-pack'
+        | 'eraser'
+        | 'exchange'
+        | 'exit'
+        | 'export'
+        | 'external'
+        | 'eye-check-mark'
+        | 'eye-dropper'
+        | 'eye-dropper-list'
+        | 'eye-first'
+        | 'eyeglasses'
+        | 'fav'
+        | 'favicon'
+        | 'file'
+        | 'file-list'
+        | 'filter'
+        | 'filter-active'
+        | 'flag'
+        | 'flip-horizontal'
+        | 'flip-vertical'
+        | 'flower'
+        | 'folder'
+        | 'folder-add'
+        | 'folder-down'
+        | 'folder-remove'
+        | 'folder-up'
+        | 'food'
+        | 'foreground'
+        | 'forklift'
+        | 'forms'
+        | 'games'
+        | 'gauge'
+        | 'geolocation'
+        | 'gift'
+        | 'gift-card'
+        | 'git-branch'
+        | 'git-commit'
+        | 'git-repository'
+        | 'globe'
+        | 'globe-asia'
+        | 'globe-europe'
+        | 'globe-lines'
+        | 'globe-list'
+        | 'graduation-hat'
+        | 'grid'
+        | 'hashtag'
+        | 'hashtag-decimal'
+        | 'hashtag-list'
+        | 'heart'
+        | 'hide'
+        | 'hide-filled'
+        | 'home'
+        | 'home-filled'
+        | 'icons'
+        | 'identity-card'
+        | 'image'
+        | 'image-add'
+        | 'image-alt'
+        | 'image-explore'
+        | 'image-magic'
+        | 'image-none'
+        | 'image-with-text-overlay'
+        | 'images'
+        | 'import'
+        | 'in-progress'
+        | 'incentive'
+        | 'incoming'
+        | 'incomplete'
+        | 'info'
+        | 'info-filled'
+        | 'inheritance'
+        | 'inventory'
+        | 'inventory-edit'
+        | 'inventory-list'
+        | 'inventory-transfer'
+        | 'inventory-updated'
+        | 'iq'
+        | 'key'
+        | 'keyboard'
+        | 'keyboard-filled'
+        | 'keyboard-hide'
+        | 'keypad'
+        | 'label-printer'
+        | 'language'
+        | 'language-translate'
+        | 'layout-block'
+        | 'layout-buy-button'
+        | 'layout-buy-button-horizontal'
+        | 'layout-buy-button-vertical'
+        | 'layout-column-1'
+        | 'layout-columns-2'
+        | 'layout-columns-3'
+        | 'layout-footer'
+        | 'layout-header'
+        | 'layout-logo-block'
+        | 'layout-popup'
+        | 'layout-rows-2'
+        | 'layout-section'
+        | 'layout-sidebar-left'
+        | 'layout-sidebar-right'
+        | 'layer'
+        | 'lightbulb'
+        | 'link'
+        | 'link-list'
+        | 'list-bulleted'
+        | 'list-bulleted-filled'
+        | 'list-numbered'
+        | 'live'
+        | 'live-critical'
+        | 'live-none'
+        | 'location'
+        | 'location-none'
+        | 'lock'
+        | 'map'
+        | 'markets'
+        | 'markets-euro'
+        | 'markets-rupee'
+        | 'markets-yen'
+        | 'maximize'
+        | 'measurement-size'
+        | 'measurement-size-list'
+        | 'measurement-volume'
+        | 'measurement-volume-list'
+        | 'measurement-weight'
+        | 'measurement-weight-list'
+        | 'media-receiver'
+        | 'megaphone'
+        | 'mention'
+        | 'menu'
+        | 'menu-filled'
+        | 'menu-horizontal'
+        | 'menu-vertical'
+        | 'merge'
+        | 'metafields'
+        | 'metaobject'
+        | 'metaobject-list'
+        | 'metaobject-reference'
+        | 'microphone'
+        | 'microphone-muted'
+        | 'minimize'
+        | 'minus'
+        | 'minus-circle'
+        | 'mobile'
+        | 'money'
+        | 'money-none'
+        | 'money-split'
+        | 'moon'
+        | 'nature'
+        | 'note'
+        | 'note-add'
+        | 'notification'
+        | 'number-one'
+        | 'order'
+        | 'order-batches'
+        | 'order-draft'
+        | 'order-filled'
+        | 'order-first'
+        | 'order-fulfilled'
+        | 'order-repeat'
+        | 'order-unfulfilled'
+        | 'orders-status'
+        | 'organization'
+        | 'outdent'
+        | 'outgoing'
+        | 'package'
+        | 'package-cancel'
+        | 'package-fulfilled'
+        | 'package-on-hold'
+        | 'package-reassign'
+        | 'package-returned'
+        | 'page'
+        | 'page-add'
+        | 'page-attachment'
+        | 'page-clock'
+        | 'page-down'
+        | 'page-heart'
+        | 'page-list'
+        | 'page-reference'
+        | 'page-remove'
+        | 'page-report'
+        | 'page-up'
+        | 'pagination-end'
+        | 'pagination-start'
+        | 'paint-brush-flat'
+        | 'paint-brush-round'
+        | 'paper-check'
+        | 'partially-complete'
+        | 'passkey'
+        | 'paste'
+        | 'pause-circle'
+        | 'payment'
+        | 'payment-capture'
+        | 'payout'
+        | 'payout-dollar'
+        | 'payout-euro'
+        | 'payout-pound'
+        | 'payout-rupee'
+        | 'payout-yen'
+        | 'person'
+        | 'person-add'
+        | 'person-exit'
+        | 'person-filled'
+        | 'person-list'
+        | 'person-lock'
+        | 'person-remove'
+        | 'person-segment'
+        | 'personalized-text'
+        | 'phablet'
+        | 'phone'
+        | 'phone-down'
+        | 'phone-down-filled'
+        | 'phone-in'
+        | 'phone-out'
+        | 'pin'
+        | 'pin-remove'
+        | 'plan'
+        | 'play'
+        | 'play-circle'
+        | 'plus'
+        | 'plus-circle'
+        | 'plus-circle-down'
+        | 'plus-circle-filled'
+        | 'plus-circle-up'
+        | 'point-of-sale'
+        | 'point-of-sale-register'
+        | 'price-list'
+        | 'print'
+        | 'product'
+        | 'product-add'
+        | 'product-cost'
+        | 'product-filled'
+        | 'product-list'
+        | 'product-reference'
+        | 'product-remove'
+        | 'product-return'
+        | 'product-unavailable'
+        | 'profile'
+        | 'profile-filled'
+        | 'question-circle'
+        | 'question-circle-filled'
+        | 'radio-control'
+        | 'receipt'
+        | 'receipt-dollar'
+        | 'receipt-euro'
+        | 'receipt-folded'
+        | 'receipt-paid'
+        | 'receipt-pound'
+        | 'receipt-refund'
+        | 'receipt-rupee'
+        | 'receipt-yen'
+        | 'receivables'
+        | 'redo'
+        | 'referral-code'
+        | 'refresh'
+        | 'remove-background'
+        | 'reorder'
+        | 'replace'
+        | 'replay'
+        | 'reset'
+        | 'return'
+        | 'reward'
+        | 'rocket'
+        | 'rotate-left'
+        | 'rotate-right'
+        | 'sandbox'
+        | 'save'
+        | 'savings'
+        | 'scan-qr-code'
+        | 'search'
+        | 'search-add'
+        | 'search-list'
+        | 'search-recent'
+        | 'search-resource'
+        | 'select'
+        | 'send'
+        | 'settings'
+        | 'share'
+        | 'shield-check-mark'
+        | 'shield-none'
+        | 'shield-pending'
+        | 'shield-person'
+        | 'shipping-label'
+        | 'shipping-label-cancel'
+        | 'shopcodes'
+        | 'slideshow'
+        | 'smiley-happy'
+        | 'smiley-joy'
+        | 'smiley-neutral'
+        | 'smiley-sad'
+        | 'social-ad'
+        | 'social-post'
+        | 'sort'
+        | 'sort-ascending'
+        | 'sort-descending'
+        | 'sound'
+        | 'split'
+        | 'sports'
+        | 'star'
+        | 'star-circle'
+        | 'star-filled'
+        | 'star-half'
+        | 'star-list'
+        | 'status'
+        | 'status-active'
+        | 'stop-circle'
+        | 'store'
+        | 'store-import'
+        | 'store-managed'
+        | 'store-online'
+        | 'sun'
+        | 'table'
+        | 'table-masonry'
+        | 'tablet'
+        | 'target'
+        | 'tax'
+        | 'team'
+        | 'text'
+        | 'text-align-center'
+        | 'text-align-left'
+        | 'text-align-right'
+        | 'text-block'
+        | 'text-bold'
+        | 'text-color'
+        | 'text-font'
+        | 'text-font-list'
+        | 'text-grammar'
+        | 'text-in-columns'
+        | 'text-in-rows'
+        | 'text-indent'
+        | 'text-indent-remove'
+        | 'text-italic'
+        | 'text-quote'
+        | 'text-title'
+        | 'text-underline'
+        | 'text-with-image'
+        | 'theme'
+        | 'theme-cart'
+        | 'theme-edit'
+        | 'theme-store'
+        | 'theme-template'
+        | 'three-d-environment'
+        | 'thumbs-down'
+        | 'thumbs-up'
+        | 'tip-jar'
+        | 'toggle-off'
+        | 'toggle-on'
+        | 'transaction'
+        | 'transaction-fee-add'
+        | 'transaction-fee-dollar'
+        | 'transaction-fee-euro'
+        | 'transaction-fee-pound'
+        | 'transaction-fee-rupee'
+        | 'transaction-fee-yen'
+        | 'transfer'
+        | 'transfer-in'
+        | 'transfer-internal'
+        | 'transfer-out'
+        | 'truck'
+        | 'undo'
+        | 'unknown-device'
+        | 'unlock'
+        | 'upload'
+        | 'variant'
+        | 'variant-list'
+        | 'video'
+        | 'video-list'
+        | 'view'
+        | 'viewport-narrow'
+        | 'viewport-short'
+        | 'viewport-tall'
+        | 'viewport-wide'
+        | 'wallet'
+        | 'wand'
+        | 'watch'
+        | 'wifi'
+        | 'work'
+        | 'work-list'
+        | 'wrench'
+        | 'x'
+        | 'x-circle'
+        | 'x-circle-filled'
+      )
+    | AnyString;
   /**
-   * Additional interactive content displayed within the field.
-   *
-   * Accepts Button and Clickable components with text content only. Commonly used for actions like clearing the field or opening additional information.
+   * Additional content to be displayed in the field.
+   * Commonly used to display an icon that activates a tooltip providing more information.
    */
   accessory?: ComponentChildren;
 }
@@ -1959,10 +3740,9 @@ export interface NumberConstraintsProps {
    */
   step?: number;
   /**
-   * Sets the type of controls displayed in the field.
+   * The type of controls displayed in the field.
    *
-   * - `stepper`: displays buttons to increase or decrease the value of the field by the stepping interval defined in the `step` property.
-   * Appropriate mouse and [keyboard interactions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role#keyboard_interactions) to control the value of the field are enabled.
+   * - `stepper`: displays buttons to increase or decrease the value of the field by the stepping interval defined in the `step` property. Appropriate mouse and [keyboard interactions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role#keyboard_interactions) to control the value of the field are enabled.
    * - `none`: no controls are displayed and users must input the value manually. Arrow keys and scroll wheels can’t be used either to avoid accidental changes.
    * - `auto`: the presence of the controls depends on the surface and context.
    *
@@ -1996,13 +3776,13 @@ export interface BaseSelectableProps {
    */
   accessibilityLabel?: string;
   /**
-   * Whether the control is disabled, preventing any user interaction.
+   * Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * The value submitted with form data when the control is checked or selected.
+   * The value submitted with the form when this checkbox is checked. If not specified, the default value is "on".
    */
   value?: string;
 }
@@ -2011,13 +3791,13 @@ export interface BaseSelectableProps {
  */
 export interface BaseOptionProps extends BaseSelectableProps {
   /**
-   * Whether the option is currently selected.
+   * Whether the option is currently selected. Use this for controlled components where you manage the selection state.
    *
    * @default false
    */
   selected?: boolean;
   /**
-   * Whether the option is selected by default when first rendered.
+   * The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.
    *
    * @implementation `defaultSelected` reflects to the `selected` attribute.
    *
@@ -2030,19 +3810,27 @@ export interface BaseOptionProps extends BaseSelectableProps {
  */
 export interface BaseCheckableProps
   extends BaseSelectableProps,
+    FocusEventProps,
+    LabelAccessibilityVisibilityProps,
     InteractionProps {
   /**
-   * The visual text label displayed alongside the control to describe its purpose.
+   * The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.
+   *
+   * @implementation (string) The label is a simple string that will be displayed to the user.
+   *
+   * @implementation (ComponentChildren) Behaves as a slot: any elements passed
+   * are rendered as the label content (subject to surface constraints); there
+   * is no coercion to a string.
    */
-  label?: string;
+  label?: string | ComponentChildren;
   /**
-   * Whether the control is currently checked (for checkboxes) or toggled on (for switches).
+   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.
    *
    * @default false
    */
   checked?: boolean;
   /**
-   * Whether the control is checked by default when first rendered.
+   * The initial checked state for uncontrolled components. Use this when you want the control to start checked but don't need to control its state afterward.
    *
    * @implementation `defaultChecked` reflects to the `checked` attribute.
    *
@@ -2050,15 +3838,19 @@ export interface BaseCheckableProps
    */
   defaultChecked?: boolean;
   /**
-   * The name attribute for the control, which must be unique within the nearest containing Form component. This name is used to identify the control's value when the form is submitted.
+   * The name used to identify this checkbox in form submissions. When the checkbox is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.
    */
   name?: string;
   /**
-   * A callback fired when the control's value changes. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
    */
   onChange?: (event: Event) => void;
   /**
-   * A callback fired when the control's value changes. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
    */
   onInput?: (event: Event) => void;
 }
@@ -2068,21 +3860,22 @@ interface CheckboxProps$1
     FieldErrorProps,
     FieldDetailsProps {
   /**
-   * Whether the checkbox displays in an indeterminate state (neither checked nor unchecked), typically used to indicate partial selection in hierarchical lists.
+   * Whether to display the checkbox in an indeterminate state (neither checked or unchecked).
    *
-   * This visual state takes priority over the `checked` prop in appearance only.
-   * The form submission value is still determined by the `checked` prop.
+   * In terms of appearance, this takes priority over the `checked` prop.
+   * But this is purely a visual change.
+   * Whether the value is submitted along with a form is still down to the `checked` prop.
    *
-   * If `indeterminate` has not been explicitly set and hasn't been modified by user interaction,
-   * it returns the value of `defaultIndeterminate`.
+   * If `indeterminate` has not been explicitly set, and the `indeterminate` state hasn't been modified by the user (via clicking),
+   * then `indeterminate` returns the value of `defaultIndeterminate`.
    *
    * @implementation The `indeterminate` property doesn't reflect to any attribute.
    */
   indeterminate?: boolean;
   /**
-   * Whether the checkbox is in an indeterminate state by default when first rendered.
+   * Whether the checkbox is in an `indeterminate` state by default.
    *
-   * Similar to `defaultValue` and `defaultChecked`, this value applies until `indeterminate` is explicitly set or the user changes the checkbox state.
+   * Similar to `defaultValue` and `defaultChecked`, this value applies until `indeterminate` is set, or user changes the state of the checkbox.
    *
    * @implementation `defaultIndeterminate` reflects to the `indeterminate` attribute.
    *
@@ -2090,7 +3883,10 @@ interface CheckboxProps$1
    */
   defaultIndeterminate?: boolean;
   /**
-   * Whether the checkbox must be checked before form submission. This adds semantic meaning and typically displays a visual indicator, but does not automatically validate or show errors. Use the `error` property to display validation messages.
+   * Whether the field needs a value. This requirement adds semantic value
+   * to the field, but it will not cause an error to appear automatically.
+   * If you want to present an error when this field is empty, you can do
+   * so with the `error` property.
    *
    * @default false
    */
@@ -2101,11 +3897,11 @@ interface CheckboxProps$1
  */
 export interface ChipProps$1 extends GlobalProps {
   /**
-   * The text content displayed within the chip.
+   * The text label displayed within the chip component, typically representing a selected filter, tag, or removable item.
    */
   children?: ComponentChildren;
   /**
-   * The graphic element (typically an icon) displayed inside the chip.
+   * The graphic to display inside of the chip.
    *
    * @implementation Only `s-icon` is supported.
    */
@@ -2115,128 +3911,29 @@ export interface ChipProps$1 extends GlobalProps {
    */
   accessibilityLabel?: string;
   /**
-   * The color intensity of the chip. Use `subdued` for less intense, `base` for standard, or `strong` for more intense coloring.
+   * The color emphasis level that controls visual intensity.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
-}
-interface ChipProps$2 extends ChipProps$1, GlobalProps {}
-interface ChoiceProps$1 extends GlobalProps, BaseOptionProps {
   /**
-   * The content displayed as the choice label.
-   *
-   * @implementation (StringChildren) The label is produced by extracting and
-   * concatenating the text nodes from the provided content; any markup or
-   * element structure is ignored.
-   *
-   * @implementation (ComponentChildren) Behaves as a slot: any elements passed
-   * are rendered as the label content (subject to surface constraints); there
-   * is no coercion to a string.
-   */
-  children?: ComponentChildren | StringChildren;
-  /**
-   * Additional helpful text displayed alongside the choice to provide context, guidance, or instructions to the user.
-   *
-   * @implementation this content should be linked to the input with an `aria-describedby` attribute.
-   */
-  details?: ComponentChildren;
-  /**
-   * Whether this choice should be associated with an error state from the parent ChoiceList.
-   *
-   * @default false
-   */
-  error?: boolean;
-  /**
-   * Secondary descriptive content displayed beneath the choice label.
-   */
-  secondaryContent?: ComponentChildren;
-  /**
-   * Content displayed when the choice is selected, useful for showing additional information or nested options related to this choice.
-   */
-  selectedContent?: ComponentChildren;
-}
-interface ChoiceListProps$1
-  extends GlobalProps,
-    Pick<BasicFieldProps, 'label' | 'labelAccessibilityVisibility' | 'error'>,
-    MultipleInputProps,
-    FieldDetailsProps {
-  /**
-   * Whether users can select multiple choices simultaneously (checkboxes) or only one choice at a time (radio buttons).
-   *
-   * @default false
-   */
-  multiple?: boolean;
-  /**
-   * The collection of Choice components that users can select from.
-   */
-  children?: ComponentChildren;
-  /**
-   * Whether the entire choice list is disabled, preventing any user interaction.
-   *
-   * When `true`, the `disabled` property on individual child Choice components is ignored.
-   *
-   * @default false
-   */
-  disabled?: MultipleInputProps['disabled'];
-  /**
-   * The layout variant for displaying the choices.
-   *
-   * - `auto`: The variant is automatically determined by the context.
-   * - `list`: The choices are displayed in a vertical list.
-   * - `inline`: The choices are arranged horizontally along the inline axis.
-   * - `block`: The choices are arranged vertically along the block axis.
-   * - `grid`: The choices are displayed in a grid layout.
-   *
-   * @implementation The `block`, `inline` and `grid` variants are more suitable for button-styled choices, but it's at the discretion of each surface.
-   *
-   * @default 'auto'
-   */
-  variant?: 'auto' | 'list' | 'inline' | 'block' | 'grid';
-}
-interface ClickableProps$1
-  extends GlobalProps,
-    BaseBoxProps,
-    BaseClickableProps {
-  /**
-   * Whether the component is in a loading state, which indicates to assistive technology that an action is in progress and prevents interaction.
-   */
-  loading?: BaseClickableProps['loading'];
-  /**
-   * Whether the component is disabled, preventing clicks and focus. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You should apply disabled styling as needed.
-   */
-  disabled?: BaseClickableProps['disabled'];
-  /**
-   * The language of the text content within the component. Useful when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. See the [reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label).
-   *
-   * @default ''
-   */
-  lang?: string;
-}
-interface ClickableChipProps$1
-  extends ChipProps$1,
-    GlobalProps,
-    InteractionProps {
-  /**
-   * A callback fired when the chip is clicked.
-   */
-  onClick?: (event: Event) => void;
-  /**
-   * The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.
-   */
-  href?: string;
-  /**
-   * Whether the chip displays a remove button for dismissal. When clicked, the `remove` callback fires.
+   * Whether the chip is removable.
    *
    * @default false
    */
   removable?: boolean;
   /**
-   * A callback fired when the chip's remove button is clicked.
+   * Callback when the chip is removed.
    */
   onRemove?: (event: Event) => void;
   /**
-   * Whether the chip is hidden from view. When using controlled component pattern with `removable` chips, update this property when the `remove` event fires. For non-removable chips, manually toggle this property to show or hide the chip.
+   * Determines whether the chip is hidden.
+   *
+   * If this property is being set on each framework render (as in 'controlled' usage),
+   * and the chip is `removable`,
+   * ensure you update app state for this property when the `remove` event fires.
+   *
+   * If the chip is not `removable`, it can still be hidden by setting this property.
    *
    * @default false
    */
@@ -2251,6 +3948,134 @@ interface ClickableChipProps$1
    * We can add an `onHide` event in future if we want to provide a hook for the start of the animation.
    */
   onAfterHide?: (event: Event) => void;
+}
+interface ChipProps$2 extends ChipProps$1, GlobalProps {}
+interface ChoiceProps$1 extends GlobalProps, BaseOptionProps {
+  /**
+   * Content to use as the choice label.
+   *
+   * @implementation (StringChildren) The label is produced by extracting and
+   * concatenating the text nodes from the provided content; any markup or
+   * element structure is ignored.
+   *
+   * @implementation (ComponentChildren) Behaves as a slot: any elements passed
+   * are rendered as the label content (subject to surface constraints); there
+   * is no coercion to a string.
+   */
+  children?: ComponentChildren | StringChildren;
+  /**
+   * Additional text to provide context or guidance for the input.
+   *
+   * This text is displayed along with the input and its label
+   * to offer more information or instructions to the user.
+   *
+   * @implementation this content should be linked to the input with an `aria-describedby` attribute.
+   */
+  details?: ComponentChildren;
+  /**
+   * Set to `true` to associate a choice with the error passed to `ChoiceList`
+   *
+   * @default false
+   */
+  error?: boolean;
+  /**
+   * Secondary content for a choice.
+   */
+  secondaryContent?: ComponentChildren;
+  /**
+   * Content to display when the option is selected.
+   *
+   * This can be used to provide additional information or options related to the choice.
+   */
+  selectedContent?: ComponentChildren;
+}
+interface ChoiceListProps$1
+  extends GlobalProps,
+    Pick<BasicFieldProps, 'label' | 'labelAccessibilityVisibility' | 'error'>,
+    MultipleInputProps,
+    FieldDetailsProps {
+  /**
+   * Whether multiple choices can be selected.
+   *
+   * @default false
+   */
+  multiple?: boolean;
+  /**
+   * The choices a user can select from.
+   *
+   * Accepts `Choice` components.
+   */
+  children?: ComponentChildren;
+  /**
+   * Disables the field, disallowing any interaction.
+   *
+   * `disabled` on any child choices is ignored when this is true.
+   *
+   * @default false
+   */
+  disabled?: MultipleInputProps['disabled'];
+  /**
+   * The variant of the choice grid.
+   *
+   * - `auto`: The variant is determined by the context.
+   * - `list`: The choices are displayed in a list.
+   * - `inline`: The choices are displayed on the inline axis.
+   * - `block`: The choices are displayed on the block axis.
+   * - `grid`: The choices are displayed in a grid.
+   *
+   * @implementation The `block`, `inline` and `grid` variants are more suitable for button looking choices, but it's at the
+   * discretion of each surface.
+   *
+   * @default 'auto'
+   */
+  variant?: 'auto' | 'list' | 'inline' | 'block' | 'grid';
+}
+interface ClickableProps$1
+  extends GlobalProps,
+    BaseBoxProps,
+    BaseClickableProps {
+  /**
+   * Disables the clickable, and indicates to assistive technology that the loading is in progress.
+   *
+   * This also disables the clickable.
+   */
+  loading?: BaseClickableProps['loading'];
+  /**
+   * Disables the clickable, meaning it cannot be clicked or receive focus.
+   *
+   * In this state, onClick will not fire.
+   * If the click event originates from a child element, the event will immediately stop propagating from this element.
+   *
+   * However, items within the clickable can still receive focus and be interacted with.
+   *
+   * This has no impact on the visual state by default,
+   * but developers are encouraged to style the clickable accordingly.
+   */
+  disabled?: BaseClickableProps['disabled'];
+  /**
+   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
+   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
+   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
+   *
+   * @default ''
+   */
+  lang?: string;
+}
+interface ClickableChipProps$1
+  extends ChipProps$1,
+    GlobalProps,
+    InteractionProps {
+  /**
+   * Callback when the chip is clicked.
+   */
+  onClick?: (event: Event) => void;
+  /**
+   * The URL to link to.
+   *
+   * - If set, it will navigate to the location specified by `href` after executing the `click` event.
+   * - If a `commandFor` is set, the `command` will be executed instead of the navigation.
+   */
+  href?: string;
   /**
    * Disables the chip, disallowing any interaction.
    *
@@ -2258,37 +4083,45 @@ interface ClickableChipProps$1
    */
   disabled?: boolean;
 }
-interface ColorPickerProps$1
-  extends GlobalProps,
-    Omit<InputProps, 'value' | 'defaultValue'> {
+interface ColorPickerProps$1 extends GlobalProps, InputProps {
   /**
-   * Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.
+   * Allow user to select an alpha value.
    *
    * @default false
    */
   alpha?: boolean;
   /**
-   * A callback that fires when the user finishes selecting a color. The value is always emitted in hexadecimal format: 8-value hex (`#RRGGBBAA`) when `alpha` is `true`, or 6-value hex (`#RRGGBB`) when `alpha` is `false`.
+   * This callback will emit the value in hex.
+   *
+   * If the `alpha` prop is `true`, `onChange` will emit an 8-value hex (#RRGGBBAA).
+   * If the `alpha` prop is `false`, `onChange` will emit a 6-value hex (#RRGGBB).
    */
   onChange?: InputProps['onChange'];
   /**
-   * A callback that fires when the user makes any change to the color selection. The value is always emitted in hexadecimal format: 8-value hex (`#RRGGBBAA`) when `alpha` is `true`, or 6-value hex (`#RRGGBB`) when `alpha` is `false`.
+   * This callback will emit the value in hex.
+   *
+   * If the `alpha` prop is `true`, `onInput` will emit an 8-value hex (#RRGGBBAA).
+   * If the `alpha` prop is `false`, `onInput` will emit a 6-value hex (#RRGGBB).
    */
   onInput?: InputProps['onChange'];
   /**
-   * The currently selected color value. Accepts multiple input formats:
+   * The currently selected color.
    *
-   * - Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA` (three, four, six, or eight digits)
-   * - RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)
-   * - HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`
+   * Supported formats include:
+   * - HSL @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
+   * - HSLA @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsla
+   * - RGB @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
+   * - RGBA @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
+   * - Hex (3-value, 4-value, 6-value, 8-value) @see https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color
    *
-   * Returns an empty string if the value is invalid. The `onChange` handler always emits values in hex format.
+   * For RGB and RGBA, both the legacy syntax (comma-separated) and modern syntax (space-separate) are supported.
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
+   *
+   * If the value is invalid, the component will return an empty string ''.
+   *
+   * Note that the `onChange` handler will emit the value in hex.
    */
-  value?: string;
-  /**
-   * The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.
-   */
-  defaultValue?: string;
+  value?: InputProps['value'];
 }
 /**
  * @publicDocs
@@ -2297,18 +4130,17 @@ export interface AutocompleteProps<
   AutocompleteField extends AnyAutocompleteField,
 > {
   /**
-   * Controls browser autofill behavior for the field.
+   * A hint about the intended content of the field for browser autofill.
    *
-   * Basic values:
-   * - `on` - Enables autofill without specifying content type (default)
-   * - `off` - Disables autofill for sensitive data or one-time codes
+   * When set to `on` (the default), this property indicates that the field should support autofill, but you do not have any more semantic information on the intended contents.
    *
-   * Specific field values describe the expected data type. You can optionally prefix these with:
-   * - `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)
-   * - `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes
-   * - Both section and group (for example, `section-primary shipping email`)
+   * When set to `off`, you are indicating that this field contains sensitive information, or contents that are never saved, like one-time codes.
    *
-   * Providing a specific autofill token helps browsers suggest more relevant saved data. Learn more about [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens).
+   * Alternatively, you can provide value which describes the specific data you would like to be entered into this field during autofill.
+   *
+   * Learn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.
+   *
+   * @see Learn more about the set of {@link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens|autocomplete values} supported in browsers.
    *
    * @default 'tel' for PhoneField
    * @default 'email' for EmailField
@@ -2324,11 +4156,9 @@ export interface AutocompleteProps<
     | 'off';
 }
 /**
- * The “section” scopes the autocomplete data that should be inserted
- * to a specific area of the page.
+ * The “section” scopes the autocomplete data that should be inserted to a specific area of the page.
  *
- * Commonly used when there are multiple fields with the same autocomplete needs
- * in the same page. For example: 2 shipping address forms in the same page.
+ * Commonly used when there are multiple fields with the same autocomplete needs in the same page. For example: 2 shipping address forms in the same page.
  * @publicDocs
  */
 export type AutocompleteSection = `section-${string}`;
@@ -2343,6 +4173,9 @@ export type AutocompleteGroup = 'shipping' | 'billing';
  */
 export type AutocompleteAddressGroup = 'fax' | 'home' | 'mobile' | 'pager';
 /**
+ * Represents all possible autocomplete field values as defined by the HTML autocomplete specification. These values help browsers provide appropriate autofill suggestions for form fields.
+ *
+ * Learn more about [autocomplete values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).
  * @publicDocs
  */
 export type AnyAutocompleteField =
@@ -2411,8 +4244,7 @@ export type AnyAutocompleteField =
   | `${AutocompleteAddressGroup} tel-local`
   | `${AutocompleteAddressGroup} tel-national`;
 /**
- * Represents autocomplete values that are valid for text input fields.
- * This is a subset of `AnyAutocompleteField` containing only fields suitable for text-based inputs.
+ * Represents autocomplete values that are valid for text input fields. This is a subset of `AnyAutocompleteField` containing only fields suitable for text-based inputs.
  *
  * Available values:
  * - `name` - Full name
@@ -2482,27 +4314,8 @@ export type TextAutocompleteField = ExtractStrict<
 >;
 interface ColorFieldProps$1
   extends GlobalProps,
-    Omit<BaseTextFieldProps, 'value' | 'defaultValue'> {
-  /**
-   * Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.
-   *
-   * @default false
-   */
-  alpha?: boolean;
-  /**
-   * The currently selected color value. Accepts multiple input formats:
-   *
-   * - Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA` (three, four, six, or eight digits)
-   * - RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)
-   * - HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`
-   *
-   * Returns an empty string if the value is invalid. The `onChange` handler always emits values in hex format.
-   */
-  value?: string;
-  /**
-   * The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.
-   */
-  defaultValue?: string;
+    BaseTextFieldProps,
+    Pick<ColorPickerProps$1, 'alpha' | 'value' | 'defaultValue'> {
   autocomplete?: Extract<
     AutocompleteProps<never>['autocomplete'],
     'on' | 'off'
@@ -2510,15 +4323,23 @@ interface ColorFieldProps$1
 }
 interface DatePickerProps$1 extends GlobalProps, InputProps, FocusEventProps {
   /**
-   * The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale.
+   * Default month to display in `YYYY-MM` format.
+   *
+   * This value is used until `view` is set, either directly or as a result of user interaction.
+   *
+   * Defaults to the current month in the user's locale.
    */
   defaultView?: string;
   /**
-   * The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`.
+   * Displayed month in `YYYY-MM` format.
+   *
+   * `onViewChange` is called when this value changes.
+   *
+   * Defaults to `defaultView`.
    */
   view?: string;
   /**
-   * A callback fired whenever the displayed month changes in the calendar.
+   * Called whenever the month to display changes.
    *
    * @param view The new month to display in `YYYY-MM` format.
    */
@@ -2534,91 +4355,144 @@ interface DatePickerProps$1 extends GlobalProps, InputProps, FocusEventProps {
    */
   type?: 'single' | 'multiple' | 'range';
   /**
-   * Specifies which dates can be selected as a comma-separated list. An empty string (default) allows all dates.
+   * Dates that can be selected.
    *
-   * **Formats:**
-   * - `YYYY-MM-DD`: Single date
-   * - `YYYY-MM`: Whole month
-   * - `YYYY`: Whole year
-   * - `start--end`: Date range (inclusive, unbounded if start/end omitted)
+   * A comma-separated list of dates, date ranges. Whitespace is allowed after commas.
    *
-   * **Examples:**
-   * - `2024-02--2025`: February 2024 through end of 2025
-   * - `2024-05-09, 2024-05-11`: Only May 9th and 11th, 2024
+   * The default `''` allows all dates.
+   *
+   * - Dates in `YYYY-MM-DD` format allow a single date.
+   * - Dates in `YYYY-MM` format allow a whole month.
+   * - Dates in `YYYY` format allow a whole year.
+   * - Ranges are expressed as `start--end`.
+   *     - Ranges are inclusive.
+   *     - If either `start` or `end` is omitted, the range is unbounded in that direction.
+   *     - If parts of the date are omitted for `start`, they are assumed to be the minimum possible value.
+   *       So `2024--` is equivalent to `2024-01-01--`.
+   *     - If parts of the date are omitted for `end`, they are assumed to be the maximum possible value.
+   *       So `--2024` is equivalent to `--2024-12-31`.
+   *     - Whitespace is allowed either side of `--`.
    *
    * @default ""
+   *
+   * @example
+   * `2024-02--2025` // allow any date from February 2024 to the end of 2025
+   * `2024-02--` // allow any date from February 2024 to the end of the month
+   * `2024-05-09, 2024-05-11` // allow only the 9th and 11th of May 2024
    */
   allow?: string;
   /**
-   * Specifies which dates can't be selected as a comma-separated list. These dates are excluded from those specified in `allow`. An empty string (default) has no effect.
+   * Dates that cannot be selected. These subtract from `allow`.
    *
-   * **Formats:**
-   * - `YYYY-MM-DD`: Single date
-   * - `YYYY-MM`: Whole month
-   * - `YYYY`: Whole year
-   * - `start--end`: Date range (inclusive, unbounded if start/end omitted)
+   * A comma-separated list of dates, date ranges. Whitespace is allowed after commas.
    *
-   * **Examples:**
-   * - `--2024-02`: All dates before February 2024
-   * - `2024-05-09, 2024-05-11`: May 9th and 11th, 2024
+   * The default `''` has no effect on `allow`.
+   *
+   * - Dates in `YYYY-MM-DD` format disallow a single date.
+   * - Dates in `YYYY-MM` format disallow a whole month.
+   * - Dates in `YYYY` format disallow a whole year.
+   * - Ranges are expressed as `start--end`.
+   *     - Ranges are inclusive.
+   *     - If either `start` or `end` is omitted, the range is unbounded in that direction.
+   *     - If parts of the date are omitted for `start`, they are assumed to be the minimum possible value.
+   *       So `2024--` is equivalent to `2024-01-01--`.
+   *     - If parts of the date are omitted for `end`, they are assumed to be the maximum possible value.
+   *       So `--2024` is equivalent to `--2024-12-31`.
+   *     - Whitespace is allowed either side of `--`.
    *
    * @default ""
+   *
+   * @example
+   * `--2024-02` // disallow any date before February 2024
+   * `2024-05-09, 2024-05-11` // disallow the 9th and 11th of May 2024
    */
   disallow?: string;
   /**
-   * Specifies which days of the week can be selected as a comma-separated list. Further restricts dates from `allow` and `disallow`. An empty string (default) has no effect.
+   * Days of the week that can be selected. These intersect with the result of `allow` and `disallow`.
    *
-   * **Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`
+   * A comma-separated list of days. Whitespace is allowed after commas.
    *
-   * **Example:** `saturday, sunday` (only weekends)
+   * The default `''` has no effect on the result of `allow` and `disallow`.
+   *
+   * Days are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`.
    *
    * @default ""
+   *
+   * @example
+   * 'saturday, sunday' // allow only weekends within the result of `allow` and `disallow`.
    */
   allowDays?: string;
   /**
-   * Specifies which days of the week can't be selected as a comma-separated list. Excludes days from `allowDays` and intersects with `allow` and `disallow`. An empty string (default) has no effect.
+   * Days of the week that cannot be selected. This subtracts from `allowDays`, and intersects with the result of `allow` and `disallow`.
    *
-   * **Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`
+   * A comma-separated list of days. Whitespace is allowed after commas.
    *
-   * **Example:** `saturday, sunday` (no weekends)
+   * The default `''` has no effect on `allowDays`.
+   *
+   * Days are `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`.
    *
    * @default ""
+   *
+   * @example
+   * 'saturday, sunday' // disallow weekends within the result of `allow` and `disallow`.
    */
   disallowDays?: string;
   /**
-   * The initially selected date(s) when the component first renders. An empty string means no date is initially selected.
+   * Default selected value.
    *
-   * - Single date in `YYYY-MM-DD` format when `type` is set to `"single"`
-   * - Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `"range"`
+   * The default means no date is selected.
+   *
+   * If the provided value is invalid, no date is selected.
+   *
+   * - If `type="single"`, this is a date in `YYYY-MM-DD` format.
+   * - If `type="multiple"`, this is a comma-separated list of dates in `YYYY-MM-DD` format.
+   * - If `type="range"`, this is a range in `YYYY-MM-DD--YYYY-MM-DD` format. The range is inclusive.
    *
    * @default ""
    */
   defaultValue?: string;
   /**
-   * The currently selected date(s). An empty string means no date is selected.
+   * Current selected value.
    *
-   * - Single date in `YYYY-MM-DD` format when `type` is set to `"single"`
-   * - Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `"range"`
+   * The default means no date is selected.
+   *
+   * If the provided value is invalid, no date is selected.
+   *
+   * Otherwise:
+   *
+   * - If `type="single"`, this is a date in `YYYY-MM-DD` format.
+   * - If `type="multiple"`, this is a comma-separated list of dates in `YYYY-MM-DD` format.
+   * - If `type="range"`, this is a range in `YYYY-MM-DD--YYYY-MM-DD` format. The range is inclusive.
    *
    * @default ""
    */
   value?: string;
   /**
-   * A callback fired when any date is selected, before `onChange`. When `type` is set to `"range"`, also fires when the first date is selected with a partial value formatted as `YYYY-MM-DD--`.
+   * Callback when any date is selected.
+   *
+   * - If `type="single"`, fires when a date is selected and happens before `onChange`.
+   * - If `type="multiple"`, fires when a date is selected before `onChange`.
+   * - If `type="range"`, fires when a first date is selected (with the partial value formatted as `YYYY-MM-DD--`), and when the last date is selected before `onChange`.
    */
   onInput?: (event: Event) => void;
   /**
-   * A callback fired when the date selection is committed and complete, after `onInput`. When `type` is set to `"range"`, fires only when the range is completed by selecting the end date.
+   * Callback when the value is committed.
+   *
+   * - If `type="single"`, fires when a date is selected after `onInput`.
+   * - If `type="multiple"`, fires when a date is selected after `onInput`.
+   * - If `type="range"`, fires when a range is completed by selecting the end date after `onInput`.
    */
   onChange?: (event: Event) => void;
 }
 interface DateFieldProps$1
   extends GlobalProps,
-    Omit<BaseTextFieldProps, 'value' | 'defaultValue'>,
+    BaseTextFieldProps,
     Pick<
       DatePickerProps$1,
       | 'view'
       | 'defaultView'
+      | 'value'
+      | 'defaultValue'
       | 'allow'
       | 'disallow'
       | 'allowDays'
@@ -2627,27 +4501,18 @@ interface DateFieldProps$1
     >,
     AutocompleteProps<DateAutocompleteField> {
   /**
-   * The initial date value when the field first renders, in `YYYY-MM-DD` format. An empty string means no date is initially selected.
-   *
-   * @default ""
-   */
-  defaultValue?: string;
-  /**
-   * The currently selected date in `YYYY-MM-DD` format. An empty string means no date is selected.
-   *
-   * @default ""
-   */
-  value?: string;
-  /**
-   * A callback fired when the user makes any changes in the field, including when selecting a date using the date picker popup. This fires before `onChange`.
+   * Callback when the user makes any changes in the field.
+   * Also triggered when a date is selected using the date picker popup before `onChange`.
    */
   onInput?: (event: Event) => void;
   /**
-   * A callback fired when the user has finished editing the field, such as when they blur the field or complete a date selection. This fires after `onInput`.
+   * Callback when the user has **finished editing** a field, e.g. once they have blurred the field.
+   * Also triggered when a date is selected using the date picker popup after `onInput`.
    */
   onChange?: (event: Event) => void;
   /**
-   * A callback fired when the field contains an invalid date, either because the typed date is malformed, doesn't exist (e.g., February 31st), or is disabled by the `allow`/`disallow` constraints.
+   * Callback when the field has an invalid date.
+   * This callback will be called, if the date typed is invalid or disabled.
    *
    * Dates that don’t exist or have formatting errors are considered invalid. Some examples of invalid dates are:
    * - 2021-02-31: February doesn’t have 31 days
@@ -2663,8 +4528,7 @@ interface DateFieldProps$1
   onInvalid?: (event: Event) => void;
 }
 /**
- * Represents autocomplete values that are valid for date input fields.
- * This is a subset of `AnyAutocompleteField` containing only fields suitable for date-based inputs.
+ * Represents autocomplete values that are valid for date input fields. This is a subset of `AnyAutocompleteField` containing only fields suitable for date-based inputs.
  *
  * Available values:
  * - `bday` - Complete birthday date
@@ -2688,19 +4552,13 @@ export type DateAutocompleteField = ExtractStrict<
 >;
 interface DividerProps$1 extends GlobalProps {
   /**
-   * The orientation of the divider line, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
-   *
-   * - `inline`: Horizontal divider for separating vertically stacked content
-   * - `block`: Vertical divider for separating horizontally arranged content
+   * Specify the direction of the divider. This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
    *
    * @default 'inline'
    */
   direction?: 'inline' | 'block';
   /**
-   * The visual prominence of the divider line.
-   *
-   * - `base`: Standard divider for most separations (default)
-   * - `strong`: More prominent divider for major section breaks
+   * Modify the color to be more or less intense.
    *
    * @default 'base'
    */
@@ -2743,8 +4601,7 @@ interface EmailFieldProps$1
     MinMaxLengthProps,
     AutocompleteProps<EmailAutocompleteField> {}
 /**
- * Represents autocomplete values that are valid for email input fields.
- * This is a subset of `AnyAutocompleteField` containing only fields suitable for email inputs.
+ * Represents autocomplete values that are valid for email input fields. This is a subset of `AnyAutocompleteField` containing only fields suitable for email inputs.
  *
  * Available values:
  * - `email` - Primary email address
@@ -2758,13 +4615,27 @@ export type EmailAutocompleteField = ExtractStrict<
   AnyAutocompleteField,
   'email' | `${AutocompleteAddressGroup} email`
 >;
+interface EmptyStateProps$1 extends GlobalProps, ActionSlots {
+  /**
+   * The heading of the EmptyState.
+   */
+  heading?: string;
+  /**
+   * The subheading of the EmptyState.
+   */
+  subheading?: ComponentChildren | StringChildren;
+  /**
+   * The graphic to display in the EmptyState. The only supported components are `Image` and `Icon`.
+   */
+  graphic?: ComponentChildren;
+}
 interface FormProps$1 extends GlobalProps {
   /**
-   * The form fields and content to be wrapped in the form element.
+   * The content of the form.
    */
   children?: ComponentChildren;
   /**
-   * Whether the form can be submitted.
+   * Whether the form is able to be submitted.
    *
    * When set to `true`, this will also disable the implicit submit behavior of the form.
    *
@@ -2775,14 +4646,14 @@ interface FormProps$1 extends GlobalProps {
    */
   disabled?: boolean;
   /**
-   * A callback fired when the form is submitted.
+   * A callback that is run when the form is submitted.
    *
-   * Use `event.waitUntil` to signal how long it takes to save the data
-   * and whether the operation was successful.
+   * Use `event.waitUntil` to signal how long it takes to save the data,
+   * and whether it was successful or not.
    */
   onSubmit?: (event: ExtendableEvent) => void;
   /**
-   * A callback fired when the form is reset, typically via a reset button.
+   * A callback that is run when the form is reset.
    */
   onReset?: (event: Event) => void;
 }
@@ -2810,56 +4681,72 @@ interface FunctionSettingsProps$1 extends GlobalProps, FormProps$1 {
   onError?: (event: AggregateErrorEvent<FunctionSettingsError>) => void;
 }
 /**
+ * Represents an error that occurs when saving function settings data.
+ *
+ * These errors are returned when the extension-provided data fails validation or causes issues during the commit process to Shopify's servers. Handle these errors in the `onError` callback to provide feedback to users about what went wrong.
  * @publicDocs
  */
 export interface FunctionSettingsError extends Error {
   /**
-   * A unique identifier describing the “class” of error. These will match
-   * the GraphQL error codes as closely as possible. For example the enums
-   * returned by the `metafieldsSet` mutation. Learn more about [MetafieldsSetUserErrorCode](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldsSetUserErrorCode).
+   * A unique identifier describing the “class” of error. These will match the GraphQL error codes as closely as possible. For example the enums returned by the `metafieldsSet` mutation.
+   *
+   * Learn more about [MetafieldsSetUserErrorCode](/docs/api/admin-graphql/latest/enums/MetafieldsSetUserErrorCode).
+   *
+   * @see https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldsSetUserErrorCode
    */
   code: string;
+  /**
+   * The error type name, always set to `FunctionSettingsError`.
+   *
+   * This helps identify errors specific to function settings, distinguishing them from other error types.
+   */
   name: 'FunctionSettingsError';
 }
 /**
+ * Defines the spacing size between elements, using the standard size scale or `none` for no spacing.
  * @publicDocs
  */
 export type SpacingKeyword = SizeKeyword | 'none';
-/**
- * @publicDocs
- */
 export interface GapProps {
   /**
    * The spacing between child elements.
    *
-   * A single value applies to both axes.
-   * A pair of values (e.g., `large-100 large-500`) can be used to set the inline and block axes respectively.
+   * Accepts a single value to apply to both axes, or two space-separated values to set the row and column gaps independently. For example: `large-100 large-500` sets the row gap to `large-100` and column gap to `large-500`.
    *
    * @default 'none'
    */
   gap?: MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>;
   /**
-   * The spacing between elements along the block axis (vertical spacing in horizontal writing modes).
+   * The vertical spacing between elements (in horizontal writing modes).
    *
-   * This overrides the row value of `gap`.
+   * Sets the gap along the block axis. This overrides the row value specified in `gap`.
    *
    * @default '' - meaning no override
    */
   rowGap?: MaybeResponsive<SpacingKeyword | ''>;
   /**
-   * The spacing between elements along the inline axis (horizontal spacing in horizontal writing modes).
+   * The horizontal spacing between elements (in horizontal writing modes).
    *
-   * This overrides the column value of `gap`.
+   * Sets the gap along the inline axis. This overrides the column value specified in `gap`.
    *
    * @default '' - meaning no override
    */
   columnGap?: MaybeResponsive<SpacingKeyword | ''>;
 }
 /**
+ * Represents baseline alignment positions used to align items relative to their baselines.
+ * - `baseline`: Aligns to the baseline of the parent.
+ * - `first baseline`: Aligns to the first baseline of the parent.
+ * - `last baseline`: Aligns to the last baseline of the parent.
  * @publicDocs
  */
 export type BaselinePosition = 'baseline' | 'first baseline' | 'last baseline';
 /**
+ * Defines how space is distributed between and around content items in flex and grid layouts.
+ * - `space-between`: Distributes items evenly with the first item at the start and last at the end.
+ * - `space-around`: Distributes items evenly with equal space around each item.
+ * - `space-evenly`: Distributes items evenly with equal space between them.
+ * - `stretch`: Stretches items to fill the container.
  * @publicDocs
  */
 export type ContentDistribution =
@@ -2868,17 +4755,26 @@ export type ContentDistribution =
   | 'space-evenly'
   | 'stretch';
 /**
+ * Defines the position of content along an axis.
+ * - `center`: Centers the content.
+ * - `start`: Aligns content to the start.
+ * - `end`: Aligns content to the end.
  * @publicDocs
  */
 export type ContentPosition = 'center' | 'start' | 'end';
 /**
+ * Represents content positioning with overflow behavior control. Use `safe` to prevent content from becoming inaccessible when it overflows, or `unsafe` to allow overflow regardless of accessibility.
  * @publicDocs
  */
 export type OverflowPosition =
   | `unsafe ${ContentPosition}`
   | `safe ${ContentPosition}`;
 /**
- * Justify items defines the default justify-self for all items of the box, giving them all a default way of justifying each box along the appropriate axis. Learn more about the [justify-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items).
+ * Justify items defines the default justify-self for all items of the box, giving them all a default way of justifying each box along the appropriate axis.
+ *
+ * Learn more about the [justify-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items).
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items
  * @publicDocs
  */
 export type JustifyItemsKeyword =
@@ -2888,7 +4784,11 @@ export type JustifyItemsKeyword =
   | OverflowPosition
   | ContentPosition;
 /**
- * Align items sets the align-self value on all direct children as a group. Learn more about the [align-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
+ * Align items sets the align-self value on all direct children as a group.
+ *
+ * Learn more about the [align-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
  * @publicDocs
  */
 export type AlignItemsKeyword =
@@ -2898,7 +4798,11 @@ export type AlignItemsKeyword =
   | OverflowPosition
   | ContentPosition;
 /**
- * Justify content defines how the browser distributes space between and around content items along the main-axis of a flex container, and the inline axis of a grid container. Learn more about the [justify-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
+ * Justify content defines how the browser distributes space between and around content items along the main-axis of a flex container, and the inline axis of a grid container.
+ *
+ * Learn more about the [justify-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
  * @publicDocs
  */
 export type JustifyContentKeyword =
@@ -2907,7 +4811,11 @@ export type JustifyContentKeyword =
   | OverflowPosition
   | ContentPosition;
 /**
- *Align content sets the distribution of space between and around content items along a flexbox's cross axis, or a grid or block-level element's block axis. Learn more about the [align-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
+ * Align content sets the distribution of space between and around content items along a flexbox's cross axis, or a grid or block-level element's block axis.
+ *
+ * Learn more about the [align-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
  * @publicDocs
  */
 export type AlignContentKeyword =
@@ -2918,60 +4826,68 @@ export type AlignContentKeyword =
   | ContentPosition;
 interface GridProps$1 extends GlobalProps, BaseBoxPropsWithRole, GapProps {
   /**
-	  Define columns and specify their size. Learn more about the [grid-template-columns property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns).
+	  Define columns and specify their size.
   
+	  @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns
 	  @default 'none'
 	*/
   gridTemplateColumns?: MaybeResponsive<string>;
   /**
-	  Define rows and specify their size. Learn more about the [grid-template-rows property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows).
+	  Define rows and specify their size.
   
+	  @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows
 	  @default 'none'
 	*/
   gridTemplateRows?: MaybeResponsive<string>;
   /**
-	  Aligns the grid items along the inline (row) axis. Learn more about the [justify-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items).
+	  Aligns the grid items along the inline (row) axis.
   
 	  This overrides the inline value of `placeItems`.
   
+	  @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items
 	  @default '' - meaning no override
 	*/
   justifyItems?: MaybeResponsive<JustifyItemsKeyword | ''>;
   /**
-	  Aligns the grid items along the block (column) axis. Learn more about the [align-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
+	  Aligns the grid items along the block (column) axis.
   
 	  This overrides the block value of `placeItems`.
   
+	  @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
 	  @default '' - meaning no override
 	*/
   alignItems?: MaybeResponsive<AlignItemsKeyword | ''>;
   /**
-	  A shorthand property for `justify-items` and `align-items`. Learn more about the [place-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/place-items).
+	  A shorthand property for `justify-items` and `align-items`.
   
+	  @see https://developer.mozilla.org/en-US/docs/Web/CSS/place-items
 	  @default 'normal normal'
 	*/
   placeItems?: MaybeResponsive<
     `${AlignItemsKeyword} ${JustifyItemsKeyword}` | AlignItemsKeyword
   >;
   /**
-	  Aligns the grid along the inline (row) axis. Learn more about the [justify-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
+	  Aligns the grid along the inline (row) axis.
   
 	  This overrides the inline value of `placeContent`.
   
+	  @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
 	  @default '' - meaning no override
 	*/
   justifyContent?: MaybeResponsive<JustifyContentKeyword | ''>;
   /**
-	  Aligns the grid along the block (column) axis. Learn more about the [align-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
+	  Aligns the grid along the block (column) axis.
   
 	  This overrides the block value of `placeContent`.
   
+	  @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
 	  @default '' - meaning no override
 	*/
   alignContent?: MaybeResponsive<AlignContentKeyword | ''>;
   /**
-	  A shorthand property for `justify-content` and `align-content`. Learn more about the [place-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/place-content).
+	  A shorthand property for `justify-content` and `align-content`.
   
+	  @see https://developer.mozilla.org/en-US/docs/Web/CSS/place-content
 	  @default 'normal normal'
 	*/
   placeContent?: MaybeResponsive<
@@ -2980,13 +4896,17 @@ interface GridProps$1 extends GlobalProps, BaseBoxPropsWithRole, GapProps {
 }
 interface GridItemProps$1 extends GlobalProps, BaseBoxPropsWithRole {
   /**
-   * The number of grid columns this item spans across. Learn more about the [grid-column property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column).
+   * Number of columns the item will span across
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column
    *
    * @default 'auto'
    */
   gridColumn?: `span ${number}` | 'auto';
   /**
-   * The number of grid rows this item spans across. Learn more about the [grid-row property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row).
+   * Number of rows the item will span across
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row
    *
    * @default 'auto'
    */
@@ -2997,7 +4917,10 @@ interface GridItemProps$1 extends GlobalProps, BaseBoxPropsWithRole {
  */
 export interface BaseTypographyProps {
   /**
-   * The color intensity of the text. Use `subdued` for less intense, `base` for standard, or `strong` for more intense coloring.
+   * The color emphasis level that controls visual intensity.
+   *
+   * - `base`: Primary color for body text, standard UI elements, and general content with good readability.
+   * - `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.
    *
    * @default 'base'
    */
@@ -3019,15 +4942,23 @@ export interface BaseTypographyProps {
    */
   tone?: ToneKeyword;
   /**
-   * Set the numeric properties of the font. Learn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+   * The rendering style for numbers in the font.
+   *
+   * - `auto`: Inherits the setting from the parent element.
+   * - `normal`: Uses the font's default numeric glyphs.
+   * - `tabular-nums`: Uses fixed-width numeric glyphs, ensuring numbers align vertically in tables or lists.
+   *
+   * Learn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric
    *
    * @default 'auto' - inherit from the parent element
    */
   fontVariantNumeric?: 'auto' | 'normal' | 'tabular-nums';
   /**
-   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
-   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
-   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
+   * The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation.
+   *
+   * The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
    *
    * It is recommended to combine it with the `dir` attribute to ensure the text is rendered correctly if the surrounding content’s direction is different.
    *
@@ -3044,6 +4975,8 @@ export interface BaseTypographyProps {
    *
    * Learn more about the [dir attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).
    *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir
+   *
    * @default ''
    */
   dir?: 'ltr' | 'rtl' | 'auto' | '';
@@ -3053,7 +4986,11 @@ export interface BaseTypographyProps {
  */
 export interface BlockTypographyProps {
   /**
-   * Truncates the text content to the specified number of lines. Learn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).
+   * The maximum number of lines to display before truncating the text content.
+   *
+   * Learn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
    *
    * @default Infinity - no truncation is applied
    */
@@ -3064,7 +5001,7 @@ interface HeadingProps$1
     AccessibilityVisibilityProps,
     BlockTypographyProps {
   /**
-   * The content of the heading.
+   * The content of the Heading.
    */
   children?: ComponentChildren;
   /**
@@ -3092,35 +5029,591 @@ interface IconProps$1
   extends GlobalProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * The semantic meaning and color treatment of the component.
-   *
-   * - `auto`: Automatically determined based on context.
-   * - `neutral`: General information without specific intent.
-   * - `info`: Informational content or helpful tips.
-   * - `success`: Positive outcomes or successful states.
-   * - `caution`: Advisory notices that need attention.
-   * - `warning`: Important warnings about potential issues.
-   * - `critical`: Urgent problems or destructive actions.
+   * Sets the tone of the icon, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * The color intensity of the icon. Use `subdued` for less intense, `base` for standard, or `strong` for more intense coloring.
+   * Modify the color to be more or less intense.
    *
    * @default 'base'
    */
   color?: ColorKeyword;
   /**
-   * The size of the icon. Available sizes range from `small-500` (smallest) to `large-500` (largest), with `base` providing the default size.
+   * Adjusts the size of the icon.
    *
    * @default 'base'
    */
   size?: SizeKeyword;
-  /**
-   * The icon to display. Can be any icon name from the icon library or a custom string identifier.
-   */
-  type?: IconType | AnyString;
+  type?:
+    | (
+        | 'adjust'
+        | 'affiliate'
+        | 'airplane'
+        | 'alert-bubble'
+        | 'alert-circle'
+        | 'alert-diamond'
+        | 'alert-location'
+        | 'alert-octagon'
+        | 'alert-octagon-filled'
+        | 'alert-triangle'
+        | 'alert-triangle-filled'
+        | 'align-horizontal-centers'
+        | 'app-extension'
+        | 'apps'
+        | 'archive'
+        | 'arrow-down'
+        | 'arrow-down-circle'
+        | 'arrow-down-right'
+        | 'arrow-left'
+        | 'arrow-left-circle'
+        | 'arrow-right'
+        | 'arrow-right-circle'
+        | 'arrow-up'
+        | 'arrow-up-circle'
+        | 'arrow-up-right'
+        | 'arrows-in-horizontal'
+        | 'arrows-out-horizontal'
+        | 'asterisk'
+        | 'attachment'
+        | 'automation'
+        | 'backspace'
+        | 'bag'
+        | 'bank'
+        | 'barcode'
+        | 'battery-low'
+        | 'bill'
+        | 'blank'
+        | 'blog'
+        | 'bolt'
+        | 'bolt-filled'
+        | 'book'
+        | 'book-open'
+        | 'brain'
+        | 'broom'
+        | 'bug'
+        | 'bullet'
+        | 'business-entity'
+        | 'button'
+        | 'button-press'
+        | 'calculator'
+        | 'calendar'
+        | 'calendar-check'
+        | 'calendar-compare'
+        | 'calendar-list'
+        | 'calendar-time'
+        | 'camera'
+        | 'camera-flip'
+        | 'caret-down'
+        | 'caret-left'
+        | 'caret-right'
+        | 'caret-up'
+        | 'cart'
+        | 'cart-abandoned'
+        | 'cart-discount'
+        | 'cart-down'
+        | 'cart-filled'
+        | 'cart-sale'
+        | 'cart-send'
+        | 'cart-up'
+        | 'cash-dollar'
+        | 'cash-euro'
+        | 'cash-pound'
+        | 'cash-rupee'
+        | 'cash-yen'
+        | 'catalog-product'
+        | 'categories'
+        | 'channels'
+        | 'channels-filled'
+        | 'chart-cohort'
+        | 'chart-donut'
+        | 'chart-funnel'
+        | 'chart-histogram-first'
+        | 'chart-histogram-first-last'
+        | 'chart-histogram-flat'
+        | 'chart-histogram-full'
+        | 'chart-histogram-growth'
+        | 'chart-histogram-last'
+        | 'chart-histogram-second-last'
+        | 'chart-horizontal'
+        | 'chart-line'
+        | 'chart-popular'
+        | 'chart-stacked'
+        | 'chart-vertical'
+        | 'chat'
+        | 'chat-new'
+        | 'chat-referral'
+        | 'check'
+        | 'check-circle'
+        | 'check-circle-filled'
+        | 'checkbox'
+        | 'chevron-down'
+        | 'chevron-down-circle'
+        | 'chevron-left'
+        | 'chevron-left-circle'
+        | 'chevron-right'
+        | 'chevron-right-circle'
+        | 'chevron-up'
+        | 'chevron-up-circle'
+        | 'circle'
+        | 'circle-dashed'
+        | 'clipboard'
+        | 'clipboard-check'
+        | 'clipboard-checklist'
+        | 'clock'
+        | 'clock-list'
+        | 'clock-revert'
+        | 'code'
+        | 'code-add'
+        | 'collection'
+        | 'collection-featured'
+        | 'collection-list'
+        | 'collection-reference'
+        | 'color'
+        | 'color-none'
+        | 'compass'
+        | 'complete'
+        | 'compose'
+        | 'confetti'
+        | 'connect'
+        | 'content'
+        | 'contract'
+        | 'corner-pill'
+        | 'corner-round'
+        | 'corner-square'
+        | 'credit-card'
+        | 'credit-card-cancel'
+        | 'credit-card-percent'
+        | 'credit-card-reader'
+        | 'credit-card-reader-chip'
+        | 'credit-card-reader-tap'
+        | 'credit-card-secure'
+        | 'credit-card-tap-chip'
+        | 'crop'
+        | 'currency-convert'
+        | 'cursor'
+        | 'cursor-banner'
+        | 'cursor-option'
+        | 'data-presentation'
+        | 'data-table'
+        | 'database'
+        | 'database-add'
+        | 'database-connect'
+        | 'delete'
+        | 'delivered'
+        | 'delivery'
+        | 'desktop'
+        | 'disabled'
+        | 'disabled-filled'
+        | 'discount'
+        | 'discount-add'
+        | 'discount-automatic'
+        | 'discount-code'
+        | 'discount-remove'
+        | 'dns-settings'
+        | 'dock-floating'
+        | 'dock-side'
+        | 'domain'
+        | 'domain-landing-page'
+        | 'domain-new'
+        | 'domain-redirect'
+        | 'download'
+        | 'drag-drop'
+        | 'drag-handle'
+        | 'drawer'
+        | 'duplicate'
+        | 'edit'
+        | 'email'
+        | 'email-follow-up'
+        | 'email-newsletter'
+        | 'empty'
+        | 'enabled'
+        | 'enter'
+        | 'envelope'
+        | 'envelope-soft-pack'
+        | 'eraser'
+        | 'exchange'
+        | 'exit'
+        | 'export'
+        | 'external'
+        | 'eye-check-mark'
+        | 'eye-dropper'
+        | 'eye-dropper-list'
+        | 'eye-first'
+        | 'eyeglasses'
+        | 'fav'
+        | 'favicon'
+        | 'file'
+        | 'file-list'
+        | 'filter'
+        | 'filter-active'
+        | 'flag'
+        | 'flip-horizontal'
+        | 'flip-vertical'
+        | 'flower'
+        | 'folder'
+        | 'folder-add'
+        | 'folder-down'
+        | 'folder-remove'
+        | 'folder-up'
+        | 'food'
+        | 'foreground'
+        | 'forklift'
+        | 'forms'
+        | 'games'
+        | 'gauge'
+        | 'geolocation'
+        | 'gift'
+        | 'gift-card'
+        | 'git-branch'
+        | 'git-commit'
+        | 'git-repository'
+        | 'globe'
+        | 'globe-asia'
+        | 'globe-europe'
+        | 'globe-lines'
+        | 'globe-list'
+        | 'graduation-hat'
+        | 'grid'
+        | 'hashtag'
+        | 'hashtag-decimal'
+        | 'hashtag-list'
+        | 'heart'
+        | 'hide'
+        | 'hide-filled'
+        | 'home'
+        | 'home-filled'
+        | 'icons'
+        | 'identity-card'
+        | 'image'
+        | 'image-add'
+        | 'image-alt'
+        | 'image-explore'
+        | 'image-magic'
+        | 'image-none'
+        | 'image-with-text-overlay'
+        | 'images'
+        | 'import'
+        | 'in-progress'
+        | 'incentive'
+        | 'incoming'
+        | 'incomplete'
+        | 'info'
+        | 'info-filled'
+        | 'inheritance'
+        | 'inventory'
+        | 'inventory-edit'
+        | 'inventory-list'
+        | 'inventory-transfer'
+        | 'inventory-updated'
+        | 'iq'
+        | 'key'
+        | 'keyboard'
+        | 'keyboard-filled'
+        | 'keyboard-hide'
+        | 'keypad'
+        | 'label-printer'
+        | 'language'
+        | 'language-translate'
+        | 'layout-block'
+        | 'layout-buy-button'
+        | 'layout-buy-button-horizontal'
+        | 'layout-buy-button-vertical'
+        | 'layout-column-1'
+        | 'layout-columns-2'
+        | 'layout-columns-3'
+        | 'layout-footer'
+        | 'layout-header'
+        | 'layout-logo-block'
+        | 'layout-popup'
+        | 'layout-rows-2'
+        | 'layout-section'
+        | 'layout-sidebar-left'
+        | 'layout-sidebar-right'
+        | 'layer'
+        | 'lightbulb'
+        | 'link'
+        | 'link-list'
+        | 'list-bulleted'
+        | 'list-bulleted-filled'
+        | 'list-numbered'
+        | 'live'
+        | 'live-critical'
+        | 'live-none'
+        | 'location'
+        | 'location-none'
+        | 'lock'
+        | 'map'
+        | 'markets'
+        | 'markets-euro'
+        | 'markets-rupee'
+        | 'markets-yen'
+        | 'maximize'
+        | 'measurement-size'
+        | 'measurement-size-list'
+        | 'measurement-volume'
+        | 'measurement-volume-list'
+        | 'measurement-weight'
+        | 'measurement-weight-list'
+        | 'media-receiver'
+        | 'megaphone'
+        | 'mention'
+        | 'menu'
+        | 'menu-filled'
+        | 'menu-horizontal'
+        | 'menu-vertical'
+        | 'merge'
+        | 'metafields'
+        | 'metaobject'
+        | 'metaobject-list'
+        | 'metaobject-reference'
+        | 'microphone'
+        | 'microphone-muted'
+        | 'minimize'
+        | 'minus'
+        | 'minus-circle'
+        | 'mobile'
+        | 'money'
+        | 'money-none'
+        | 'money-split'
+        | 'moon'
+        | 'nature'
+        | 'note'
+        | 'note-add'
+        | 'notification'
+        | 'number-one'
+        | 'order'
+        | 'order-batches'
+        | 'order-draft'
+        | 'order-filled'
+        | 'order-first'
+        | 'order-fulfilled'
+        | 'order-repeat'
+        | 'order-unfulfilled'
+        | 'orders-status'
+        | 'organization'
+        | 'outdent'
+        | 'outgoing'
+        | 'package'
+        | 'package-cancel'
+        | 'package-fulfilled'
+        | 'package-on-hold'
+        | 'package-reassign'
+        | 'package-returned'
+        | 'page'
+        | 'page-add'
+        | 'page-attachment'
+        | 'page-clock'
+        | 'page-down'
+        | 'page-heart'
+        | 'page-list'
+        | 'page-reference'
+        | 'page-remove'
+        | 'page-report'
+        | 'page-up'
+        | 'pagination-end'
+        | 'pagination-start'
+        | 'paint-brush-flat'
+        | 'paint-brush-round'
+        | 'paper-check'
+        | 'partially-complete'
+        | 'passkey'
+        | 'paste'
+        | 'pause-circle'
+        | 'payment'
+        | 'payment-capture'
+        | 'payout'
+        | 'payout-dollar'
+        | 'payout-euro'
+        | 'payout-pound'
+        | 'payout-rupee'
+        | 'payout-yen'
+        | 'person'
+        | 'person-add'
+        | 'person-exit'
+        | 'person-filled'
+        | 'person-list'
+        | 'person-lock'
+        | 'person-remove'
+        | 'person-segment'
+        | 'personalized-text'
+        | 'phablet'
+        | 'phone'
+        | 'phone-down'
+        | 'phone-down-filled'
+        | 'phone-in'
+        | 'phone-out'
+        | 'pin'
+        | 'pin-remove'
+        | 'plan'
+        | 'play'
+        | 'play-circle'
+        | 'plus'
+        | 'plus-circle'
+        | 'plus-circle-down'
+        | 'plus-circle-filled'
+        | 'plus-circle-up'
+        | 'point-of-sale'
+        | 'point-of-sale-register'
+        | 'price-list'
+        | 'print'
+        | 'product'
+        | 'product-add'
+        | 'product-cost'
+        | 'product-filled'
+        | 'product-list'
+        | 'product-reference'
+        | 'product-remove'
+        | 'product-return'
+        | 'product-unavailable'
+        | 'profile'
+        | 'profile-filled'
+        | 'question-circle'
+        | 'question-circle-filled'
+        | 'radio-control'
+        | 'receipt'
+        | 'receipt-dollar'
+        | 'receipt-euro'
+        | 'receipt-folded'
+        | 'receipt-paid'
+        | 'receipt-pound'
+        | 'receipt-refund'
+        | 'receipt-rupee'
+        | 'receipt-yen'
+        | 'receivables'
+        | 'redo'
+        | 'referral-code'
+        | 'refresh'
+        | 'remove-background'
+        | 'reorder'
+        | 'replace'
+        | 'replay'
+        | 'reset'
+        | 'return'
+        | 'reward'
+        | 'rocket'
+        | 'rotate-left'
+        | 'rotate-right'
+        | 'sandbox'
+        | 'save'
+        | 'savings'
+        | 'scan-qr-code'
+        | 'search'
+        | 'search-add'
+        | 'search-list'
+        | 'search-recent'
+        | 'search-resource'
+        | 'select'
+        | 'send'
+        | 'settings'
+        | 'share'
+        | 'shield-check-mark'
+        | 'shield-none'
+        | 'shield-pending'
+        | 'shield-person'
+        | 'shipping-label'
+        | 'shipping-label-cancel'
+        | 'shopcodes'
+        | 'slideshow'
+        | 'smiley-happy'
+        | 'smiley-joy'
+        | 'smiley-neutral'
+        | 'smiley-sad'
+        | 'social-ad'
+        | 'social-post'
+        | 'sort'
+        | 'sort-ascending'
+        | 'sort-descending'
+        | 'sound'
+        | 'split'
+        | 'sports'
+        | 'star'
+        | 'star-circle'
+        | 'star-filled'
+        | 'star-half'
+        | 'star-list'
+        | 'status'
+        | 'status-active'
+        | 'stop-circle'
+        | 'store'
+        | 'store-import'
+        | 'store-managed'
+        | 'store-online'
+        | 'sun'
+        | 'table'
+        | 'table-masonry'
+        | 'tablet'
+        | 'target'
+        | 'tax'
+        | 'team'
+        | 'text'
+        | 'text-align-center'
+        | 'text-align-left'
+        | 'text-align-right'
+        | 'text-block'
+        | 'text-bold'
+        | 'text-color'
+        | 'text-font'
+        | 'text-font-list'
+        | 'text-grammar'
+        | 'text-in-columns'
+        | 'text-in-rows'
+        | 'text-indent'
+        | 'text-indent-remove'
+        | 'text-italic'
+        | 'text-quote'
+        | 'text-title'
+        | 'text-underline'
+        | 'text-with-image'
+        | 'theme'
+        | 'theme-cart'
+        | 'theme-edit'
+        | 'theme-store'
+        | 'theme-template'
+        | 'three-d-environment'
+        | 'thumbs-down'
+        | 'thumbs-up'
+        | 'tip-jar'
+        | 'toggle-off'
+        | 'toggle-on'
+        | 'transaction'
+        | 'transaction-fee-add'
+        | 'transaction-fee-dollar'
+        | 'transaction-fee-euro'
+        | 'transaction-fee-pound'
+        | 'transaction-fee-rupee'
+        | 'transaction-fee-yen'
+        | 'transfer'
+        | 'transfer-in'
+        | 'transfer-internal'
+        | 'transfer-out'
+        | 'truck'
+        | 'undo'
+        | 'unknown-device'
+        | 'unlock'
+        | 'upload'
+        | 'variant'
+        | 'variant-list'
+        | 'video'
+        | 'video-list'
+        | 'view'
+        | 'viewport-narrow'
+        | 'viewport-short'
+        | 'viewport-tall'
+        | 'viewport-wide'
+        | 'wallet'
+        | 'wand'
+        | 'watch'
+        | 'wifi'
+        | 'work'
+        | 'work-list'
+        | 'wrench'
+        | 'x'
+        | 'x-circle'
+        | 'x-circle-filled'
+      )
+    | AnyString;
 }
 /**
  * @publicDocs
@@ -3129,22 +5622,22 @@ export interface BaseImageProps {
   /**
    * Alternative text that describes the image for accessibility.
    *
-   * Provides a text description of the image for users with assistive technology
-   * and serves as a fallback when the image fails to load. A well-written description
-   * enables people with visual impairments to understand non-text content.
+   * Provides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.
    *
-   * When a screen reader encounters an image, it reads this description aloud.
-   * When an image fails to load, this text displays on screen, helping all users
-   * understand what content was intended.
+   * When a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.
    *
-   * Learn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4)
-   * and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).
+   * Learn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).
    *
-   * @default ''
+   * @default `''`
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt
    */
   alt?: string;
   /**
-   * A set of media conditions and their corresponding sizes. Learn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes).
+   * A set of media conditions and their corresponding sizes.
+   *
+   * Learn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes
    */
   sizes?: string;
   /**
@@ -3153,11 +5646,17 @@ export interface BaseImageProps {
    * When the image is loading or no `src` is provided, a placeholder is rendered.
    *
    * @implementation Surfaces may choose the style of the placeholder, but the space the image occupies should be
-   * reserved, except in cases where the image area does not have a contextual inline or block size, which should be rare. Learn more about the [src attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src).
+   * reserved, except in cases where the image area does not have a contextual inline or block size, which should be rare.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src
    */
   src?: string;
   /**
-   * A set of image sources and their width or pixel density descriptors. Learn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset). This overrides the `src` property.
+   * A set of image sources and their width or pixel density descriptors. This overrides the `src` property.
+   *
+   * Learn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset
    */
   srcSet?: string;
 }
@@ -3166,10 +5665,6 @@ interface ImageProps$1 extends GlobalProps, BaseImageProps, BorderProps {
    * Sets the semantic meaning of the component’s content. When set,
    * the role will be used by assistive technologies to help users
    * navigate the page.
-   *
-   * - `img`: Identifies the element as an image that conveys meaningful information to users.
-   * - `presentation`: Removes semantic meaning, making the image purely decorative and ignored by screen readers.
-   * - `none`: Completely hides the element and its content from assistive technologies.
    *
    * @default 'img'
    *
@@ -3181,14 +5676,14 @@ interface ImageProps$1 extends GlobalProps, BaseImageProps, BorderProps {
     | 'img'
     | ExtractStrict<AccessibilityRole, 'presentation' | 'none'>;
   /**
-   * The inline width (horizontal size) of the image.
+   * The displayed inline width of the image.
    *
-   * - `fill`: The image takes up 100% of the available inline space.
-   * - `auto`: The image is displayed at its natural size.
-   *
-   * Learn more about the [width attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).
+   * - `fill`: the image will takes up 100% of the available inline size.
+   * - `auto`: the image will be displayed at its natural size.
    *
    * @default 'fill'
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width
    */
   inlineSize?: 'fill' | 'auto';
   /**
@@ -3202,18 +5697,20 @@ interface ImageProps$1 extends GlobalProps, BaseImageProps, BorderProps {
    * For example, if the value is set as `50 / 100`, the getter returns `50 / 100`.
    * If the value is set as `0.5`, the getter returns `0.5 / 1`.
    *
-   * Learn more about the [aspect-ratio property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).
-   *
    * @default '1/1'
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio
    */
   aspectRatio?:
     | `${number}${optionalSpace}/${optionalSpace}${number}`
     | `${number}`;
   /**
    * Determines how the content of the image is resized to fit its container.
-   * The image is positioned in the center of the container. Learn more about the [object-fit property](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
+   * The image is positioned in the center of the container.
    *
    * @default 'contain'
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
    */
   objectFit?: 'contain' | 'cover';
   /**
@@ -3221,57 +5718,62 @@ interface ImageProps$1 extends GlobalProps, BaseImageProps, BorderProps {
    * - `eager`: Immediately loads the image, irrespective of its position within the visible viewport.
    * - `lazy`: Delays loading the image until it approaches a specified distance from the viewport.
    *
-   * Learn more about the [loading attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading).
-   *
    * @default 'eager'
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading
    */
   loading?: 'eager' | 'lazy';
   /**
-   * A callback fired when the image loads successfully. Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload).
+   * Invoked when load completes successfully.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
    */
   onLoad?: (event: Event) => void;
   /**
-   * A callback fired when the image fails to load. Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror).
+   * Invoked on load error.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
    */
   onError?: (event: Event) => void;
 }
 interface LinkProps$1 extends GlobalProps, LinkBehaviorProps {
   /**
-   * The text or elements displayed as the link's content.
+   * The content of the Link.
    */
   children?: ComponentChildren;
   /**
-   * The semantic meaning and color treatment of the component.
-   *
-   * - `critical`: Urgent problems or destructive actions.
-   * - `auto`: Automatically determined based on context.
-   * - `neutral`: General information without specific intent.
+   * Sets the tone of the Link, based on the intention of the information being conveyed.
    *
    * @default 'auto'
    */
   tone?: ToneKeyword;
   /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   * A label that describes the purpose or contents of the Link. It will be read to users using assistive technologies such as screen readers.
+   *
+   * Use this when using only an icon or the content of the link is not enough context
+   * for users using assistive technologies.
    */
   accessibilityLabel?: string;
   /**
-   * The language of the link's text content. Use this when the link text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. See the [reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label).
+   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
+   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
+   * [Reference of values](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) ("subtag" label)
    */
   lang?: string;
 }
 interface ListItemProps$1 extends GlobalProps {
   /**
-   * The content displayed within the list item.
+   * The content of the ListItem.
    */
   children?: ComponentChildren;
 }
 interface MenuProps$1 extends GlobalProps {
   /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   * A label that describes the purpose or contents of the element. When set,
+   * it will be announced using assistive technologies and provide additional context.
    */
   accessibilityLabel?: string;
   /**
-   * The collection of Button components displayed as menu actions. Only Button components are allowed as children, which can perform actions using `onClick` or link to other parts of the application using `href`. Any other component type will be ignored.
+   * The children define the actions to render inside the Menu. Only Button and SearchField components are allowed as children of a Menu, and these Buttons can perform actions (using `onClick`) or link to other parts of the application (using `to`/ `href`). Any other component placed here will be ignored.
    */
   children?: ComponentChildren;
 }
@@ -3289,41 +5791,220 @@ interface ModalProps$1
    */
   accessibilityLabel?: string;
   /**
-   * A title that describes the content of the modal.
+   * A title that describes the content of the Modal.
    *
    */
   heading?: string;
   /**
-   * Adjust the padding around the modal content.
+   * Adjust the padding around the Modal content.
    *
    * `base`: applies padding that is appropriate for the element.
    *
-   * `none`: removes all padding from the element. This can be useful when elements inside the modal need to span
-   * to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base'
+   * `none`: removes all padding from the element. This can be useful when elements inside the Modal need to span
+   * to the edge of the Modal. For example, a full-width image. In this case, rely on `Box` with a padding of 'base'
    * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
    */
   padding?: 'base' | 'none';
   /**
-   * Adjust the size of the modal.
+   * Adjust the size of the Modal.
    *
-   * `max`: expands the modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
+   * `max`: expands the Modal to its maximum size as defined by the host application, on both the horizontal and vertical axes.
    *
    * @default 'base'
    */
   size?: SizeKeyword | 'max';
   /**
-   * The content of the modal.
+   * The content of the Modal.
    */
   children?: ComponentChildren;
 }
+
 interface MoneyFieldProps$1
   extends GlobalProps,
     BaseTextFieldProps,
     NumberConstraintsProps,
-    AutocompleteProps<MoneyAutocompleteField> {}
+    AutocompleteProps<MoneyAutocompleteField> {
+  /**
+   * The currency code of the field.
+   *
+   * When set to 'auto', the field will display the currency code of the shop.
+   * If no currency code is set for the shop, resolve to 'XXX' the explicit non value.
+   *
+   * This value will match the global currency code of the shop, so if you need to know the currency code of the field,
+   * you can read the value from those APIs.
+   *
+   * @default 'auto'
+   */
+  currencyCode?:
+    | (
+        | 'USD'
+        | 'EUR'
+        | 'GBP'
+        | 'CAD'
+        | 'AFN'
+        | 'ALL'
+        | 'DZD'
+        | 'AOA'
+        | 'ARS'
+        | 'AMD'
+        | 'AWG'
+        | 'AUD'
+        | 'BBD'
+        | 'AZN'
+        | 'BDT'
+        | 'BSD'
+        | 'BHD'
+        | 'BIF'
+        | 'BZD'
+        | 'BMD'
+        | 'BTN'
+        | 'BAM'
+        | 'BRL'
+        | 'BOB'
+        | 'BWP'
+        | 'BND'
+        | 'BGN'
+        | 'MMK'
+        | 'KHR'
+        | 'CVE'
+        | 'KYD'
+        | 'XAF'
+        | 'CLP'
+        | 'CNY'
+        | 'COP'
+        | 'KMF'
+        | 'CDF'
+        | 'CRC'
+        | 'HRK'
+        | 'CZK'
+        | 'DKK'
+        | 'DOP'
+        | 'XCD'
+        | 'EGP'
+        | 'ETB'
+        | 'XPF'
+        | 'FJD'
+        | 'GMD'
+        | 'GHS'
+        | 'GTQ'
+        | 'GYD'
+        | 'GEL'
+        | 'HTG'
+        | 'HNL'
+        | 'HKD'
+        | 'HUF'
+        | 'ISK'
+        | 'INR'
+        | 'IDR'
+        | 'ILS'
+        | 'IQD'
+        | 'JMD'
+        | 'JPY'
+        | 'JEP'
+        | 'JOD'
+        | 'KZT'
+        | 'KES'
+        | 'KWD'
+        | 'KGS'
+        | 'LAK'
+        | 'LVL'
+        | 'LBP'
+        | 'LSL'
+        | 'LRD'
+        | 'LTL'
+        | 'MGA'
+        | 'MKD'
+        | 'MOP'
+        | 'MWK'
+        | 'MVR'
+        | 'MXN'
+        | 'MYR'
+        | 'MUR'
+        | 'MDL'
+        | 'MAD'
+        | 'MNT'
+        | 'MZN'
+        | 'NAD'
+        | 'NPR'
+        | 'ANG'
+        | 'NZD'
+        | 'NIO'
+        | 'NGN'
+        | 'NOK'
+        | 'OMR'
+        | 'PAB'
+        | 'PKR'
+        | 'PGK'
+        | 'PYG'
+        | 'PEN'
+        | 'PHP'
+        | 'PLN'
+        | 'QAR'
+        | 'RON'
+        | 'RUB'
+        | 'RWF'
+        | 'WST'
+        | 'SAR'
+        | 'RSD'
+        | 'SCR'
+        | 'SGD'
+        | 'SDG'
+        | 'SYP'
+        | 'ZAR'
+        | 'KRW'
+        | 'SSP'
+        | 'SBD'
+        | 'LKR'
+        | 'SRD'
+        | 'SZL'
+        | 'SEK'
+        | 'CHF'
+        | 'TWD'
+        | 'THB'
+        | 'TZS'
+        | 'TTD'
+        | 'TND'
+        | 'TRY'
+        | 'TMT'
+        | 'UGX'
+        | 'UAH'
+        | 'AED'
+        | 'UYU'
+        | 'UZS'
+        | 'VUV'
+        | 'VND'
+        | 'XOF'
+        | 'YER'
+        | 'ZMW'
+        | 'BYN'
+        | 'BYR'
+        | 'DJF'
+        | 'ERN'
+        | 'FKP'
+        | 'GIP'
+        | 'GNF'
+        | 'IRR'
+        | 'KID'
+        | 'LYD'
+        | 'MRU'
+        | 'SLL'
+        | 'SHP'
+        | 'SOS'
+        | 'STD'
+        | 'STN'
+        | 'TJS'
+        | 'TOP'
+        | 'VED'
+        | 'VEF'
+        | 'VES'
+        | 'XXX'
+      )
+    | 'auto';
+}
 /**
+ * Represents autocomplete values that are valid for money/currency input fields. This is a subset of `AnyAutocompleteField` containing only fields suitable for monetary inputs.
  * @publicDocs
  */
 export type MoneyAutocompleteField = ExtractStrict<
@@ -3337,24 +6018,30 @@ interface NumberFieldProps$1
     NumberConstraintsProps,
     FieldDecorationProps {
   /**
-   * Sets the virtual keyboard. Learn more about the [inputmode attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
+   * Sets the virtual keyboard.
    *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
    * @default 'decimal'
    */
   inputMode?: 'decimal' | 'numeric';
   /**
-   * Callback when the user has **finished editing** a field, such as when they blur the field after changing the value.
-   * Also fired after `onInput` on every step when using keyboard up and down arrows. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+   * Callback when the user has **finished editing** a field, e.g. once they have blurred
+   * the field after changing the value.
+   * Also fired after `onInput` on every step when interacting with the controls or the keyboard up and down arrows.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
    */
   onChange?: (event: Event) => void;
   /**
-   * A callback fired when the user makes any changes to the field value, including when using keyboard up/down arrows. This fires before `onChange`. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).
+   * Callback when the user makes any changes in the field.
+   * Also fired before `onChange` on every step when interacting with the controls or the keyboard up and down arrows.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
    */
   onInput?: (event: Event) => void;
 }
 /**
- * Represents autocomplete values that are valid for number input fields.
- * This is a subset of `AnyAutocompleteField` containing only fields suitable for numeric inputs.
+ * Represents autocomplete values that are valid for number input fields. This is a subset of `AnyAutocompleteField` containing only fields suitable for numeric inputs.
  *
  * Available values:
  * - `one-time-code` - One-time codes for authentication (OTP, 2FA codes)
@@ -3380,18 +6067,27 @@ interface OptionGroupProps$1 extends GlobalProps {
    */
   disabled?: boolean;
   /**
-   * The label text displayed for this group of related options.
+   * The user-facing label for this group of options.
    */
   label?: string;
   /**
-   * The collection of option components that users can select from within this group.
+   * The options a user can select from.
+   *
+   * Accepts `Option` components.
    */
   children?: ComponentChildren;
 }
-interface OrderedListProps$1 extends GlobalProps {}
+interface OrderedListProps$1 extends GlobalProps {
+  /**
+   * The content of the OrderededList.
+   *
+   * Accepts only `ListItem` components.
+   */
+  children?: ComponentChildren;
+}
 interface PageProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The content of the page.
+   * The content of the Page.
    */
   children?: ComponentChildren;
   /**
@@ -3424,6 +6120,12 @@ interface PageProps$1 extends GlobalProps, ActionSlots {
    * @default 'base'
    */
   inlineSize?: SizeKeyword;
+  /**
+   * A slot for content that comes before the main content, such as an `s-banner`.
+   *
+   * @implementation surfaces could restrict the content of this slot to certain elements, such as only allowing an `s-banner`.
+   */
+  supplementalStart?: ComponentChildren;
 }
 interface ParagraphProps$1
   extends GlobalProps,
@@ -3431,13 +6133,13 @@ interface ParagraphProps$1
     BlockTypographyProps,
     AccessibilityVisibilityProps {
   /**
-   * The text or elements displayed within the paragraph.
+   * The content of the Paragraph.
    */
   children?: ComponentChildren;
   /**
-   * The semantic type of the paragraph, which provides meaning and default styling.
+   * Provide semantic meaning and default styling to the paragraph.
    *
-   * Other presentation properties on the paragraph can override the default styling.
+   * Other presentation properties on `s-paragraph` override the default styling.
    *
    * @default 'paragraph'
    */
@@ -3448,13 +6150,20 @@ interface ParagraphProps$1
  */
 export type ParagraphType =
   /**
-   * Indicates the text is a structural grouping of related content. In an HTML host, the text will be rendered in a `<p>` element. Learn more about the [p element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
+   * Indicate the text is a structural grouping of related content.
+   *
+   * In an HTML host, the text will be rendered in an `<p>` element.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
    */
   | 'paragraph'
   /**
-   * Indicates the text is considered less important than the main content but is still necessary for understanding. This can be used for secondary content, disclaimers, terms and conditions, or legal information.
+   * Indicates the text is considered less important than the main content, but is still necessary for the reader to understand.
+   * It can be used for secondary content but also for disclaimers, terms and conditions, or legal information.
    *
-   * Surfaces should apply a smaller font size than the default. In an HTML host, the text will be rendered in a `<small>` element. Learn more about the [small element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small).
+   * Surfaces should apply a smaller font size than the default size.
+   *
+   * In an HTML host, the text will be rendered in a `<small>` element.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
    */
   | 'small';
 interface PasswordFieldProps$1
@@ -3463,8 +6172,7 @@ interface PasswordFieldProps$1
     MinMaxLengthProps,
     AutocompleteProps<PasswordAutocompleteField> {}
 /**
- * Represents autocomplete values that are valid for password input fields.
- * This is a subset of `AnyAutocompleteField` containing only fields suitable for password inputs.
+ * Represents autocomplete values that are valid for password input fields. This is a subset of `AnyAutocompleteField` containing only fields suitable for password inputs.
  *
  * Available values:
  * - `current-password` - Existing password for login or authentication
@@ -3486,44 +6194,86 @@ interface PopoverProps$1
    */
   children?: ComponentChildren;
 }
+interface PressButtonProps$1
+  extends GlobalProps,
+    Pick<
+      ButtonProps$1,
+      | 'accessibilityLabel'
+      | 'children'
+      | 'icon'
+      | 'inlineSize'
+      | 'lang'
+      | 'tone'
+      | 'variant'
+      | 'disabled'
+      | 'loading'
+      | 'onClick'
+      | 'onBlur'
+      | 'onFocus'
+    > {
+  /**
+   * Whether the button is pressed.
+   *
+   * @default false
+   */
+  pressed?: boolean;
+  /**
+   * Whether the button is pressed by default.
+   *
+   * @default false
+   *
+   * @implementation `defaultPressed` reflects to the `pressed` attribute.
+   */
+  defaultPressed?: boolean;
+}
 interface QueryContainerProps$1 extends GlobalProps {
   /**
    * The content of the container.
    */
   children?: ComponentChildren;
   /**
-   * An identifier for this container that you can reference in CSS container queries to apply styles based on this specific container's size.
+   * The name of the container, which can be used in your container queries to target this container specifically.
    *
-   * All QueryContainer components automatically receive a container name of `s-default`. You can omit the container name in your queries, so `@container (inline-size <= 300px)` is equivalent to `@container s-default (inline-size <= 300px)`.
+   * We place the container name of `s-default` on every container. Because of this, it is not required to add a `containerName` identifier in your queries. For example, a `@container (inline-size <= 300px) none, auto` query is equivalent to `@container s-default (inline-size <= 300px) none, auto`.
    *
-   * When you provide a custom `containerName`, it's added alongside `s-default`. For example, `containerName="product-card"` results in `s-default product-card` being set on the `container-name` CSS property, allowing you to target this container with `@container product-card (inline-size <= 300px)`.
-   *
-   * Learn more about the [container-name property](https://developer.mozilla.org/en-US/docs/Web/CSS/container-name).
+   * Any value set in `containerName` will be set alongside alongside `s-default`. For example, `containerName="my-container-name"` will result in a value of `s-default my-container-name` set on the `container-name` CSS property of the rendered HTML.
    *
    * @default ''
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/container-name
    *
    * @implementation You must always have a CSS `container-name` of `s-default` for this component.
    */
   containerName?: string;
 }
+export type OverflowKeyword = 'auto' | 'hidden';
+export type ScrollSnapType = 'none' | 'mandatory' | 'proximity';
+export type ScrollAccessibilityRole = 'generic' | 'region';
 interface SectionProps$1 extends GlobalProps, ActionSlots {
   /**
-   * The content of the section.
+   * The content of the Section.
    */
   children?: ComponentChildren;
   /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   * A label used to describe the section that will be announced by assistive technologies.
+   *
+   * When no `heading` property is provided or included as a children of the Section, you **must** provide an
+   * `accessibilityLabel` to describe the Section. This is important as it allows assistive technologies to provide
+   * the right context to users.
    */
   accessibilityLabel?: string;
   /**
-   * The heading text displayed at the top of the section. This heading provides a title for the section's content and automatically uses the appropriate semantic heading level (h2, h3, h4) based on nesting depth to maintain proper document structure.
+   * A title that describes the content of the section.
    */
   heading?: string;
   /**
-   * The amount of padding applied to all edges of the section.
+   * Adjust the padding of all edges.
    *
-   * - `base`: Applies standard padding appropriate for the section. Note that this might result in no padding if that's the right design decision for the context.
-   * - `none`: Removes all padding, useful when content like images needs to extend to the section's edges. Use Box with `padding="base"` for individual content areas that need padding.
+   * - `base`: applies padding that is appropriate for the element. Note that it may result in no padding if
+   * this is the right design decision in a particular context.
+   * - `none`: removes all padding from the element. This can be useful when elements inside the Section need to span
+   * to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
+   * to bring back the desired padding for the rest of the content.
    *
    * @default 'base'
    */
@@ -3536,61 +6286,76 @@ interface SelectProps$1
     Omit<FieldProps, 'defaultValue'>,
     FocusEventProps {
   /**
-   * The selectable options displayed in the dropdown list.
+   * The options a user can select from.
    *
-   * Accepts Option components for individual selectable items, and OptionGroup components to organize related options into logical groups with labels.
+   * Accepts `Option` and `OptionGroup` components.
    */
   children?: ComponentChildren;
 }
 interface SpinnerProps$1 extends GlobalProps {
   /**
-   * The size of the spinner icon. Available sizes range from `small-500` (smallest) to `large-500` (largest), with `base` providing the default size.
+   * Adjusts the size of the spinner icon.
    *
    * @default 'base'
    */
   size?: SizeKeyword;
   /**
-   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.
+   * A label that describes the purpose of the progress. When set,
+   * it will be announced to users using assistive technologies and will
+   * provide them with more context. Providing an `accessibilityLabel` is
+   * recommended if there is no accompanying text describing that something
+   * is loading.
    */
   accessibilityLabel?: string;
 }
 interface StackProps$1 extends GlobalProps, BaseBoxPropsWithRole, GapProps {
   /**
-   * The elements arranged within the stack layout.
+   * The child elements displayed within the stack component, which are arranged vertically or horizontally with consistent spacing.
    */
   children?: ComponentChildren;
   /**
-   * The axis along which child elements are arranged, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   * The direction in which children are arranged within the stack.
    *
-   * - `block`: Arranges children vertically (in horizontal writing modes). Content does not wrap.
-   * - `inline`: Arranges children horizontally (in horizontal writing modes). Content wraps to the next line if needed.
+   * - `block`: Arranges children vertically in a column (in horizontal writing modes). Children will not wrap.
+   * - `inline`: Arranges children horizontally in a row (in horizontal writing modes). Children will wrap to the next line if needed.
+   *
+   * This uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values) to ensure proper behavior across different writing modes.
    *
    * @default 'block'
    *
-   * @implementation The content will wrap if the direction is 'inline', and not wrap if the direction is 'block'.
+   * @implementation the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'
    */
   direction?: MaybeResponsive<'block' | 'inline'>;
   /**
-   * Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).
+   * The distribution of children along the stack component's main axis (the direction of stacking).
    *
-   * Use this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines. Learn more about the [justify-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
+   * For example, in a vertical stack (block direction), this controls vertical distribution. Use this to space out children or align them to the start, center, or end.
    *
+   * Learn more about the [justify-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
    * @default 'normal'
    */
   justifyContent?: MaybeResponsive<JustifyContentKeyword>;
   /**
-   * Controls the alignment of children along the block axis (vertically in horizontal writing modes).
+   * The alignment of individual children along the stack component's cross axis (perpendicular to the stacking direction).
    *
-   * Use this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks. Learn more about the [align-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
+   * For example, in a vertical stack (block direction), this controls horizontal alignment of each child.
    *
+   * Learn more about the [align-items property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
    * @default 'normal'
    */
   alignItems?: MaybeResponsive<AlignItemsKeyword>;
   /**
-   * Controls the distribution of lines along the block axis when content wraps into multiple lines.
+   * The alignment of multiple lines of content along the stack component's cross axis.
    *
-   * This property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead. Learn more about the [align-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
+   * This only applies when content wraps to multiple lines (typically in inline direction).
    *
+   * Learn more about the [align-content property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
    * @default 'normal'
    */
   alignContent?: MaybeResponsive<AlignContentKeyword>;
@@ -3632,62 +6397,62 @@ export interface PaginationProps {
    */
   hasPreviousPage?: boolean;
   /**
-   * Whether the table is in a loading state, such as during initial page load or when loading the next page in a paginated table.
-   * When `true`, the table might be in an inert state that prevents user interaction.
+   * Whether the table is in a loading state, such as during initial page load or when loading the next page in a paginated table. When `true`, the table might be in an inert state that prevents user interaction.
    *
    * @default false
    */
   loading?: boolean;
 }
+export type ComputedTableVariant = 'list' | 'table';
 interface TableProps$1 extends GlobalProps, PaginationProps {
   /**
-   * The table structure defining headers and data rows.
-   *
-   * Accepts table header row (for column headers) and table body (for data rows) components. Structure your table with a table header row first, followed by table body.
+   * The content of the Table.
    */
   children?: ComponentChildren;
   /**
-   * Filter controls displayed above the table.
-   *
-   * Accepts input components like search field or select for filtering table data. These controls appear in a dedicated area above the table content.
+   * Input elements, such as SearchField, used to search and filter the table.
    */
   filters?: ComponentChildren;
   /**
-   * The layout variant of the table.
+   * Sets the layout of the Table.
    *
-   * - `list`: Always displays as a list layout.
-   * - `table`: Always displays as a traditional table layout.
-   * - `auto`: Automatically displays as a table on wide screens and as a list on narrow screens.
+   * - `list`: The Table is displayed as a list.
+   * - `table`: The Table is displayed as a table.
+   * - `auto`: The Table is displayed as a table on wide devices and as a list on narrow devices.
    *
    * @default 'auto'
    */
-  variant?: 'list' | 'table' | 'auto';
+  variant?: ComputedTableVariant | 'auto';
+  /**
+   * The currently-used variant of the Table.
+   * This is only a getter; you cannot set it.
+   */
+  computedVariant?: ComputedTableVariant;
+  /**
+   * Event is emitted when the computed variant of the Table changes.
+   */
+  onComputedVariantChange?: (event: Event) => void;
 }
 interface TableBodyProps$1 extends GlobalProps {
   /**
-   * The data rows displayed in the table body.
-   *
-   * Accepts TableRow components, with each row representing a single record or entry in the table.
+   * The body of the table. May not have any semantic meaning in the Table's `list` variant.
    */
   children?: ComponentChildren;
 }
 interface TableCellProps$1 extends GlobalProps {
   /**
-   * The data value displayed in this cell.
-   *
-   * Accepts text content or inline components representing the cell's data value.
+   * The content of the table cell.
    */
   children?: ComponentChildren;
 }
 /**
- * Represents the content designation for table columns when displayed in list variant on mobile devices.
+ * Represents the semantic type of content slots within list items.
  *
- * Available values:
- * - `primary` - The most important content. Only one column can have this designation.
- * - `secondary` - Supporting content displayed below primary. Only one column can have this designation.
- * - `kicker` - Small label displayed above primary content with less visual prominence. Only one column can have this designation.
- * - `inline` - Content displayed inline with primary content.
- * - `labeled` - Each column displays as a heading-content pair.
+ * - `primary`: The main content or title of the list item.
+ * - `secondary`: Supporting or descriptive content below the primary content.
+ * - `kicker`: A small label or tag displayed above the primary content.
+ * - `inline`: Content displayed inline with the primary content.
+ * - `labeled`: Content with an associated label.
  * @publicDocs
  */
 export type ListSlotType =
@@ -3696,49 +6461,43 @@ export type ListSlotType =
   | 'kicker'
   | 'inline'
   | 'labeled';
-/**
- * Represents the format options for table headers that control styling and alignment of column content.
- *
- * Available values:
- * - `base`: Standard format for text columns
- * - `currency`: Right-aligned format for monetary values
- * - `numeric`: Right-aligned format for numeric values
- * @publicDocs
- */
-export type HeaderFormat = 'base' | 'currency' | 'numeric';
 interface TableHeaderProps$1 extends GlobalProps {
   /**
-   * The column heading text.
-   *
-   * This text labels the column in table variant and appears as a label for data in list variant.
+   * The heading of the column in the `table` variant, and the label of its data in `list` variant.
    */
   children?: ComponentChildren;
   /**
-   * The content designation for this column when the table displays in list variant on mobile devices.
+   * Content designation for the table's `list` variant.
+   *
+   * - `primary`: The most important content. Only one column can have this designation.
+   * - `secondary`: The secondary content. Only one column can have this designation.
+   * - `kicker`: Content that is displayed before primary and secondary content, but with less visual prominence. Only one column can have this designation.
+   * - `inline`: Content that is displayed inline.
+   * - `labeled`: Each column with this designation displays as a heading-content pair.
    *
    * @default 'labeled'
    */
   listSlot?: ListSlotType;
   /**
-   * The format of the column that controls styling and alignment of cell content.
+   * The format of the column. Will automatically apply styling and alignment to cell content based on the value.
+   *
+   * - `base`: The base format for columns.
+   * - `currency`: Formats the column as currency.
+   * - `numeric`: Formats the column as a number.
    *
    * @default 'base'
    */
-  format?: HeaderFormat;
+  format?: 'base' | 'currency' | 'numeric';
 }
 interface TableHeaderRowProps$1 extends GlobalProps {
   /**
-   * The column headers displayed in the table header row.
-   *
-   * Accepts TableHeader components, with each header defining a column and providing its label.
+   * Contents of the table heading row; children should be `TableHeading` components.
    */
   children?: ComponentChildren;
 }
 interface TableRowProps$1 extends GlobalProps {
   /**
-   * The data cells displayed in this table row.
-   *
-   * Accepts TableCell components, with each cell containing a data value for the corresponding column.
+   * The content of a TableRow, which should be `TableCell` components.
    */
   children?: ComponentChildren;
   /**
@@ -3749,7 +6508,7 @@ interface TableRowProps$1 extends GlobalProps {
    * Which is why the target element must be in the table; so that keyboard and screen reader users can interact with it normally.
    *
    * @implementation no focus or keyboard affordances are introduced by this property. No aria attributes need to be added to the table row.
-   * @implementation the row and/or delegate should have some affordance that indicates it is clickable. This may be a background color, a border, or a hover effect.
+   * @implementation the row and/or delegate should have some affordance that indicates it is clickable. This may be a background color, a border, a hover effect, etc.
    */
   clickDelegate?: string;
 }
@@ -3760,11 +6519,11 @@ interface TextProps$1
     DisplayProps,
     Pick<InteractionProps, 'interestFor'> {
   /**
-   * The text content or inline elements displayed within the component.
+   * The content of the Text.
    */
   children?: ComponentChildren;
   /**
-   * The semantic type of the text, which provides meaning and default styling.
+   * Provide semantic meaning and default styling to the text.
    *
    * Other presentation properties on Text override the default styling.
    *
@@ -3773,6 +6532,7 @@ interface TextProps$1
   type?: TextType;
 }
 /**
+ * Defines the semantic type and styling treatment for text content. Each type maps to appropriate HTML elements and applies specific styling for different contexts.
  * @publicDocs
  */
 export type TextType =
@@ -3783,9 +6543,11 @@ export type TextType =
    *
    * Surfaces may apply styling to this type.
    *
-   * In an HTML host, the text will be rendered in an `<address>` element. Learn more about the [address element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address).
+   * In an HTML host, the text will be rendered in an `<address>` element.
    *
    * @implementation vertical alignment should be `baseline` (`vertical-align: baseline`)
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
    */
   | 'address'
   /**
@@ -3793,7 +6555,8 @@ export type TextType =
    *
    * Surfaces should apply styling to this type to suggest its content no longer applies.
    *
-   * In an HTML host, the text will be rendered in a `<s>` element. Learn more about the [s element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s).
+   * In an HTML host, the text will be rendered in a `<s>` element.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
    */
   | 'redundant'
   /**
@@ -3802,7 +6565,8 @@ export type TextType =
    *
    * Surfaces should apply styling to this type to draw attention to the content.
    *
-   * In an HTML host, the text will be rendered in a `<mark>` element. Learn more about the [mark element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark).
+   * In an HTML host, the text will be rendered in a `<mark>` element.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
    */
   | 'mark'
   /**
@@ -3810,7 +6574,8 @@ export type TextType =
    *
    * Surfaces should apply styling to this type to distinguish it from surrounding text. Italicization is a common choice, but not required.
    *
-   * In an HTML host, the text will be rendered in an `<em>` element. Learn more about the [em element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em).
+   * In an HTML host, the text will be rendered in an `<em>` element.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
    */
   | 'emphasis'
   /**
@@ -3820,7 +6585,8 @@ export type TextType =
    *
    * Surfaces should italicize this content by default.
    *
-   * In an HTML host, the text will be rendered in a `<i>` tag. Learn more about the [i element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i).
+   * In an HTML host, the text will be rendered in a `<i>` tag.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
    */
   | 'offset'
   /**
@@ -3828,7 +6594,8 @@ export type TextType =
    *
    * Surfaces should render this content bold by default.
    *
-   * In an HTML host, the text will be rendered in a `<strong>` tag. Learn more about the [strong element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong).
+   * In an HTML host, the text will be rendered in a `<strong>` tag.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
    */
   | 'strong'
   /**
@@ -3837,7 +6604,8 @@ export type TextType =
    *
    * Surfaces should apply a smaller font size than the default size.
    *
-   * In an HTML host, the text will be rendered in a `<small>` element. Learn more about the [small element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small).
+   * In an HTML host, the text will be rendered in a `<small>` element.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
    */
   | 'small'
   /**
@@ -3845,7 +6613,8 @@ export type TextType =
    *
    * Surfaces must not apply any default styling to this type.
    *
-   * In an HTML host, the text will be rendered in a `<span>` tag. Learn more about the [span element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span).
+   * In an HTML host, the text will be rendered in a `<span>` tag.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
    */
   | 'generic';
 interface TextAreaProps$1
@@ -3854,7 +6623,7 @@ interface TextAreaProps$1
     MinMaxLengthProps,
     AutocompleteProps<TextAutocompleteField> {
   /**
-   * The number of visible text lines displayed in the textarea, which controls its initial height.
+   * A number of visible text lines.
    *
    * @default 2
    */
@@ -3868,15 +6637,19 @@ interface TextFieldProps$1
     FieldDecorationProps {}
 interface ThumbnailProps$1 extends GlobalProps, BaseImageProps {
   /**
-   * A callback fired when the thumbnail image loads successfully. Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload).
+   * Invoked when load of provided image completes successfully.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload
    */
   onLoad?: (event: Event) => void;
   /**
-   * A callback fired when the thumbnail image fails to load. Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror).
+   * Invoked on load error of provided image.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
    */
   onError?: (event: Event) => void;
   /**
-   * The size of the product thumbnail image. Available sizes range from `small-500` (smallest) to `large-500` (largest), with `base` providing the default size.
+   * Adjusts the size the product thumbnail image.
    *
    * @default 'base'
    */
@@ -3884,19 +6657,25 @@ interface ThumbnailProps$1 extends GlobalProps, BaseImageProps {
 }
 interface TooltipProps$1 extends GlobalProps {
   /**
-   * The text or elements displayed inside the tooltip popup.
+   * The content of the Tooltip.
    */
   children?: ComponentChildren;
 }
-interface UnorderedListProps$1 extends GlobalProps {}
+interface UnorderedListProps$1 extends GlobalProps {
+  /**
+   * The content of the UnorderededList.
+   *
+   * Accepts only `ListItem` components.
+   */
+  children?: ComponentChildren;
+}
 interface URLFieldProps$1
   extends GlobalProps,
     BaseTextFieldProps,
     MinMaxLengthProps,
     AutocompleteProps<URLAutocompleteField> {}
 /**
- * Represents autocomplete values that are valid for URL input fields.
- * This is a subset of `AnyAutocompleteField` containing only fields suitable for URL inputs.
+ * Represents autocomplete values that are valid for URL input fields. This is a subset of `AnyAutocompleteField` containing only fields suitable for URL inputs.
  *
  * Available values:
  * - `url` - General URL or web address
@@ -3915,17 +6694,23 @@ export type URLAutocompleteField = ExtractStrict<
 //
 // Preact Virtual DOM
 // -----------------------------------
-/**
- * @publicDocs
- */
 export interface VNode<P = {}> {
+  /**
+   * The component type or HTML element tag name that this VNode represents.
+   */
   type: ComponentType<P> | string;
+  /**
+   * The properties passed to this component or element, including children.
+   */
   props: P & {
     children: ComponentChildren$1;
   };
+  /**
+   * A unique key used to identify this element in lists for efficient reconciliation.
+   */
   key: Key;
   /**
-   * The ref is not guaranteed by `React.ReactElement`. For compatibility with popular React libraries, this is defined as optional.
+   * A ref to the element, which is not guaranteed by React.ReactElement. For compatibility reasons with popular react libs we define it as optional too.
    */
   ref?: Ref<any> | null;
   /**
@@ -3945,24 +6730,25 @@ export interface VNode<P = {}> {
 // Preact Component interface
 // -----------------------------------
 /**
+ * Represents a unique key for identifying elements in lists. Can be a string, number, or any other value.
  * @publicDocs
  */
 export type Key = string | number | any;
-/**
- * @publicDocs
- */
 export interface RefObject<T> {
   current: T | null;
 }
 /**
+ * Represents a callback function that receives a reference to a DOM element or component instance. Called when the element is mounted or unmounted.
  * @publicDocs
  */
-export type RefCallback<T> = (instance: T | null) => void;
+export type RefCallback<T> = (instance: T | null) => void | (() => void);
 /**
+ * Represents a reference to a DOM element or component instance. Can be either a ref object, callback function, or null.
  * @publicDocs
  */
 export type Ref<T> = RefObject<T> | RefCallback<T> | null;
 /**
+ * Represents a single child element that can be rendered, including VNodes, primitives, or null/undefined values.
  * @publicDocs
  */
 export type ComponentChild =
@@ -3975,20 +6761,27 @@ export type ComponentChild =
   | null
   | undefined;
 type ComponentChildren$1 = ComponentChild[] | ComponentChild;
-/**
- * @publicDocs
- */
 export interface Attributes {
+  /**
+   * A unique key used to identify this element in lists for efficient reconciliation during re-renders.
+   */
   key?: Key | undefined;
+  /**
+   * An internal flag indicating whether this element was created using JSX syntax.
+   */
   jsx?: boolean | undefined;
 }
 /**
  * @publicDocs
  */
 export interface ErrorInfo {
+  /**
+   * A string representation of the component stack trace at the point where an error occurred. Useful for debugging to understand which components were rendering when the error happened.
+   */
   componentStack?: string;
 }
 /**
+ * Represents the props that can be rendered by a component, combining custom props with standard attributes like children and ref.
  * @publicDocs
  */
 export type RenderableProps<P, RefType = any> = P &
@@ -3999,15 +6792,19 @@ export type RenderableProps<P, RefType = any> = P &
     }
   >;
 /**
+ * Represents any valid component type, either a class component or a function component.
  * @publicDocs
  */
 export type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
-/**
- * @publicDocs
- */
 export interface FunctionComponent<P = {}> {
   (props: RenderableProps<P>, context?: any): ComponentChildren$1;
+  /**
+   * A human-readable name for this component, used in debugging and dev tools.
+   */
   displayName?: string;
+  /**
+   * The default values for props that will be used when props are not explicitly provided.
+   */
   defaultProps?: Partial<P> | undefined;
 }
 /**
@@ -4015,8 +6812,17 @@ export interface FunctionComponent<P = {}> {
  */
 export interface ComponentClass<P = {}, S = {}> {
   new (props: P, context?: any): Component<P, S>;
+  /**
+   * A human-readable name for this component class, used in debugging and dev tools.
+   */
   displayName?: string;
+  /**
+   * The default values for props that will be used when props are not explicitly provided to component instances.
+   */
   defaultProps?: Partial<P>;
+  /**
+   * The context type this component can consume. When set, the component will have access to this context's value.
+   */
   contextType?: Context<any>;
   getDerivedStateFromProps?(
     props: Readonly<P>,
@@ -4068,9 +6874,21 @@ declare abstract class Component<P, S> {
   ): object | null;
 
   static getDerivedStateFromError?(error: any): object | null;
+  /**
+   * The current state of the component.
+   */
   state: Readonly<S>;
+  /**
+   * The props passed to this component.
+   */
   props: RenderableProps<P>;
+  /**
+   * The context value this component can access if a contextType is specified.
+   */
   context: any;
+  /**
+   * The underlying DOM element or text node that this component rendered.
+   */
   base?: Element | Text;
   // From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e836acc75a78cf0655b5dfdbe81d69fdd4d8a252/types/react/index.d.ts#L402
   // // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
@@ -4095,9 +6913,6 @@ declare abstract class Component<P, S> {
 //
 // Context
 // -----------------------------------
-/**
- * @publicDocs
- */
 export interface Consumer<T>
   extends FunctionComponent<{
     children: (value: T) => ComponentChildren$1;
@@ -4114,9 +6929,135 @@ export interface Provider<T>
  * @publicDocs
  */
 export interface Context<T> extends Provider<T> {
+  /**
+   * A component that consumes the context value and re-renders when it changes.
+   */
   Consumer: Consumer<T>;
+  /**
+   * A component that provides the context value to its descendants.
+   */
   Provider: Provider<T>;
+  /**
+   * A human-readable name for this context, used in debugging and dev tools.
+   */
   displayName?: string;
+}
+/**
+ * Represents CSS styles as a string, typically used for inline styles or style injection.
+ * @publicDocs
+ */
+export type Styles = string;
+declare const shadowRootSymbol: unique symbol;
+declare const flushRenderSymbol: unique symbol;
+/**
+ * Represents the implementation details for rendering components within a shadow DOM. Extends `ShadowRootInit` with a render function and optional styles.
+ * @publicDocs
+ */
+export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  ShadowRoot: (element: any) => ComponentChildren$1;
+  styles?: Styles;
+  /**
+   * Only needed once in the root element, to inject global shadow CSS for all components.
+   */
+  globalShadowCSS?: Styles;
+};
+export interface ActivationEventEsque {
+  /**
+   * Whether the Shift key was pressed when the event occurred.
+   */
+  shiftKey: boolean;
+  /**
+   * Whether the Meta/Command key (Mac) or Windows key was pressed when the event occurred.
+   */
+  metaKey: boolean;
+  /**
+   * Whether the Ctrl key was pressed when the event occurred.
+   */
+  ctrlKey: boolean;
+  /**
+   * The button number that was pressed on the mouse. 0 for left button, 1 for middle button, 2 for right button.
+   */
+  button: number;
+}
+/**
+ * @publicDocs
+ */
+export interface ClickOptions {
+  /**
+   * The event you want to influence the synthetic click.
+   */
+  sourceEvent?: ActivationEventEsque;
+}
+declare const BaseClass: {
+  new (): HTMLElement;
+  prototype: HTMLElement;
+};
+export declare abstract class PreactCustomElement extends BaseClass {
+  /** @private */
+  static get observedAttributes(): string[];
+  /** @private */
+  [shadowRootSymbol]: ShadowRoot | null;
+  /**
+   * A promise that resolves after the next render completes.
+   * Useful for non-React consumers who need to wait for the shadow DOM
+   * to be populated after setting properties.
+   * @private
+   */
+  get updateComplete(): Promise<void>;
+  constructor({
+    styles,
+    ShadowRoot: renderFunction,
+    delegatesFocus,
+    globalShadowCSS,
+    ...options
+  }: RenderImpl);
+
+  /**
+   * Flush any pending render synchronously.
+   *
+   * Called by reactWrap's useLayoutEffect after all props are set,
+   * ensuring the shadow DOM is populated before the consumer's
+   * useLayoutEffect fires. The version counter invalidates any
+   * pending microtask so the total render count stays at 1.
+   *
+   * Uses a Symbol key so this method is not callable by external
+   * consumers — only internal code that imports flushRenderSymbol
+   * can invoke it.
+   *
+   * Guarded by #hasPendingRender to avoid spurious Preact re-renders.
+   * React creates a new props object reference on every parent render,
+   * so reactWrap's useLayoutEffect (which depends on [props]) fires
+   * even when no prop *values* changed. Without the guard, every
+   * unrelated parent re-render would trigger a full Preact
+   * reconciliation — proportional to parent re-render frequency.
+   * @private
+   */
+  [flushRenderSymbol](): void;
+  /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
+  attributeChangedCallback(name: string): void;
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  disconnectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+  /**
+   * Queue a run of the render function.
+   * You shouldn't need to call this manually - it should be handled by changes to @property values.
+   * @private
+   */
+  queueRender(): void;
+  /**
+   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
+   *
+   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
+   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
+   * @private
+   * @param options
+   */
+  click({sourceEvent}?: ClickOptions): void;
 }
 type IconType$1 =
   | 'adjust'
@@ -4129,6 +7070,7 @@ type IconType$1 =
   | 'alert-octagon'
   | 'alert-octagon-filled'
   | 'alert-triangle'
+  | 'align-horizontal-centers'
   | 'app-extension'
   | 'apps'
   | 'archive'
@@ -4143,20 +7085,26 @@ type IconType$1 =
   | 'arrow-up-right'
   | 'arrows-in-horizontal'
   | 'arrows-out-horizontal'
+  | 'arrows-out-horizontal-filled'
   | 'asterisk'
   | 'attachment'
   | 'automation'
+  | 'automation-filled'
   | 'backspace'
   | 'bag'
   | 'bank'
   | 'barcode'
   | 'bill'
+  | 'bill-filled'
   | 'blank'
+  | 'blank-filled'
   | 'blog'
+  | 'blog-filled'
   | 'bolt'
   | 'bolt-filled'
   | 'book'
   | 'book-open'
+  | 'brain'
   | 'bug'
   | 'bullet'
   | 'business-entity'
@@ -4176,8 +7124,10 @@ type IconType$1 =
   | 'caret-up'
   | 'cart'
   | 'cart-abandoned'
+  | 'cart-abandoned-filled'
   | 'cart-discount'
   | 'cart-down'
+  | 'cart-down-filled'
   | 'cart-sale'
   | 'cart-up'
   | 'cash-dollar'
@@ -4230,6 +7180,7 @@ type IconType$1 =
   | 'code-add'
   | 'collection'
   | 'collection-featured'
+  | 'collection-filled'
   | 'collection-list'
   | 'collection-reference'
   | 'color'
@@ -4299,6 +7250,7 @@ type IconType$1 =
   | 'eyeglasses'
   | 'favicon'
   | 'file'
+  | 'file-filled'
   | 'file-list'
   | 'filter'
   | 'filter-active'
@@ -4317,13 +7269,19 @@ type IconType$1 =
   | 'forms'
   | 'games'
   | 'gauge'
+  | 'gauge-filled'
+  | 'generated-app'
+  | 'generated-app-filled'
   | 'gift-card'
   | 'git-branch'
   | 'git-commit'
   | 'git-repository'
   | 'globe'
   | 'globe-asia'
+  | 'globe-asia-filled'
   | 'globe-europe'
+  | 'globe-europe-filled'
+  | 'globe-filled'
   | 'globe-lines'
   | 'globe-list'
   | 'grid'
@@ -4336,6 +7294,7 @@ type IconType$1 =
   | 'home'
   | 'icons'
   | 'identity-card'
+  | 'identity-card-filled'
   | 'image'
   | 'image-add'
   | 'image-alt'
@@ -4352,6 +7311,7 @@ type IconType$1 =
   | 'info'
   | 'inheritance'
   | 'inventory'
+  | 'inventory-filled'
   | 'inventory-updated'
   | 'iq'
   | 'key'
@@ -4361,7 +7321,9 @@ type IconType$1 =
   | 'label-printer'
   | 'language'
   | 'language-translate'
+  | 'layer'
   | 'layout-block'
+  | 'layout-block-ai'
   | 'layout-buy-button'
   | 'layout-buy-button-horizontal'
   | 'layout-buy-button-vertical'
@@ -4380,16 +7342,23 @@ type IconType$1 =
   | 'link'
   | 'link-list'
   | 'list-bulleted'
+  | 'list-bulleted-filled'
   | 'list-numbered'
   | 'live'
+  | 'live-filled'
   | 'location'
   | 'location-none'
   | 'lock'
+  | 'logo-apple-tap-to-pay-filled'
+  | 'magic'
   | 'map'
   | 'markets'
   | 'markets-euro'
+  | 'markets-euro-filled'
   | 'markets-rupee'
+  | 'markets-rupee-filled'
   | 'markets-yen'
+  | 'markets-yen-filled'
   | 'maximize'
   | 'measurement-size'
   | 'measurement-size-list'
@@ -4399,6 +7368,7 @@ type IconType$1 =
   | 'measurement-weight-list'
   | 'media-receiver'
   | 'megaphone'
+  | 'megaphone-filled'
   | 'mention'
   | 'menu'
   | 'menu-horizontal'
@@ -4406,6 +7376,7 @@ type IconType$1 =
   | 'merge'
   | 'metafields'
   | 'metaobject'
+  | 'metaobject-filled'
   | 'metaobject-list'
   | 'metaobject-reference'
   | 'microphone'
@@ -4415,6 +7386,7 @@ type IconType$1 =
   | 'minus-circle'
   | 'mobile'
   | 'money'
+  | 'money-filled'
   | 'money-none'
   | 'moon'
   | 'nature'
@@ -4425,6 +7397,7 @@ type IconType$1 =
   | 'order'
   | 'order-batches'
   | 'order-draft'
+  | 'order-draft-filled'
   | 'order-first'
   | 'order-fulfilled'
   | 'order-repeat'
@@ -4454,6 +7427,7 @@ type IconType$1 =
   | 'paint-brush-round'
   | 'paper-check'
   | 'passkey'
+  | 'passkey-filled'
   | 'paste'
   | 'pause-circle'
   | 'payment'
@@ -4478,6 +7452,7 @@ type IconType$1 =
   | 'phone-in'
   | 'phone-out'
   | 'pin'
+  | 'pin-filled'
   | 'pin-remove'
   | 'plan'
   | 'play'
@@ -4489,6 +7464,7 @@ type IconType$1 =
   | 'plus-circle-up'
   | 'point-of-sale'
   | 'price-list'
+  | 'price-list-filled'
   | 'print'
   | 'product'
   | 'product-add'
@@ -4503,14 +7479,20 @@ type IconType$1 =
   | 'question-circle'
   | 'question-circle-filled'
   | 'radio-control'
+  | 'rank-bottom'
+  | 'rank-top'
   | 'receipt'
   | 'receipt-dollar'
   | 'receipt-euro'
+  | 'receipt-euro-filled'
   | 'receipt-paid'
   | 'receipt-pound'
+  | 'receipt-pound-filled'
   | 'receipt-refund'
   | 'receipt-rupee'
+  | 'receipt-rupee-filled'
   | 'receipt-yen'
+  | 'receipt-yen-filled'
   | 'receivables'
   | 'redo'
   | 'referral-code'
@@ -4536,10 +7518,12 @@ type IconType$1 =
   | 'settings'
   | 'share'
   | 'shield-check-mark'
+  | 'shield-network'
   | 'shield-none'
   | 'shield-pending'
   | 'shield-person'
   | 'shipping-label'
+  | 'shipping-label-filled'
   | 'shopcodes'
   | 'slideshow'
   | 'smiley-happy'
@@ -4552,6 +7536,7 @@ type IconType$1 =
   | 'sort-ascending'
   | 'sort-descending'
   | 'sound'
+  | 'split'
   | 'sports'
   | 'star'
   | 'star-filled'
@@ -4571,6 +7556,7 @@ type IconType$1 =
   | 'tax'
   | 'team'
   | 'text'
+  | 'text-ai'
   | 'text-align-center'
   | 'text-align-left'
   | 'text-align-right'
@@ -4582,6 +7568,7 @@ type IconType$1 =
   | 'text-grammar'
   | 'text-in-columns'
   | 'text-in-rows'
+  | 'text-in-rows-filled'
   | 'text-indent'
   | 'text-italic'
   | 'text-quote'
@@ -4589,6 +7576,7 @@ type IconType$1 =
   | 'text-underline'
   | 'text-with-image'
   | 'theme'
+  | 'theme-cart'
   | 'theme-edit'
   | 'theme-store'
   | 'theme-template'
@@ -4622,10 +7610,12 @@ type IconType$1 =
   | 'viewport-tall'
   | 'viewport-wide'
   | 'wallet'
+  | 'wallet-filled'
   | 'wand'
   | 'watch'
   | 'wifi'
   | 'work'
+  | 'work-filled'
   | 'work-list'
   | 'wrench'
   | 'x'


### PR DESCRIPTION
## What

Regenerates the Admin `Section` type definitions from `admin-ui-components` 2.21.2, picking up the header work that has landed in Polaris since these types were last generated (1.25.0), and adds the missing `Number` and `EmptyState` definitions from the same generator run.

### `Section`

New API surface for `s-section`:

| Addition | Kind | Notes |
| --- | --- | --- |
| `subheading` | property | Supporting text under the heading. Not a heading: no document-outline entry, doesn't shift child heading levels, not announced as part of the heading. |
| `primaryAction` | slot | Main call-to-action. |
| `secondaryActions` | slot | Alternative/supporting actions. A `ButtonGroup` holding an action plus an icon-only Menu activator renders as one segmented group. |
| `graphic` | slot | Decorative visual before the heading. Single icon-only `Badge` with `size="large"`; not rendered without a `heading`. |
| `accessory` | slot | Contextual info inline beside the heading text. Badge, Icon, Button, Menu, Text, Avatar, Thumbnail. |
| `supplemental` | slot | Status/metadata for the section as a whole, at the inline-end of the header. Badge, Avatar, Text, Icon, Thumbnail. |

```tsx
<Section heading="Payment" subheading="Captured 2 days ago">
  <Badge slot="graphic" icon="credit-card" size="large" />
  <Badge slot="accessory">Paid</Badge>
  <Text slot="supplemental">$248.00</Text>
  <Button slot="primaryAction">Refund</Button>
  Content
</Section>
```

### `Number` and `EmptyState` (net new)

Both are in the Polaris 3P allowlist (`UI_EXTENSIONS_COMPONENTS` in `admin-ui-components/lib/uiExtensionsBundlePlugin.js`) but had never been generated onto any definition surface, so an extension author writing `s-number` or `s-empty-state` got no types at all.

`s-number` — no slots:

| Property | Type | Notes |
| --- | --- | --- |
| `tone` | `'auto' \| 'neutral' \| 'info' \| 'success' \| 'warning' \| 'caution' \| 'critical'` | Default `'auto'`. |
| `color` | `'base' \| 'subdued'` | Default `'base'`. |
| `fontSize` | `'auto' \| 'small-200' \| 'small-100' \| 'small' \| 'base' \| 'large' \| 'large-100'` | Default `'auto'`; also applies matching line-height and letter-spacing. |
| `fontWeight` | `'auto' \| 'base' \| 'medium' \| 'semibold' \| 'bold'` | Default `'auto'`. |
| `dir`, `accessibilityVisibility` | inherited from `TextProps` | `Required<Pick<TextProps, …>>`. |
| `id`, `lang`, `children` | inherited from `TextProps` | The component styles the value passed in and renders it as given — format and localize it yourself. |

`s-empty-state`:

| Addition | Kind | Notes |
| --- | --- | --- |
| `heading` | property | Required on the element; optional in JSX props. |
| `graphic` | slot | A single `Image` or `Icon`, directly or as the only child of a wrapper. |
| `subheading` | slot | Supporting text below the heading. `Text` and `Link`. |
| `primaryAction` | slot | A single `Button` with `variant="primary"`. |
| `secondaryActions` | slot | A single `Button` with `variant="secondary"` or `"auto"` — despite the plural name, only one renders. |

```tsx
<EmptyState heading="No orders yet">
  <Icon slot="graphic" type="orders" />
  <Text slot="subheading">Orders will show up here once customers start buying.</Text>
  <Button slot="primaryAction" variant="primary">Create order</Button>
</EmptyState>
```

## How

```bash
# in libraries/javascript/polaris (shop/world)
pnpm build:definitions --configComponents=Section
pnpm build:definitions --configComponents=Number,EmptyState
```

Note for anyone reproducing this: there is no `--` before `--configComponents`. Under pnpm 11 the extra `--` makes rollup treat the flag as a positional path. `documentation/extensions-architecture.md` in the Polaris zone is stale on this.

## Scope note

The generator also rewrites `surfaces/admin/components.d.ts` and `surfaces/admin/components/shared.d.ts` in full. Both are still generated from 1.25.0 and have since accumulated hand-written docs polish (`Description improvements`, `Use 'web components' terminology`, `Fix broken web-components doc links`). Regenerating them here would be +7.9k/-2.5k and +4.2k/-1.3k and would revert all of that, so this PR is scoped to the per-component files — the same shape as 6ed2ff9db, which exposed Popover.

Bringing those two files back in sync with Polaris is real work that deserves its own PR.

## Follow-ups

- **shopify.dev docs are not affected by this PR.** `docs/surfaces/admin/build-docs.mjs:51` generates from `src/surfaces/admin/components.d.ts`, not from the per-component file. That aggregate still has `SectionSlots` (`@publicDocs`) declaring only `children`, and `RequiredSectionProps` listing `primaryAction`/`secondaryActions` but not `subheading`, `graphic`, `accessory`, or `supplemental` — so the docs continue to describe Section at 1.25.0 until `components.d.ts` is regenerated. `Number` and `EmptyState` are absent from that aggregate entirely, so they get no docs page from this PR either.
- **`Number` and `EmptyState` are not in `admin/components/StandardComponents.ts`.** This PR ships their types; it does not add either to the standard admin extension component set. `Section` was already there, so it needs no component-set change. Exposing the two new ones is a deliberate separate decision, the shape 6ed2ff9db used for Popover.
- Note that `Section.d.ts`, `Number.d.ts`, and `EmptyState.d.ts` import `PreactCustomElement` and `RenderImpl` from `./shared.d.ts`, which does not export them; `Number.d.ts` and `EmptyState.d.ts` additionally import `TextProps` and `EmptyStateProps$1`, which `shared.d.ts` only has as unexported `TextProps$1` / `EmptyStateProps$1`. None of this errors because `skipLibCheck: true` (`@shopify/typescript-configs/base.json`), and `Popover.d.ts` already ships the identical dangling imports. It resolves when `shared.d.ts` is regenerated.
- shop/world: the admin-web remote definitions for `s-section`, `s-number`, and `s-empty-state` need the matching properties and slots. That change can only land after this merges and admin-web bumps `@shopify/ui-extensions-next` past `2026.10.0-rc.8`.

## Testing

- `prettier --check` clean on the changed files.
- `Section` is already in `StandardComponents.ts`, so no component-set change is needed.
