### PR TITLE
fix(admin): use control-generic wording for selectable prop docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
@@ -2648,7 +2648,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked.",
+          "description": "The value used in form data when the control is checked.",
           "isOptional": true
         },
         {
@@ -2689,7 +2689,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -2914,7 +2914,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false",
           "isOptional": true
         },
@@ -2932,7 +2932,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         },
         {
@@ -7244,7 +7244,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         },
         {
@@ -7252,7 +7252,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false",
           "isOptional": true
         },
@@ -8996,7 +8996,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked.",
+          "description": "The value used in form data when the control is checked.",
           "isOptional": true
         },
         {
@@ -9037,7 +9037,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -17182,7 +17182,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17191,11 +17191,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the checkbox is disabled, preventing user interaction.\n   * Disabled checkboxes appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this checkbox is checked.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
+      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the control is disabled, preventing user interaction.\n   * Disabled controls appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this control is selected.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
     }
   },
   "BaseOptionProps": {
@@ -17227,7 +17227,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17245,7 +17245,7 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
@@ -17307,7 +17307,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17324,7 +17324,7 @@
           "syntaxKind": "PropertySignature",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -17332,7 +17332,7 @@
           "syntaxKind": "PropertySignature",
           "name": "name",
           "value": "string",
-          "description": "The name used to identify this checkbox in form submissions. When the checkbox is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
+          "description": "The name used to identify this control in form submissions. When the control is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
           "isOptional": true
         },
         {
@@ -17356,11 +17356,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the checkbox that describes what the checkbox controls.\n   * Clicking the label will also toggle the checkbox state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this checkbox in form submissions.\n   * When the checkbox is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
+      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the control that describes what it does.\n   * Clicking the label will also toggle the control state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this control in form submissions.\n   * When the control is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
     }
   },
   "ChipProps$1": {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -2648,7 +2648,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked.",
+          "description": "The value used in form data when the control is checked.",
           "isOptional": true
         },
         {
@@ -2689,7 +2689,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -2914,7 +2914,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false",
           "isOptional": true
         },
@@ -2932,7 +2932,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         },
         {
@@ -7244,7 +7244,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         },
         {
@@ -7252,7 +7252,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false",
           "isOptional": true
         },
@@ -8996,7 +8996,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked.",
+          "description": "The value used in form data when the control is checked.",
           "isOptional": true
         },
         {
@@ -9037,7 +9037,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -17182,7 +17182,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17191,11 +17191,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the checkbox is disabled, preventing user interaction.\n   * Disabled checkboxes appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this checkbox is checked.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
+      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the control is disabled, preventing user interaction.\n   * Disabled controls appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this control is selected.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
     }
   },
   "BaseOptionProps": {
@@ -17227,7 +17227,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17245,7 +17245,7 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
@@ -17307,7 +17307,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17324,7 +17324,7 @@
           "syntaxKind": "PropertySignature",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -17332,7 +17332,7 @@
           "syntaxKind": "PropertySignature",
           "name": "name",
           "value": "string",
-          "description": "The name used to identify this checkbox in form submissions. When the checkbox is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
+          "description": "The name used to identify this control in form submissions. When the control is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
           "isOptional": true
         },
         {
@@ -17356,11 +17356,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the checkbox that describes what the checkbox controls.\n   * Clicking the label will also toggle the checkbox state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this checkbox in form submissions.\n   * When the checkbox is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
+      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the control that describes what it does.\n   * Clicking the label will also toggle the control state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this control in form submissions.\n   * When the control is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
     }
   },
   "ChipProps$1": {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
@@ -2648,7 +2648,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked.",
+          "description": "The value used in form data when the control is checked.",
           "isOptional": true
         },
         {
@@ -2689,7 +2689,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -2914,7 +2914,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false",
           "isOptional": true
         },
@@ -2932,7 +2932,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         },
         {
@@ -7244,7 +7244,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         },
         {
@@ -7252,7 +7252,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false",
           "isOptional": true
         },
