### PR TITLE
fix(admin): use control-generic wording for selectable prop docs [2026-01]

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-01/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-01/generated_docs_data_v2.json
@@ -2427,7 +2427,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the control is checked."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2463,7 +2463,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2665,7 +2665,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false"
         },
         {
@@ -2681,7 +2681,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\"."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6549,14 +6549,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\"."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false"
         },
         {
@@ -8120,7 +8120,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the control is checked."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8156,7 +8156,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -6411,7 +6411,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the control is checked."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6447,7 +6447,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6649,7 +6649,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false"
         },
         {
@@ -6665,7 +6665,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\"."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10345,14 +10345,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this control is selected. If not specified, the default value is \"on\"."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
+          "description": "Whether the control is disabled, preventing user interaction. Disabled controls appear dimmed and their values aren't submitted with forms.",
           "defaultValue": "false"
         },
         {
@@ -11916,7 +11916,7 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the control is checked."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11952,7 +11952,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the control that describes what it does. Clicking the label will also toggle the control state."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -1977,14 +1977,14 @@ export interface BaseSelectableProps {
    */
   accessibilityLabel?: string;
   /**
-   * Whether the checkbox is disabled, preventing user interaction.
-   * Disabled checkboxes appear dimmed and their values aren't submitted with forms.
+   * Whether the control is disabled, preventing user interaction.
+   * Disabled controls appear dimmed and their values aren't submitted with forms.
    *
    * @default false
    */
   disabled?: boolean;
   /**
-   * The value submitted with the form when this checkbox is checked.
+   * The value submitted with the form when this control is selected.
    * If not specified, the default value is "on".
    */
   value?: string;
@@ -2010,8 +2010,8 @@ export interface BaseCheckableProps
   extends BaseSelectableProps,
     InteractionProps {
   /**
-   * The text label displayed next to the checkbox that describes what the checkbox controls.
-   * Clicking the label will also toggle the checkbox state.
+   * The text label displayed next to the control that describes what it does.
+   * Clicking the label will also toggle the control state.
    */
   label?: string;
   /**
@@ -2030,8 +2030,8 @@ export interface BaseCheckableProps
    */
   defaultChecked?: boolean;
   /**
-   * The name used to identify this checkbox in form submissions.
-   * When the checkbox is checked, its `name` and `value` are included in the form data.
+   * The name used to identify this control in form submissions.
+   * When the control is checked, its `name` and `value` are included in the form data.
    * Must be unique within the containing form.
    */
   name?: string;
@@ -5784,7 +5784,7 @@ export interface PreactCheckboxProps
     >
   > {
   /**
-   * The value used in form data when the checkbox is checked.
+   * The value used in form data when the control is checked.
    */
   value: Required<CheckboxProps$1>['value'];
 }
@@ -5795,7 +5795,7 @@ declare class PreactCheckboxElement
   get checked(): boolean;
   set checked(checked: PreactCheckboxProps['checked']);
   /**
-   * The value used in form data when the checkbox is checked.
+   * The value used in form data when the control is checked.
    */
   get value(): string;
   set value(value: string);


### PR DESCRIPTION
Backport of #4667 to `2026-01`.

## What

Four shared declarations describe themselves as a checkbox, and all of them are inherited by components that aren't checkboxes:

- `BaseSelectableProps` (`disabled`, `value`) → `BaseOptionProps` → **Choice**, **Option**
- `BaseCheckableProps` (`label`, `name`) → **Switch**
- `PreactCheckboxProps` / `PreactCheckboxElement` (`value`) → **Switch** (`SwitchProps extends PreactCheckboxProps`, `class Switch extends PreactCheckboxElement`)

## Wording

"checkbox" → "control". State verbs follow each interface's own family vocabulary: `BaseSelectableProps` uses **selected** (matching its name and the Option/Choice wording), the checkable declarations keep **checked**. "control" matches `ui-api-design`, the upstream source of truth.

## Change

Same 8 sentence-level replacements as #4667, applied to this branch's `components.d.ts` and generated docs. Each is asserted to appear an exact expected number of times before writing, so version drift fails loudly rather than silently no-op'ing. Generated JSON was patched textually rather than regenerated; all files re-parse as valid JSON and the diff is symmetric (3 files changed, 25 insertions(+), 25 deletions(-)).

Refs shop/issues-learn#2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
