### PR TITLE
Add fiscalDeviceIdentifier to the POS Device API

### DIFF
--- a/.changeset/pos-device-fiscal-device-identifier.md
+++ b/.changeset/pos-device-fiscal-device-identifier.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add `fiscalDeviceIdentifier` to the POS Device API. `shopify.device.fiscalDeviceIdentifier` exposes the Shopify-assigned fiscal register identifier for the device (such as Sweden's manufacturing number), so fiscal compliance extensions can stamp receipts and journals without querying the GraphQL Admin API. It's `undefined` when the device's location doesn't require fiscal device registration, and only available on API version `2026-10` and later.

--- a/.changeset/pos-device-fiscal-device-identifier.md
+++ b/.changeset/pos-device-fiscal-device-identifier.md
@@ -2,4 +2,4 @@
 '@shopify/ui-extensions': minor
 ---
 
-Add `fiscalDeviceIdentifier` to the POS Device API. `shopify.device.fiscalDeviceIdentifier` exposes the Shopify-assigned fiscal register identifier for the device (such as Sweden's manufacturing number), so fiscal compliance extensions can stamp receipts and journals without querying the GraphQL Admin API. It's `undefined` when the device's location doesn't require fiscal device registration, and only available on API version `2026-10` and later.
+Add `fiscalDeviceIdentifier` to the POS Device API. `shopify.device.fiscalDeviceIdentifier` is the Shopify-assigned fiscal register identifier for the device (such as Sweden's manufacturing number), matching the `fiscalDeviceIdentifier` field on the `PointOfSaleDevice` object in the GraphQL Admin API. It's `undefined` when the device's location doesn't require fiscal device registration.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -12,6 +12,16 @@ export interface DeviceApiContent {
    */
   registerName: string;
   /**
+   * The Shopify-assigned fiscal register identifier for the device, such as Sweden's manufacturing number (tillverkningsnummer). Use it to identify the register on fiscal receipts, journals, and reports required by tax authorities. It's `undefined` when the device's location is in a country that doesn't require registering the device with the tax authority.
+   *
+   * This is the same value as the `fiscalDeviceIdentifier` field on the [PointOfSaleDevice](https://shopify.dev/docs/api/admin-graphql/latest/objects/PointOfSaleDevice) object in the GraphQL Admin API, and it's available while the device is offline.
+   *
+   * Only available on API version `2026-10` and later.
+   *
+   * @example "SH-9IX-7"
+   */
+  fiscalDeviceIdentifier?: string;
+  /**
    * Retrieves the unique string identifier for the device. Returns a promise that resolves to the device ID. Use for device-specific data storage, analytics tracking, or implementing device-based permissions and configurations.
    * Note: While Shopify POS attempts to maintain a stable identifier, it is not guaranteed to be permanent and may change.
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/device-api/device-api.ts
@@ -12,11 +12,9 @@ export interface DeviceApiContent {
    */
   registerName: string;
   /**
-   * The Shopify-assigned fiscal register identifier for the device, such as Sweden's manufacturing number (tillverkningsnummer). Use it to identify the register on fiscal receipts, journals, and reports required by tax authorities. It's `undefined` when the device's location is in a country that doesn't require registering the device with the tax authority.
+   * The Shopify-assigned fiscal register identifier for the device, such as Sweden's manufacturing number (tillverkningsnummer). It's the same value as the `fiscalDeviceIdentifier` field on the [PointOfSaleDevice](https://shopify.dev/docs/api/admin-graphql/latest/objects/PointOfSaleDevice) object in the GraphQL Admin API, and it's available while the device is offline.
    *
-   * This is the same value as the `fiscalDeviceIdentifier` field on the [PointOfSaleDevice](https://shopify.dev/docs/api/admin-graphql/latest/objects/PointOfSaleDevice) object in the GraphQL Admin API, and it's available while the device is offline.
-   *
-   * Only available on API version `2026-10` and later.
+   * It's `undefined` when the device's location is in a country that doesn't require registering the device with the tax authority.
    *
    * @example "SH-9IX-7"
    */


### PR DESCRIPTION
### Background

The GraphQL Admin API exposes a `PointOfSaleDevice.fiscalDeviceIdentifier` (API version `2026-10`). Today the only way for a POS UI extension to read it is `shopify.session.deviceId` → build a GID → query `pointOfSaleDevice(id:)` via the Direct API. That path is online-only, requires an Admin API access scope, costs a network round-trip.

### Solution

Adds an optional, static property to the POS Device API:

```ts
shopify.device.fiscalDeviceIdentifier?: string;
```

- Lives on `device` alongside `name` and `registerName`, which already mirrors the Admin API's `PointOfSaleDevice.handle` — same class of Shopify-assigned device identity data. `session` describes who/where (shop, user, location, staff); `device` describes the hardware.
- Same name as the Admin API field, because it is the same value — developers can correlate it across surfaces.
- Static string rather than a signal: it doesn't change for the lifetime of a device registration (same as `registerName`).
- `undefined` when the device's location doesn't require fiscal device registration. Only available on API version `2026-10` and later; the host exposes it version-gated (same approach as `session.deviceId`).

Companion changes: the extensibility host `devicePlugin` reads it from the POS domain bridge and exposes it for `2026-10`+; POS Mobile supplies the value it already holds locally after device registration.

Docs generate from the JSDoc; the checked-in `generated_docs_data_v2.json` is regenerated in the usual `docs(pos): generate …` PR rather than here.

### Checklist

- [ ] I have :tophat:'d these changes
    - Can only be tophatted once the host plugin and POS Mobile changes ship
- [x] I have updated relevant documentation
