### PR TITLE
[Customer Account] Document mailto and tel href support (2026-07)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/generated/customer_account_ui_extensions/2026-07/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/generated/customer_account_ui_extensions/2026-07/generated_docs_data_v2.json
@@ -40084,7 +40084,7 @@
           "syntaxKind": "PropertySignature",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "description": "The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
           "isOptional": true
         },
         {
@@ -41154,7 +41154,7 @@
           "syntaxKind": "PropertySignature",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "description": "The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
           "isOptional": true
         },
         {
@@ -55254,7 +55254,7 @@
           "syntaxKind": "PropertySignature",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "description": "The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
           "isOptional": true
         },
         {
@@ -55545,7 +55545,7 @@
           "syntaxKind": "PropertySignature",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "description": "The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
           "isOptional": true
         },
         {
@@ -56840,7 +56840,7 @@
           "syntaxKind": "PropertySignature",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "description": "The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
           "isOptional": true
         },
         {
@@ -101685,7 +101685,7 @@
           "syntaxKind": "PropertySignature",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "description": "The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
           "isOptional": true
         },
         {
@@ -102718,7 +102718,7 @@
           "syntaxKind": "PropertySignature",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "description": "The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
           "isOptional": true
         },
         {
@@ -104153,7 +104153,7 @@
           "syntaxKind": "PropertySignature",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "description": "The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -1384,7 +1384,7 @@ export interface ButtonBehaviorProps extends InteractionProps, FocusEventProps {
 }
 export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
 	/**
-	 * The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.
+	 * The URL to navigate to when clicked, including `mailto:` and `tel:` URLs. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.
 	 */
 	href?: string;
 	/**


### PR DESCRIPTION
Closes https://github.com/shop/issues-learn/issues/3035

## What

Clarify that the shared `href` field supports `mailto:` and `tel:` URLs, and regenerate the Customer Account reference data inherited by Link, Button, and Clickable.

## Validation

- `yarn docs:customer-account 2026-07`
- Generated diff changes exactly eight inherited `href` descriptions
- Prettier passes for both changed files

## Related

- [shop/world#1013796](https://github.com/shop/world/pull/1013796)