### PR TITLE
fix(admin): use control-generic wording for selectable prop docs [2026-04]

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-04/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-04/generated_docs_data_v2.json
@@ -2545,7 +2545,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the control is checked."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2581,7 +2581,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2783,7 +2783,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false"
         },
         {
@@ -2799,7 +2799,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\"."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6667,14 +6667,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\"."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false"
         },
         {
@@ -8238,7 +8238,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the control is checked."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8274,7 +8274,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -15360,7 +15360,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -15369,11 +15369,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the checkbox is disabled, preventing user interaction.\n   * Disabled checkboxes appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this checkbox is checked.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
+      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the control is disabled, preventing user interaction.\n   * Disabled controls appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this control is selected.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
     }
   },
   "BaseOptionProps": {
@@ -15405,7 +15405,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -15423,7 +15423,7 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
@@ -15485,7 +15485,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -15502,7 +15502,7 @@
           "syntaxKind": "PropertySignature",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -15510,7 +15510,7 @@
           "syntaxKind": "PropertySignature",
           "name": "name",
           "value": "string",
-          "description": "The name used to identify this checkbox in form submissions. When the checkbox is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
+          "description": "The name used to identify this control in form submissions. When the control is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
           "isOptional": true
         },
         {
@@ -15534,11 +15534,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the checkbox that describes what the checkbox controls.\n   * Clicking the label will also toggle the checkbox state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this checkbox in form submissions.\n   * When the checkbox is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
+      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the control that describes what it does.\n   * Clicking the label will also toggle the control state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this control in form submissions.\n   * When the control is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
     }
   },
   "ChipProps$1": {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -2545,7 +2545,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the control is checked."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2581,7 +2581,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2783,7 +2783,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false"
         },
         {
@@ -2799,7 +2799,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\"."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6667,14 +6667,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\"."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false"
         },
         {
@@ -8238,7 +8238,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the control is checked."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8274,7 +8274,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -15360,7 +15360,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -15369,11 +15369,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the checkbox is disabled, preventing user interaction.\n   * Disabled checkboxes appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this checkbox is checked.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
+      "value": "export interface BaseSelectableProps {\n  /**\n   * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.\n   */\n  accessibilityLabel?: string;\n  /**\n   * Whether the control is disabled, preventing user interaction.\n   * Disabled controls appear dimmed and their values aren't submitted with forms.\n   *\n   * @default false\n   */\n  disabled?: boolean;\n  /**\n   * The value submitted with the form when this control is selected.\n   * If not specified, the default value is \"on\".\n   */\n  value?: string;\n}"
     }
   },
   "BaseOptionProps": {
@@ -15405,7 +15405,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -15423,7 +15423,7 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
@@ -15485,7 +15485,7 @@
           "syntaxKind": "PropertySignature",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "isOptional": true,
           "defaultValue": "false"
         },
@@ -15502,7 +15502,7 @@
           "syntaxKind": "PropertySignature",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state.",
           "isOptional": true
         },
         {
@@ -15510,7 +15510,7 @@
           "syntaxKind": "PropertySignature",
           "name": "name",
           "value": "string",
-          "description": "The name used to identify this checkbox in form submissions. When the checkbox is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
+          "description": "The name used to identify this control in form submissions. When the control is checked, its `name` and `value` are included in the form data. Must be unique within the containing form.",
           "isOptional": true
         },
         {
@@ -15534,11 +15534,11 @@
           "syntaxKind": "PropertySignature",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\".",
           "isOptional": true
         }
       ],