@@ -8996,7 +8996,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked.",
+          "description": "The value used in form data when the control is checked.",
           "isOptional": true
         },
         {
@@ -9037,7 +9037,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -17182,7 +17182,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17191,11 +17191,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the checkbox is disabled, preventing user interaction.\n   * Disabled checkboxes appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this checkbox is checked.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
+      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the control is disabled, preventing user interaction.\n   * Disabled controls appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this control is selected.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
     }
   },
   "BaseOptionProps": {
@@ -17227,7 +17227,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17245,7 +17245,7 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
@@ -17307,7 +17307,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -17324,7 +17324,7 @@
           "syntaxKind": "PropertySignature",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -17332,7 +17332,7 @@
           "syntaxKind": "PropertySignature",
           "name": "name",
           "value": "string",
-          "description": "The name used to identify this checkbox in form submissions. When the checkbox is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
+          "description": "The name used to identify this control in form submissions. When the control is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
           "isOptional": true
         },
         {
@@ -17356,11 +17356,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the checkbox that describes what the checkbox controls.\n   * Clicking the label will also toggle the checkbox state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this checkbox in form submissions.\n   * When the checkbox is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
+      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the control that describes what it does.\n   * Clicking the label will also toggle the control state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this control in form submissions.\n   * When the control is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
     }
   },
   "ChipProps$1": {

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -2007,14 +2007,14 @@ export interface BaseSelectableProps {
    */
   accessibilityLabel?: string;
   /**
-   * Whether the checkbox is disabled, preventing user interaction.
-   * Disabled checkboxes appear dimmed and their values aren't submitted with forms.
+   * Whether the control is disabled, preventing user interaction.
+   * Disabled controls appear dimmed and their values aren't submitted with forms.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * The value submitted with the form when this checkbox is checked.
+   * The value submitted with the form when this control is selected.
    * If not specified, the default value is "on".
    */
   value?: string;
@@ -2042,8 +2042,8 @@ export interface BaseCheckableProps
   extends BaseSelectableProps,
     InteractionProps {
   /**
-   * The text label displayed next to the checkbox that describes what the checkbox controls.
-   * Clicking the label will also toggle the checkbox state.
+   * The text label displayed next to the control that describes what it does.
+   * Clicking the label will also toggle the control state.
    */
   label?: string;
   /**
@@ -2062,8 +2062,8 @@ export interface BaseCheckableProps
    */
   defaultChecked?: boolean;
   /**
-   * The name used to identify this checkbox in form submissions.
-   * When the checkbox is checked, its `name` and `value` are included in the form data.
+   * The name used to identify this control in form submissions.
+   * When the control is checked, its `name` and `value` are included in the form data.
    * Must be unique within the containing form.
    */
   name?: string;
@@ -5829,7 +5829,7 @@ export interface PreactCheckboxProps
     >
   > {
   /**
-   * The value used in form data when the checkbox is checked.
+   * The value used in form data when the control is checked.
    */
   value: Required<CheckboxProps$1>['value'];
 }
@@ -5840,7 +5840,7 @@ declare class PreactCheckboxElement
   get checked(): boolean;
   set checked(checked: PreactCheckboxProps['checked']);
   /**
-   * The value used in form data when the checkbox is checked.
+   * The value used in form data when the control is checked.
    */
   get value(): string;
   set value(value: string);


### PR DESCRIPTION
Follow-up to #4662, found while fixing the World-side source. Same bug class, different props.

## What

Four shared declarations describe themselves as a checkbox. All of them are inherited by components that aren't checkboxes:

| String | Declared on | Renders on |
|---|---|---|
| "Whether **the checkbox** is disabled…" | `BaseSelectableProps` | **Choice**, **Option** |
| "The value submitted with the form when **this checkbox** is checked" | `BaseSelectableProps` | **Choice**, **Option** |
| "The text label displayed next to **the checkbox**…" | `BaseCheckableProps` | **Switch** |
| "The name used to identify **this checkbox**…" | `BaseCheckableProps` | **Switch** |
| "The value used in form data when **the checkbox** is checked." | `PreactCheckboxProps` / `PreactCheckboxElement` | **Switch** |

`BaseSelectableProps` → `BaseOptionProps` → Choice/Option; `BaseSelectableProps` → `BaseCheckableProps` → Switch; `SwitchProps extends PreactCheckboxProps` and `class Switch extends PreactCheckboxElement`.

## Wording

"checkbox" → "control" throughout. State verbs follow each interface's own family vocabulary, which is split in this file:

- `BaseOptionProps` family (Choice/Option) uses **selected** — 5 occurrences, 0 "checked"
- `BaseCheckableProps` family (Checkbox/Switch) uses **checked** — 7 occurrences, 0 "selected"

So `BaseSelectableProps`, the shared parent of both, uses **selected** (matching its own name); `BaseCheckableProps` and the `PreactCheckbox*` declarations, which cover only Checkbox and Switch, keep **checked** (matching the `checked`/`defaultChecked` descriptions already on them). "control" also matches `ui-api-design`, the upstream source of truth.

Mentions of "control **is checked**" remains, as `checked` is the actual property name, including on Switch.

## What's left

The remaining `checkbox` mentions in `components.d.ts` are genuinely checkbox-specific: `CheckboxProps`, `CheckboxJSXProps`, the `s-checkbox` tag, the `'checkbox'` context literal, and Choice's description of "(checkboxes)" as a selection mode. The `PreactCheckboxProps` / `PreactCheckboxElement` declarations still carry checkbox wording on their *other* members (`checked`, `defaultChecked`, `details`, `error`, `required`) — those also leak onto Switch, but they're a larger rewording question than a find/replace, so they're out of scope here.

## Change

8 sentence-level replacements — identical in the `.d.ts`, the flattened JSON descriptions, and the escaped interface blocks, so one pass covers all three. Each is asserted to appear an exact expected number of times in the source.

Independent of #4662 (different lines), so the two can merge in either order. Generated JSON was patched textually rather than regenerated, as in #4662; all files re-parse as valid JSON and the diff is symmetric (+63/-63).

Backports: #4668 (2026-04), #4669 (2026-01), #4670 (2025-10).

Refs shop/issues-learn#2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