-      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the checkbox that describes what the checkbox controls.\n   * Clicking the label will also toggle the checkbox state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this checkbox in form submissions.\n   * When the checkbox is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
+      "value": "export interface BaseCheckableProps\n  extends BaseSelectableProps,\n    InteractionProps {\n  /**\n   * The text label displayed next to the control that describes what it does.\n   * Clicking the label will also toggle the control state.\n   */\n  label?: string;\n  /**\n   * Whether the control is currently checked. Use this for controlled components where you manage the checked state.\n   *\n   * @default false\n   */\n  checked?: boolean;\n  /**\n   * The initial checked state for uncontrolled components. Use this when you want the control to start checked\n   * but don't need to control its state afterward.\n   *\n   * @implementation `defaultChecked` reflects to the `checked` attribute.\n   *\n   * @default false\n   */\n  defaultChecked?: boolean;\n  /**\n   * The name used to identify this control in form submissions.\n   * When the control is checked, its `name` and `value` are included in the form data.\n   * Must be unique within the containing form.\n   */\n  name?: string;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  onChange?: (event: Event) => void;\n  /**\n   * A callback that is run whenever the control is changed. Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event).\n   */\n  onInput?: (event: Event) => void;\n}"
     }
   },
   "ChipProps$1": {

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -2007,14 +2007,14 @@ export interface BaseSelectableProps {
    */
   accessibilityLabel?: string;
   /**
-   * Whether the checkbox is disabled, preventing user interaction.
-   * Disabled checkboxes appear dimmed and their values aren't submitted with forms.
+   * Whether the control is disabled, preventing user interaction.
+   * Disabled controls appear dimmed and their values aren't submitted with forms.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * The value submitted with the form when this checkbox is checked.
+   * The value submitted with the form when this control is selected.
    * If not specified, the default value is "on".
    */
   value?: string;
@@ -2042,8 +2042,8 @@ export interface BaseCheckableProps
   extends BaseSelectableProps,
     InteractionProps {
   /**
-   * The text label displayed next to the checkbox that describes what the checkbox controls.
-   * Clicking the label will also toggle the checkbox state.
+   * The text label displayed next to the control that describes what it does.
+   * Clicking the label will also toggle the control state.
    */
   label?: string;
   /**
@@ -2062,8 +2062,8 @@ export interface BaseCheckableProps
    */
   defaultChecked?: boolean;
   /**
-   * The name used to identify this checkbox in form submissions.
-   * When the checkbox is checked, its `name` and `value` are included in the form data.
+   * The name used to identify this control in form submissions.
+   * When the control is checked, its `name` and `value` are included in the form data.
    * Must be unique within the containing form.
    */
   name?: string;
@@ -5829,7 +5829,7 @@ export interface PreactCheckboxProps
     >
   > {
   /**
-   * The value used in form data when the checkbox is checked.
+   * The value used in form data when the control is checked.
    */
   value: Required<CheckboxProps$1>['value'];
 }
@@ -5840,7 +5840,7 @@ declare class PreactCheckboxElement
   get checked(): boolean;
   set checked(checked: PreactCheckboxProps['checked']);
   /**
-   * The value used in form data when the checkbox is checked.
+   * The value used in form data when the control is checked.
    */
   get value(): string;
   set value(value: string);


### PR DESCRIPTION
Backport of #4667 to `2026-04`.

## What

Four shared declarations describe themselves as a checkbox, and all of them are inherited by components that aren't checkboxes:

- `BaseSelectableProps` (`disabled`, `value`) → `BaseOptionProps` → **Choice**, **Option**
- `BaseCheckableProps` (`label`, `name`) → **Switch**
- `PreactCheckboxProps` / `PreactCheckboxElement` (`value`) → **Switch** (`SwitchProps extends PreactCheckboxProps`, `class Switch extends PreactCheckboxElement`)

## Wording

"checkbox" → "control". State verbs follow each interface's own family vocabulary: `BaseSelectableProps` uses **selected** (matching its name and the Option/Choice wording), the checkable declarations keep **checked**. "control" matches `ui-api-design`, the upstream source of truth.

## Change

Same 8 sentence-level replacements as #4667, applied to this branch's `components.d.ts` and generated docs. Each is asserted to appear an exact expected number of times before writing, so version drift fails loudly rather than silently no-op'ing. Generated JSON was patched textually rather than regenerated; all files re-parse as valid JSON and the diff is symmetric (3 files changed, 45 insertions(+), 45 deletions(-)).

Refs shop/issues-learn#2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
